### PR TITLE
Change serialisation mechanism

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 .stack-work*/
 **/dist
 dist-newstyle/
+.ghc.environment.x86_64-linux-8.6.5
+stack.yaml.lock
 
 # Editors
 TAGS

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Class.hs
@@ -64,15 +64,13 @@ class ( Typeable v
 
   signDSIGN
     :: (MonadRandom m, Signable v a, HasCallStack)
-    => (a -> Encoding)
-    -> a
+    => a
     -> SignKeyDSIGN v
     -> m (SigDSIGN v)
 
   verifyDSIGN
     :: (Signable v a, HasCallStack)
-    => (a -> Encoding)
-    -> VerKeyDSIGN v
+    => VerKeyDSIGN v
     -> a
     -> SigDSIGN v
     -> Either String ()
@@ -88,20 +86,18 @@ deriving instance DSIGNAlgorithm v => Ord (SignedDSIGN v a)
 
 signedDSIGN
   :: (DSIGNAlgorithm v, MonadRandom m, Signable v a)
-  => (a -> Encoding)
-  -> a
+  => a
   -> SignKeyDSIGN v
   -> m (SignedDSIGN v a)
-signedDSIGN encoder a key = SignedDSIGN <$> signDSIGN encoder a key
+signedDSIGN a key = SignedDSIGN <$> signDSIGN a key
 
 verifySignedDSIGN
   :: (DSIGNAlgorithm v, Signable v a, HasCallStack)
-  => (a -> Encoding)
-  -> VerKeyDSIGN v
+  => VerKeyDSIGN v
   -> a
   -> SignedDSIGN v a
   -> Either String ()
-verifySignedDSIGN encoder key a (SignedDSIGN s) = verifyDSIGN encoder key a s
+verifySignedDSIGN key a (SignedDSIGN s) = verifyDSIGN key a s
 
 encodeSignedDSIGN :: DSIGNAlgorithm v => SignedDSIGN v a -> Encoding
 encodeSignedDSIGN (SignedDSIGN s) = encodeSigDSIGN s

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Class.hs
@@ -64,16 +64,14 @@ class ( Typeable v
 
   signKES
     :: (MonadRandom m, Signable v a, HasCallStack)
-    => (a -> Encoding)
-    -> Natural
+    => Natural
     -> a
     -> SignKeyKES v
     -> m (Maybe (SigKES v, SignKeyKES v))
 
   verifyKES
     :: (Signable v a, HasCallStack)
-    => (a -> Encoding)
-    -> VerKeyKES v
+    => VerKeyKES v
     -> Natural
     -> a
     -> SigKES v
@@ -90,26 +88,24 @@ deriving instance KESAlgorithm v => Ord (SignedKES v a)
 
 signedKES
   :: (KESAlgorithm v, MonadRandom m, Signable v a)
-  => (a -> Encoding)
-  -> Natural
+  => Natural
   -> a
   -> SignKeyKES v
   -> m (Maybe (SignedKES v a, SignKeyKES v))
-signedKES toEnc time a key = do
-  m <- signKES toEnc time a key
+signedKES time a key = do
+  m <- signKES time a key
   return $ case m of
     Nothing -> Nothing
     Just (sig, key') -> Just (SignedKES sig, key')
 
 verifySignedKES
   :: (KESAlgorithm v, Signable v a)
-  => (a -> Encoding)
-  -> VerKeyKES v
+  => VerKeyKES v
   -> Natural
   -> a
   -> SignedKES v a
   -> Either String ()
-verifySignedKES toEnc vk j a (SignedKES sig) = verifyKES toEnc vk j a sig
+verifySignedKES vk j a (SignedKES sig) = verifyKES vk j a sig
 
 encodeSignedKES :: KESAlgorithm v => SignedKES v a -> Encoding
 encodeSignedKES (SignedKES s) = encodeSigKES s

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Mock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Mock.hs
@@ -26,6 +26,8 @@ type H = MD5
 
 instance KESAlgorithm MockKES where
 
+    type Signable MockKES = ToCBOR
+
     newtype VerKeyKES MockKES = VerKeyMockKES Int
         deriving (Show, Eq, Ord, Generic, ToCBOR, FromCBOR)
 
@@ -49,17 +51,17 @@ instance KESAlgorithm MockKES where
 
     deriveVerKeyKES (SignKeyMockKES (vk, _, _)) = vk
 
-    signKES toEnc j a (SignKeyMockKES (vk, k, t))
+    signKES j a (SignKeyMockKES (vk, k, t))
         | j >= k && j < t = return $ Just
-            ( SigMockKES (fromHash $ hashWithSerialiser @H toEnc a) (SignKeyMockKES (vk, j, t))
+            ( SigMockKES (fromHash $ hash @H a) (SignKeyMockKES (vk, j, t))
             , SignKeyMockKES (vk, j + 1, t)
             )
         | otherwise       = return Nothing
 
-    verifyKES toEnc vk j a (SigMockKES h (SignKeyMockKES (vk', j', _))) =
+    verifyKES vk j a (SigMockKES h (SignKeyMockKES (vk', j', _))) =
         if    j  == j'
            && vk == vk'
-           && fromHash (hashWithSerialiser @H toEnc a) == h
+           && fromHash (hash @H a) == h
           then Right ()
           else Left "KES verification failed"
 

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Simple.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Simple.hs
@@ -65,16 +65,16 @@ instance (DSIGNAlgorithm d, Typeable d) => KESAlgorithm (SimpleKES d) where
 
     deriveVerKeyKES (SignKeySimpleKES (vks, _)) = VerKeySimpleKES $ fromList vks
 
-    signKES toEnc j a (SignKeySimpleKES (vks, xs)) = case dropWhile (\(k, _) -> k < j) xs of
+    signKES j a (SignKeySimpleKES (vks, xs)) = case dropWhile (\(k, _) -> k < j) xs of
         []           -> return Nothing
         (_, sk) : ys -> do
-            sig <- signDSIGN toEnc a sk
+            sig <- signDSIGN a sk
             return $ Just (SigSimpleKES sig, SignKeySimpleKES (vks, ys))
 
-    verifyKES toEnc (VerKeySimpleKES vks) j a (SigSimpleKES sig) =
+    verifyKES (VerKeySimpleKES vks) j a (SigSimpleKES sig) =
         case vks !? fromIntegral j of
             Nothing -> Left "KES verification failed: out of range"
-            Just vk -> verifyDSIGN toEnc vk a sig
+            Just vk -> verifyDSIGN vk a sig
 
 deriving instance DSIGNAlgorithm d => Show (VerKeyKES (SimpleKES d))
 

--- a/cardano-crypto-class/src/Cardano/Crypto/VRF/Mock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/VRF/Mock.hs
@@ -12,7 +12,7 @@ module Cardano.Crypto.VRF.Mock
   )
 where
 
-import Cardano.Binary (Encoding, FromCBOR, ToCBOR (..))
+import Cardano.Binary (FromCBOR, ToCBOR (..))
 import Cardano.Crypto.Hash
 import Cardano.Crypto.Util (nonNegIntR)
 import Cardano.Crypto.VRF.Class
@@ -23,6 +23,9 @@ import Numeric.Natural (Natural)
 data MockVRF
 
 instance VRFAlgorithm MockVRF where
+
+  type Signable MockVRF = ToCBOR
+
   newtype VerKeyVRF MockVRF = VerKeyMockVRF Int
     deriving (Show, Eq, Ord, Generic, ToCBOR, FromCBOR)
   newtype SignKeyVRF MockVRF = SignKeyMockVRF Int
@@ -32,10 +35,10 @@ instance VRFAlgorithm MockVRF where
   maxVRF _ = 2 ^ (8 * byteCount (Proxy :: Proxy MD5)) - 1
   genKeyVRF = SignKeyMockVRF <$> nonNegIntR
   deriveVerKeyVRF (SignKeyMockVRF n) = VerKeyMockVRF n
-  evalVRF toEnc a sk = return $ evalVRF' toEnc a sk
-  verifyVRF toEnc (VerKeyMockVRF n) a c = evalVRF' toEnc a (SignKeyMockVRF n) == c
+  evalVRF a sk = return $ evalVRF' a sk
+  verifyVRF (VerKeyMockVRF n) a c = evalVRF' a (SignKeyMockVRF n) == c
 
-evalVRF' :: (a -> Encoding) -> a -> SignKeyVRF MockVRF -> (Natural, CertVRF MockVRF)
-evalVRF' toEnc a sk@(SignKeyMockVRF n) =
-  let y = fromHash $ hashWithSerialiser @MD5 id $ toEnc a <> toCBOR sk
+evalVRF' :: ToCBOR a => a -> SignKeyVRF MockVRF -> (Natural, CertVRF MockVRF)
+evalVRF' a sk@(SignKeyMockVRF n) =
+  let y = fromHash $ hashWithSerialiser @MD5 id $ toCBOR a <> toCBOR sk
   in (y, CertMockVRF n)

--- a/cardano-crypto-class/test/Test/Crypto/DSIGN.hs
+++ b/cardano-crypto-class/test/Test/Crypto/DSIGN.hs
@@ -61,18 +61,18 @@ testDSIGNAlgorithm _ n =
     ]
 
 prop_dsign_verify_pos
-  :: forall a v. (ToCBOR a, DSIGNAlgorithm v, Signable v a)
+  :: forall a v. (DSIGNAlgorithm v, Signable v a)
   => Seed
   -> a
   -> SignKeyDSIGN v
   -> Property
 prop_dsign_verify_pos seed a sk =
-  let sig = withSeed seed $ signDSIGN toCBOR a sk
+  let sig = withSeed seed $ signDSIGN a sk
       vk = deriveVerKeyDSIGN sk
-  in verifyDSIGN toCBOR vk a sig === Right ()
+  in verifyDSIGN vk a sig === Right ()
 
 prop_dsign_verify_neg_key
-  :: forall a v. (ToCBOR a, DSIGNAlgorithm v, Signable v a)
+  :: forall a v. (DSIGNAlgorithm v, Signable v a)
   => Seed
   -> a
   -> SignKeyDSIGN v
@@ -80,12 +80,12 @@ prop_dsign_verify_neg_key
   -> Property
 prop_dsign_verify_neg_key seed a sk sk' =
   sk /= sk' ==>
-    let sig = withSeed seed $ signDSIGN toCBOR a sk'
+    let sig = withSeed seed $ signDSIGN a sk'
         vk = deriveVerKeyDSIGN sk
-    in verifyDSIGN toCBOR vk a sig =/= Right ()
+    in verifyDSIGN vk a sig =/= Right ()
 
 prop_dsign_verify_neg_msg
-  :: forall a v. (ToCBOR a, Eq a, DSIGNAlgorithm v, Signable v a)
+  :: forall a v. (Eq a, DSIGNAlgorithm v, Signable v a)
   => Seed
   -> a
   -> a
@@ -93,6 +93,6 @@ prop_dsign_verify_neg_msg
   -> Property
 prop_dsign_verify_neg_msg seed a a' sk =
   a /= a' ==>
-    let sig = withSeed seed $ signDSIGN toCBOR a sk
+    let sig = withSeed seed $ signDSIGN a sk
         vk = deriveVerKeyDSIGN sk
-    in verifyDSIGN toCBOR vk a' sig =/= Right ()
+    in verifyDSIGN vk a' sig =/= Right ()

--- a/cardano-crypto-class/test/Test/Crypto/Orphans/Arbitrary.hs
+++ b/cardano-crypto-class/test/Test/Crypto/Orphans/Arbitrary.hs
@@ -41,12 +41,13 @@ instance DSIGNAlgorithm v => Arbitrary (VerKeyDSIGN v) where
   arbitrary = deriveVerKeyDSIGN <$> arbitrary
   shrink = const []
 
-instance (Signable v Int, DSIGNAlgorithm v) => Arbitrary (SigDSIGN v) where
+instance (Cardano.Crypto.DSIGN.Signable v Int, DSIGNAlgorithm v) 
+  => Arbitrary (SigDSIGN v) where
   arbitrary = do
     a <- arbitrary :: Gen Int
     sk <- arbitrary
     seed <- arbitrary
-    return $ withSeed seed $ signDSIGN toCBOR a sk
+    return $ withSeed seed $ signDSIGN a sk
   shrink = const []
 
 instance VRFAlgorithm v => Arbitrary (SignKeyVRF v) where
@@ -59,10 +60,11 @@ instance VRFAlgorithm v => Arbitrary (VerKeyVRF v) where
   arbitrary = deriveVerKeyVRF <$> arbitrary
   shrink = const []
 
-instance VRFAlgorithm v => Arbitrary (CertVRF v) where
+instance (Cardano.Crypto.VRF.Signable v Int, VRFAlgorithm v) 
+  => Arbitrary (CertVRF v) where
   arbitrary = do
     a <- arbitrary :: Gen Int
     sk <- arbitrary
     seed <- arbitrary
-    return $ withSeed seed $ fmap snd $ evalVRF toCBOR a sk
+    return $ withSeed seed $ fmap snd $ evalVRF a sk
   shrink = const []

--- a/cardano-crypto-class/test/Test/Crypto/VRF.hs
+++ b/cardano-crypto-class/test/Test/Crypto/VRF.hs
@@ -31,6 +31,7 @@ testVRFAlgorithm
                      , FromCBOR (VerKeyVRF v)
                      , ToCBOR (SignKeyVRF v)
                      , FromCBOR (SignKeyVRF v)
+                     , Signable v Int
                      )
   => proxy v
   -> String
@@ -47,29 +48,29 @@ testVRFAlgorithm _ n =
     ]
 
 prop_vrf_max
-  :: forall a v. (ToCBOR a, VRFAlgorithm v)
+  :: forall a v. (Signable v a, VRFAlgorithm v)
   => Seed
   -> a
   -> SignKeyVRF v
   -> Property
 prop_vrf_max seed a sk =
-  let (y, _) = withSeed seed $ evalVRF toCBOR a sk
+  let (y, _) = withSeed seed $ evalVRF a sk
       m = maxVRF (Proxy :: Proxy v)
   in counterexample ("expected " ++ show y ++ " <= " ++ show m) $ y <= m
 
 prop_vrf_verify_pos
-  :: forall a v. (ToCBOR a, VRFAlgorithm v)
+  :: forall a v. (Signable v a, VRFAlgorithm v)
   => Seed
   -> a
   -> SignKeyVRF v
   -> Bool
 prop_vrf_verify_pos seed a sk =
-  let (y, c) = withSeed seed $ evalVRF toCBOR a sk
+  let (y, c) = withSeed seed $ evalVRF a sk
       vk = deriveVerKeyVRF sk
-  in verifyVRF toCBOR vk a (y, c)
+  in verifyVRF vk a (y, c)
 
 prop_vrf_verify_neg
-  :: forall a v. (ToCBOR a, VRFAlgorithm v)
+  :: forall a v. (Signable v a, VRFAlgorithm v)
   => Seed
   -> a
   -> SignKeyVRF v
@@ -78,6 +79,6 @@ prop_vrf_verify_neg
 prop_vrf_verify_neg seed a sk sk' =
   sk /=
     sk' ==>
-    let (y, c) = withSeed seed $ evalVRF toCBOR a sk'
+    let (y, c) = withSeed seed $ evalVRF a sk'
         vk = deriveVerKeyVRF sk
-    in not $ verifyVRF toCBOR vk a (y, c)
+    in not $ verifyVRF vk a (y, c)


### PR DESCRIPTION
We earlier introduced explicit serialisers, but we now have the
`Signable` associated type, which can be used for exactly this. The
intention here is that, for example, the serialisation of old cardano
types may be done over the `Decoded` class, thus ensuring that we use
the correct bytes carried in the annotation.