### PR TITLE
Add `abstractSizeVKey` and `abstractSizeSig` to `DSIGNAlgorithm`

### DIFF
--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Class.hs
@@ -25,6 +25,7 @@ import Data.Typeable (Typeable)
 import GHC.Exts (Constraint)
 import GHC.Generics (Generic)
 import GHC.Stack
+import Numeric.Natural
 
 class ( Typeable v
       , Show (VerKeyDSIGN v)
@@ -46,6 +47,12 @@ class ( Typeable v
 
   type Signable v :: Type -> Constraint
   type Signable v = Empty
+
+
+  -- | Abstract sizes for verification keys and signatures, specifies an upper
+  -- bound on the real byte sizes.
+  abstractSizeVKey :: proxy v -> Natural
+  abstractSizeSig  :: proxy v -> Natural
 
   -- | Context required to run the DSIGN algorithm
   --

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed448.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed448.hs
@@ -69,6 +69,10 @@ instance DSIGNAlgorithm Ed448DSIGN where
           then Right ()
           else Left "Verification failed"
 
+    -- | Goldilocks points are 448 bits long, so 64 byte is a good abstract size
+    abstractSizeVKey _ = 64
+    abstractSizeSig  _ = 64
+
 instance ToCBOR (VerKeyDSIGN Ed448DSIGN) where
   toCBOR = encodeBA
 

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Mock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Mock.hs
@@ -28,7 +28,7 @@ import Cardano.Binary
 import Cardano.Crypto.DSIGN.Class
 import Cardano.Crypto.Hash
 import Cardano.Crypto.Util (nonNegIntR)
-import Cardano.Prelude (NoUnexpectedThunks)
+import Cardano.Prelude (NoUnexpectedThunks, Proxy(..))
 import GHC.Generics (Generic)
 import GHC.Stack
 
@@ -72,6 +72,14 @@ instance DSIGNAlgorithm MockDSIGN where
                , vErrSignature = s
                , vErrCallStack = prettyCallStack callStack
                }
+
+    abstractSizeVKey _ = 8 -- for 64 bit Int
+    abstractSizeSig  _ = 1
+                       + (byteCount (Proxy :: Proxy ShortHash))
+                       + 8 -- length tag + length
+                                                        -- short hash + 64 bit
+                                                        -- Int
+
 
 -- | Debugging: provide information about the verification failure
 --

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/NeverUsed.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/NeverUsed.hs
@@ -40,3 +40,6 @@ instance DSIGNAlgorithm NeverDSIGN where
 
   signDSIGN   = error "DSIGN not available"
   verifyDSIGN = error "DSIGN not available"
+
+  abstractSizeVKey _ = error "abstract size not available"
+  abstractSizeSig  _ = error "abstract size not available"

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/RSAPSS.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/RSAPSS.hs
@@ -69,6 +69,11 @@ instance DSIGNAlgorithm RSAPSSDSIGN where
           then Right ()
           else Left "Verification failed"
 
+    -- | The problem is that the integers are not bounded here, they could be
+    -- any bitsize.
+    abstractSizeVKey _ = error "RSA can use unbounded Integer"
+    abstractSizeSig  _ = error "RSA can use unbounded Integer"
+
 instance ToCBOR (VerKeyDSIGN RSAPSSDSIGN) where
   toCBOR (VerKeyRSAPSSDSIGN vk) = toCBOR $ vkToTuple vk
 


### PR DESCRIPTION
There is s need to calculate the abstract size of a transaction in Shelley. The
size of a transaction also includes the witnesses which in turn contain the
verification key and signature.

Adding the above functions to the class allows having an upper bound of the
actual size of signatures and verification keys. For the un-bounded bitsize RSA
implementation, this is not possible.