### PR TITLE
Fail when decoding a negative Natural instead of throwing

### DIFF
--- a/binary/src/Cardano/Binary/FromCBOR.hs
+++ b/binary/src/Cardano/Binary/FromCBOR.hs
@@ -195,7 +195,11 @@ instance FromCBOR NominalDiffTime where
   fromCBOR = fromRational . (% 1e6) <$> fromCBOR
 
 instance FromCBOR Natural where
-  fromCBOR = fromInteger <$> fromCBOR
+  fromCBOR = do
+      !n <- fromCBOR
+      if n >= 0
+        then return $! fromInteger n
+        else cborError $ DecoderErrorCustom "Natural" "got a negative number"
 
 instance FromCBOR Void where
   fromCBOR = cborError DecoderErrorVoid

--- a/binary/test/Test/Cardano/Binary/Failure.hs
+++ b/binary/test/Test/Cardano/Binary/Failure.hs
@@ -29,6 +29,10 @@ genInvalidEitherCBOR = do
   b <- Gen.bool
   pure (encodeListLen 2 <> encodeWord 3 <> toCBOR b)
 
+genNegativeInteger :: Gen Integer
+genNegativeInteger =
+  negate . toInteger <$> Gen.word64 (Range.exponential 1 maxBound)
+
 ----------------------------------------------------------------------
 -------------------------   Properties   -----------------------------
 
@@ -60,6 +64,11 @@ prop_shouldFailSet = property $ do
           <> encodeListLen (fromIntegral $ length ls + 2) 
           <> (mconcat $ toCBOR <$> (4: 3:ls))
   assertIsLeft (decode set :: Either DecoderError (Set Int))
+
+prop_shouldFailNegativeNatural :: Property
+prop_shouldFailNegativeNatural = property $ do
+  n <- forAll $ genNegativeInteger
+  assertIsLeft (decode (toCBOR n) :: Either DecoderError Natural)
 
 ---------------------------------------------------------------------
 ------------------------------- helpers -----------------------------

--- a/cardano-crypto-class/cardano-crypto-class.cabal
+++ b/cardano-crypto-class/cardano-crypto-class.cabal
@@ -60,7 +60,6 @@ library
                      , cryptonite
                      , deepseq
                      , memory
-                     , reflection
                      , vector
 
   default-language:    Haskell2010


### PR DESCRIPTION
Decoding a negative `Natural` should not result in `Exception: arithmetic
underflow` but in a `cborError`.