### PR TITLE
Hashing a pair of hashes together

### DIFF
--- a/cardano-crypto-class/src/Cardano/Crypto/Hash/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Hash/Class.hs
@@ -9,6 +9,7 @@ module Cardano.Crypto.Hash.Class
   , Hash
   , getHash
   , hash
+  , hashPair
   , hashWithSerialiser
   , fromHash
   , xor
@@ -84,3 +85,6 @@ fromHash = foldl' f 0 . SB.unpack . getHash
 --   This functionality is required for VRF calculation.
 xor :: Hash h a -> Hash h a -> Hash h a
 xor (Hash x) (Hash y) = Hash $ SB.pack $ SB.zipWith Bits.xor x y
+
+hashPair :: forall h a b c. HashAlgorithm h => Hash h a -> Hash h b -> Hash h c
+hashPair (Hash a) (Hash b) = Hash $ digest (Proxy :: Proxy h) $ a <> b


### PR DESCRIPTION
The purpose is to construct a merkle pair (a tiny merkle tree) for segwit. We plan to hash the transaction bodies, hash the transaction witnesses, and hash those two hashes together.

Is this a sane approach?