### PR TITLE
Use released Hackage versions of cborg and canonical-json (in the cabal files)

### DIFF
--- a/binary/cardano-binary.cabal
+++ b/binary/cardano-binary.cabal
@@ -37,7 +37,7 @@ library
                      , aeson
                      , bytestring
                      , cardano-prelude
-                     , cborg
+                     , cborg              >= 0.2.2 && < 0.3
                      , containers
                      , digest
                      , formatting

--- a/cabal.project
+++ b/cabal.project
@@ -3,12 +3,6 @@ packages:
   binary/test
   cardano-crypto-class
 
-
-source-repository-package
-  type: git
-  location: http://github.com/well-typed/canonical-json
-  tag: ddfe3593b80b5ceb88842bb7a6f2268df75d2c2f
-
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
@@ -19,12 +13,6 @@ source-repository-package
   location: https://github.com/input-output-hk/cardano-prelude
   tag: 8273fe5f00ac03b0c66ef3841c8e957139ee18f2
   subdir: test
-
-source-repository-package
-  type: git
-  location: https://github.com/well-typed/cborg
-  tag: 80fbe0ee5e67a5622e2cb9eaa9d8594a2214322d
-  subdir: cborg
 
 source-repository-package
   type: git


### PR DESCRIPTION
This was already set in the cardano-prelude stack file and nix files.

So this just sets the constraint in `cardano-binary.cabal` so that dependent packages that are built with cabal will always get the right version without having to set a local constraint.

Also update the `cabal.project`.