### PR TITLE
Remove Ord instances for crypto keys

### DIFF
--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Class.hs
@@ -28,11 +28,10 @@ import GHC.Stack
 
 class ( Typeable v
       , Show (VerKeyDSIGN v)
-      , Ord (VerKeyDSIGN v)
+      , Eq (VerKeyDSIGN v)
       , Show (SignKeyDSIGN v)
-      , Ord (SignKeyDSIGN v)
       , Show (SigDSIGN v)
-      , Ord (SigDSIGN v)
+      , Eq (SigDSIGN v)
       )
       => DSIGNAlgorithm v where
 
@@ -81,8 +80,6 @@ newtype SignedDSIGN v a = SignedDSIGN (SigDSIGN v)
 deriving instance DSIGNAlgorithm v => Show (SignedDSIGN v a)
 
 deriving instance DSIGNAlgorithm v => Eq (SignedDSIGN v a)
-
-deriving instance DSIGNAlgorithm v => Ord (SignedDSIGN v a)
 
 signedDSIGN
   :: (DSIGNAlgorithm v, MonadRandom m, Signable v a)

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Class.hs
@@ -28,11 +28,10 @@ import Numeric.Natural (Natural)
 
 class ( Typeable v
       , Show (VerKeyKES v)
-      , Ord (VerKeyKES v)
+      , Eq (VerKeyKES v)
       , Show (SignKeyKES v)
-      , Ord (SignKeyKES v)
       , Show (SigKES v)
-      , Ord (SigKES v)
+      , Eq (SigKES v)
       )
       => KESAlgorithm v where
 
@@ -83,8 +82,6 @@ newtype SignedKES v a = SignedKES {getSig :: SigKES v}
 deriving instance KESAlgorithm v => Show (SignedKES v a)
 
 deriving instance KESAlgorithm v => Eq (SignedKES v a)
-
-deriving instance KESAlgorithm v => Ord (SignedKES v a)
 
 signedKES
   :: (KESAlgorithm v, MonadRandom m, Signable v a)

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Simple.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Simple.hs
@@ -10,6 +10,7 @@
 module Cardano.Crypto.KES.Simple
   ( SimpleKES
   , SigKES (..)
+  , SignKeyKES (..)
   )
 where
 

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Simple.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Simple.hs
@@ -80,8 +80,6 @@ deriving instance DSIGNAlgorithm d => Show (VerKeyKES (SimpleKES d))
 
 deriving instance DSIGNAlgorithm d => Eq (VerKeyKES (SimpleKES d))
 
-deriving instance DSIGNAlgorithm d => Ord (VerKeyKES (SimpleKES d))
-
 instance (DSIGNAlgorithm d, Typeable d) => ToCBOR (VerKeyKES (SimpleKES d)) where
   toCBOR (VerKeySimpleKES vvks) =
     encodeListLen (fromIntegral $ Vec.length vvks) <>
@@ -94,10 +92,6 @@ instance (DSIGNAlgorithm d, Typeable d) => FromCBOR (VerKeyKES (SimpleKES d)) wh
       Vec.fromList <$> replicateM len decodeVerKeyDSIGN
 
 deriving instance DSIGNAlgorithm d => Show (SignKeyKES (SimpleKES d))
-
-deriving instance DSIGNAlgorithm d => Eq (SignKeyKES (SimpleKES d))
-
-deriving instance DSIGNAlgorithm d => Ord (SignKeyKES (SimpleKES d))
 
 instance (DSIGNAlgorithm d, Typeable d) => ToCBOR (SignKeyKES (SimpleKES d)) where
   toCBOR (SignKeySimpleKES (vks, stuff)) =
@@ -133,8 +127,6 @@ instance (DSIGNAlgorithm d, Typeable d) => FromCBOR (SignKeyKES (SimpleKES d)) w
 deriving instance DSIGNAlgorithm d => Show (SigKES (SimpleKES d))
 
 deriving instance DSIGNAlgorithm d => Eq (SigKES (SimpleKES d))
-
-deriving instance DSIGNAlgorithm d => Ord (SigKES (SimpleKES d))
 
 instance (DSIGNAlgorithm d, Typeable d) => ToCBOR (SigKES (SimpleKES d)) where
   toCBOR (SigSimpleKES d) = encodeSigDSIGN d

--- a/cardano-crypto-class/src/Cardano/Crypto/VRF/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/VRF/Class.hs
@@ -32,11 +32,10 @@ import Numeric.Natural
 
 class ( Typeable v
       , Show (VerKeyVRF v)
-      , Ord (VerKeyVRF v)
+      , Eq (VerKeyVRF v)
       , Show (SignKeyVRF v)
-      , Ord (SignKeyVRF v)
       , Show (CertVRF v)
-      , Ord (CertVRF v)
+      , Eq (CertVRF v)
       , FromCBOR (CertVRF v)
       , ToCBOR (CertVRF v)
       )
@@ -81,8 +80,6 @@ data CertifiedVRF v a
 deriving instance VRFAlgorithm v => Show (CertifiedVRF v a)
 
 deriving instance VRFAlgorithm v => Eq (CertifiedVRF v a)
-
-deriving instance VRFAlgorithm v => Ord (CertifiedVRF v a)
 
 instance (VRFAlgorithm v, Typeable a) => ToCBOR (CertifiedVRF v a) where
   toCBOR cvrf =

--- a/cardano-crypto-class/test/Test/Crypto/DSIGN.hs
+++ b/cardano-crypto-class/test/Test/Crypto/DSIGN.hs
@@ -43,6 +43,7 @@ testDSIGNAlgorithm
                      , FromCBOR (VerKeyDSIGN v)
                      , ToCBOR (SignKeyDSIGN v)
                      , FromCBOR (SignKeyDSIGN v)
+                     , Eq (SignKeyDSIGN v)   -- no Eq for signing keys normally
                      , ToCBOR (SigDSIGN v)
                      , FromCBOR (SigDSIGN v)
                      , Signable v Int
@@ -72,7 +73,7 @@ prop_dsign_verify_pos seed a sk =
   in verifyDSIGN vk a sig === Right ()
 
 prop_dsign_verify_neg_key
-  :: forall a v. (DSIGNAlgorithm v, Signable v a)
+  :: forall a v. (DSIGNAlgorithm v, Eq (SignKeyDSIGN v), Signable v a)
   => Seed
   -> a
   -> SignKeyDSIGN v

--- a/cardano-crypto-class/test/Test/Crypto/VRF.hs
+++ b/cardano-crypto-class/test/Test/Crypto/VRF.hs
@@ -31,6 +31,7 @@ testVRFAlgorithm
                      , FromCBOR (VerKeyVRF v)
                      , ToCBOR (SignKeyVRF v)
                      , FromCBOR (SignKeyVRF v)
+                     , Eq (SignKeyVRF v)     -- no Eq for signing keys normally
                      , Signable v Int
                      )
   => proxy v
@@ -70,7 +71,7 @@ prop_vrf_verify_pos seed a sk =
   in verifyVRF vk a (y, c)
 
 prop_vrf_verify_neg
-  :: forall a v. (Signable v a, VRFAlgorithm v)
+  :: forall a v. (Signable v a, VRFAlgorithm v, Eq (SignKeyVRF v))
   => Seed
   -> a
   -> SignKeyVRF v


### PR DESCRIPTION
The pattern that our crypto libraries use is that they deliberately do not provide Ord instances for keys (verification or signing keys). Instead our crypto library encourage the use of comparisons on key hashes.

This patch removes Ord instances for keys and signatures. It removes Eq instances for signing keys. It keeps Eq instances for verification keys and signatures.

This is the same pattern as https://github.com/input-output-hk/cardano-ledger/pull/587 which was done at the request of the internal auditors.

There will be a follow-up patch for `ouroboros-consensus`.