### PR TITLE
Avoid confusion with slot/block numbers

### DIFF
--- a/slotting/src/Cardano/Slotting/Block.hs
+++ b/slotting/src/Cardano/Slotting/Block.hs
@@ -3,8 +3,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module Cardano.Slotting.Block
-  ( BlockNo (..),
-    genesisBlockNo,
+  ( BlockNo (..)
   )
 where
 
@@ -26,6 +25,3 @@ instance ToCBOR BlockNo where
 
 instance FromCBOR BlockNo where
   fromCBOR = decode
-
-genesisBlockNo :: BlockNo
-genesisBlockNo = BlockNo 0

--- a/slotting/src/Cardano/Slotting/Slot.hs
+++ b/slotting/src/Cardano/Slotting/Slot.hs
@@ -8,7 +8,6 @@
 
 module Cardano.Slotting.Slot
   ( SlotNo (..),
-    genesisSlotNo,
     WithOrigin (..),
     at,
     origin,
@@ -38,9 +37,6 @@ instance ToCBOR SlotNo where
 
 instance FromCBOR SlotNo where
   fromCBOR = decode
-
-genesisSlotNo :: SlotNo
-genesisSlotNo = SlotNo 0
 
 {-------------------------------------------------------------------------------
   WithOrigin


### PR DESCRIPTION
When we are at genesis, there _is_ no slot/block number yet. Moreover, there should be no assumptions about what the slot/block number in any particular ledger is in the generic infrastructure, as this may be ledger dependent.

* Delete `genesisSlotNo` and `genesisBlockNo`
* Add `WithOrigin` to the lower bound in `SlotBounded`