### PR TITLE
Add To/FromCBOR instances for ShortByteString

### DIFF
--- a/binary/cardano-binary.cabal
+++ b/binary/cardano-binary.cabal
@@ -43,6 +43,7 @@ library
                      , containers
                      , digest
                      , formatting
+                     , primitive
                      , recursion-schemes
                      , safe-exceptions
                      , tagged

--- a/binary/src/Cardano/Binary/FromCBOR.hs
+++ b/binary/src/Cardano/Binary/FromCBOR.hs
@@ -21,9 +21,13 @@ where
 import Cardano.Prelude
 
 import Codec.CBOR.Decoding as D
+import Codec.CBOR.ByteArray as BA
 import qualified Codec.CBOR.Read as CBOR.Read
 import Control.Exception (Exception)
 import qualified Data.ByteString.Lazy as BS.Lazy
+import qualified Data.ByteString.Short as SBS
+import qualified Data.ByteString.Short.Internal as SBS
+import qualified Data.Primitive.ByteArray as Prim
 import Data.Fixed (Fixed(..), Nano, Pico)
 import qualified Data.Map as M
 import qualified Data.Set as S
@@ -277,6 +281,11 @@ instance FromCBOR Text where
 
 instance FromCBOR LByteString where
   fromCBOR = BS.Lazy.fromStrict <$> fromCBOR
+
+instance FromCBOR SBS.ShortByteString where
+  fromCBOR = do
+    BA.BA (Prim.ByteArray ba) <- D.decodeByteArray
+    return $ SBS.SBS ba
 
 instance FromCBOR a => FromCBOR [a] where
   fromCBOR = decodeListWith fromCBOR

--- a/binary/test/Test/Cardano/Binary/Serialization.hs
+++ b/binary/test/Test/Cardano/Binary/Serialization.hs
@@ -12,6 +12,7 @@ import Codec.CBOR.Decoding as D
 
 import qualified Data.Vector as V
 import qualified Data.ByteString.Lazy as BS.Lazy
+import qualified Data.ByteString.Short as BS.Short
 
 import Cardano.Prelude
 
@@ -49,6 +50,7 @@ data TestStruct = TestStruct
   , tsRaw                   :: !Raw
   , tsVectorBool            :: !(V.Vector Bool)
   , tsLByteString           :: BS.Lazy.ByteString
+  , tsSByteString           :: BS.Short.ShortByteString
   }
   deriving (Show, Eq)
 
@@ -80,6 +82,7 @@ genTestStruct = TestStruct
     <*> (Raw <$> ( Gen.bytes (Range.linear 0 20)))
     <*> (V.fromList <$> ( Gen.list (Range.constant 0 10) Gen.bool))
     <*> (BS.Lazy.fromStrict <$> Gen.bytes (Range.linear 0 20))
+    <*> (BS.Short.toShort <$> Gen.bytes (Range.linear 0 20))
 
 instance ToCBOR TestStruct where
   toCBOR ts = E.encodeListLen 1 
@@ -109,12 +112,14 @@ instance ToCBOR TestStruct where
     <> toCBOR ( tsRaw                   ts)
     <> toCBOR ( tsVectorBool            ts)
     <> toCBOR ( tsLByteString           ts)
+    <> toCBOR ( tsSByteString           ts)
 
 instance FromCBOR TestStruct where
   fromCBOR = do
     D.decodeListLenOf 1 
     TestStruct 
       <$> fromCBOR
+      <*> fromCBOR
       <*> fromCBOR
       <*> fromCBOR
       <*> fromCBOR


### PR DESCRIPTION
And add it to the round trip test.

These are basically copied from the serialise package instances.