### PR TITLE
Rename and move some CBOR utilities

### DIFF
--- a/binary/test/Test/Cardano/Binary/Helpers.hs
+++ b/binary/test/Test/Cardano/Binary/Helpers.hs
@@ -59,9 +59,9 @@ import Cardano.Binary
   , SizeOverride(..)
   , ToCBOR(..)
   , decodeListLenOf
-  , decodeUnknownCborDataItem
+  , decodeNestedCborBytes
   , encodeListLen
-  , encodeUnknownCborDataItem
+  , encodeNestedCborBytes
   , serialize
   , szSimplify
   , szWithCtx
@@ -87,14 +87,14 @@ data U = U Word8 BS.ByteString deriving (Show, Eq)
 
 instance ToCBOR U where
   toCBOR (U word8 bs) =
-    encodeListLen 2 <> toCBOR (word8 :: Word8) <> encodeUnknownCborDataItem
+    encodeListLen 2 <> toCBOR (word8 :: Word8) <> encodeNestedCborBytes
       (LBS.fromStrict bs)
 
 
 instance FromCBOR U where
   fromCBOR = do
     decodeListLenOf 2
-    U <$> fromCBOR <*> decodeUnknownCborDataItem
+    U <$> fromCBOR <*> decodeNestedCborBytes
 
 instance Arbitrary U where
   arbitrary = U <$> choose (0, 255) <*> arbitrary
@@ -105,11 +105,11 @@ data U24 = U24 Word8 BS.ByteString deriving (Show, Eq)
 instance FromCBOR U24 where
   fromCBOR = do
     decodeListLenOf 2
-    U24 <$> fromCBOR <*> decodeUnknownCborDataItem
+    U24 <$> fromCBOR <*> decodeNestedCborBytes
 
 instance ToCBOR U24 where
   toCBOR (U24 word8 bs) =
-    encodeListLen 2 <> toCBOR (word8 :: Word8) <> encodeUnknownCborDataItem
+    encodeListLen 2 <> toCBOR (word8 :: Word8) <> encodeNestedCborBytes
       (LBS.fromStrict bs)
 
 
@@ -131,9 +131,9 @@ extensionProperty = forAll @a (arbitrary :: Gen a) $ \input ->
 
       Such type will be encoded, roughly, like this:
 
-      encode (Constructor1 a b) = encodeWord 0 <> encodeKnownCborDataItem (a,b)
-      encode (Constructor2 a b) = encodeWord 1 <> encodeKnownCborDataItem a
-      encode (UnknownConstructor tag bs) = encodeWord tag <> encodeUnknownCborDataItem bs
+      encode (Constructor1 a b) = encodeWord 0 <> encodeNestedCbor (a,b)
+      encode (Constructor2 a b) = encodeWord 1 <> encodeNestedCbor a
+      encode (UnknownConstructor tag bs) = encodeWord tag <> encodeNestedCborBytes bs
 
       In CBOR terms, we would produce something like this:
 

--- a/binary/test/Test/Cardano/Binary/Serialization.hs
+++ b/binary/test/Test/Cardano/Binary/Serialization.hs
@@ -146,17 +146,11 @@ prop_roundTripSerialize' = property $ do
   ts <- forAll genTestStruct
   (unsafeDeserialize' . serialize' $ ts) === ts
 
-prop_roundTripCrcProtected :: Property
-prop_roundTripCrcProtected = property $ do
+prop_roundTripEncodeNestedCbor :: Property
+prop_roundTripEncodeNestedCbor = property $ do
   ts <- forAll genTestStruct
-  let crcEncodedBS = serializeEncoding . encodeCrcProtected $ ts
-  decodeFullDecoder "" decodeCrcProtected crcEncodedBS === Right ts
-
-prop_roundTripKnownCBORData :: Property
-prop_roundTripKnownCBORData = property $ do
-  ts <- forAll genTestStruct
-  let encoded = serializeEncoding . encodeKnownCborDataItem $ ts
-  decodeFullDecoder "" decodeKnownCborDataItem encoded === Right ts
+  let encoded = serializeEncoding . encodeNestedCbor $ ts
+  decodeFullDecoder "" decodeNestedCbor encoded === Right ts
 
 prop_decodeContainerSkelWithReplicate :: Property
 prop_decodeContainerSkelWithReplicate = property $


### PR DESCRIPTION
`{encode,decode}{KnownUnkown}CborDataItem` gets renamed to `{encode,decode}NestedCbor{Bytes}`.

The CRC utils are removed entirely.

The rationale in both cases is that this package should be for general utils that we expect to reuse across other packages, not for things that are quirks of the Byron encodings. In this case the "known"/"unknown" pattern is exclusive to the Byron encodings. This is not a pattern we wish to perpetuate in new code. The nested CBOR is still useful elsewhere so we keep the code but under a more appropriate name.

The old name, and the CRC utils will be moved into the `cardano-ledger` package directly, where their scope can be limited to the Byron era encodings.