### PR TITLE
Added missing encodedSizeExpr for BlockNo and SlotNo

### DIFF
--- a/slotting/src/Cardano/Slotting/Block.hs
+++ b/slotting/src/Cardano/Slotting/Block.hs
@@ -22,6 +22,7 @@ newtype BlockNo = BlockNo {unBlockNo :: Word64}
 
 instance ToCBOR BlockNo where
   toCBOR = encode
+  encodedSizeExpr size = encodedSizeExpr size . fmap unBlockNo
 
 instance FromCBOR BlockNo where
   fromCBOR = decode

--- a/slotting/src/Cardano/Slotting/Slot.hs
+++ b/slotting/src/Cardano/Slotting/Slot.hs
@@ -34,6 +34,7 @@ newtype SlotNo = SlotNo {unSlotNo :: Word64}
 
 instance ToCBOR SlotNo where
   toCBOR = encode
+  encodedSizeExpr size = encodedSizeExpr size . fmap unSlotNo
 
 instance FromCBOR SlotNo where
   fromCBOR = decode


### PR DESCRIPTION
These ToCBOR instances ought (i.e. that the encoded size is in bounds of
'encodedSizeExpr') to be tested in `cardano-ledger`, where test
infrastructure for these kind of tests exists.