### PR TITLE
Support cabal build in nix-shell.

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -36,7 +36,7 @@ let
 
     # Prevents cabal from choosing alternate plans, so that
     # *all* dependencies are provided by Nix.
-    exactDeps = true;
+    exactDeps = false;
 
     inherit withHoogle;
   };


### PR DESCRIPTION
For some reason, this fails with `exactDeps = true`.