### PR TITLE
Use quiet-0.2 for some data types

### DIFF
--- a/slotting/cardano-slotting.cabal
+++ b/slotting/cardano-slotting.cabal
@@ -45,5 +45,6 @@ library
                       , containers
                       , mmorph
                       , mtl
+                      , quiet
                       , serialise
                       , transformers

--- a/slotting/src/Cardano/Slotting/Block.hs
+++ b/slotting/src/Cardano/Slotting/Block.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module Cardano.Slotting.Block
@@ -12,13 +13,15 @@ import Cardano.Prelude (NoUnexpectedThunks)
 import Codec.Serialise (Serialise (..))
 import Data.Word (Word64)
 import GHC.Generics (Generic)
+import Quiet (Quiet (..))
 
 -- | The 0-based index of the block in the blockchain.
 -- BlockNo is <= SlotNo and is only equal at slot N if there is a block
 -- for every slot where N <= SlotNo.
 newtype BlockNo = BlockNo {unBlockNo :: Word64}
-  deriving stock (Show, Eq, Ord, Generic)
+  deriving stock (Eq, Ord, Generic)
   deriving newtype (Enum, Bounded, Num, Serialise, NoUnexpectedThunks)
+  deriving (Show) via (Quiet BlockNo)
 
 instance ToCBOR BlockNo where
   toCBOR = encode

--- a/slotting/src/Cardano/Slotting/Slot.hs
+++ b/slotting/src/Cardano/Slotting/Slot.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module Cardano.Slotting.Slot
@@ -26,11 +27,13 @@ import Codec.Serialise (Serialise (..))
 import Data.Typeable (Typeable)
 import Data.Word (Word64)
 import GHC.Generics (Generic)
+import Quiet (Quiet (..))
 
 -- | The 0-based index for the Ourboros time slot.
 newtype SlotNo = SlotNo {unSlotNo :: Word64}
-  deriving stock (Show, Eq, Ord, Generic)
+  deriving stock ( Eq, Ord, Generic)
   deriving newtype (Enum, Bounded, Num, NFData, Serialise, NoUnexpectedThunks)
+  deriving (Show) via (Quiet SlotNo)
 
 instance ToCBOR SlotNo where
   toCBOR = encode
@@ -90,9 +93,11 @@ withOriginFromMaybe (Just t) = At t
 
 -- | An epoch, i.e. the number of the epoch.
 newtype EpochNo = EpochNo {unEpochNo :: Word64}
-  deriving stock (Eq, Ord, Show, Generic)
+  deriving stock (Eq, Ord, Generic)
   deriving newtype (Enum, Num, Serialise, ToCBOR, FromCBOR, NoUnexpectedThunks)
+  deriving (Show) via (Quiet EpochNo)
 
 newtype EpochSize = EpochSize {unEpochSize :: Word64}
-  deriving stock (Eq, Ord, Show, Generic)
+  deriving stock (Eq, Ord, Generic)
   deriving newtype (Enum, Num, Real, Integral, NoUnexpectedThunks)
+  deriving (Show) via (Quiet EpochSize)


### PR DESCRIPTION
E.G. `show (SlotNo 3) == "SlotNo 3"` now instead of `"SlotNo {unSlotNo = 3}"`.