### PR TITLE
Use decodeListLenOf instead of decodeListLen

### DIFF
--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Mock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Mock.hs
@@ -23,7 +23,7 @@ where
 import Cardano.Binary
   ( FromCBOR (..)
   , ToCBOR (..)
-  , decodeListLen
+  , decodeListLenOf
   , encodeListLen
   )
 import Cardano.Crypto.DSIGN.Class
@@ -104,7 +104,7 @@ instance ToCBOR (SigDSIGN MockDSIGN) where
   toCBOR (SigMockDSIGN b i) = encodeListLen 2 <> toCBOR b <> toCBOR i
 
 instance FromCBOR (SigDSIGN MockDSIGN) where
-  fromCBOR = SigMockDSIGN <$ decodeListLen <*> fromCBOR <*> fromCBOR
+  fromCBOR = SigMockDSIGN <$ decodeListLenOf 2 <*> fromCBOR <*> fromCBOR
 
 -- | Get the id of the signer from a signature. Used for testing.
 verKeyIdFromSigned :: SignedDSIGN MockDSIGN a -> Int

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Mock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Mock.hs
@@ -15,7 +15,7 @@ module Cardano.Crypto.KES.Mock
   )
 where
 
-import Cardano.Binary (FromCBOR (..), ToCBOR (..), decodeListLen, encodeListLen)
+import Cardano.Binary (FromCBOR (..), ToCBOR (..), decodeListLenOf, encodeListLen)
 import Cardano.Crypto.Hash
 import Cardano.Crypto.KES.Class
 import Cardano.Crypto.Util (nonNegIntR)
@@ -88,7 +88,7 @@ instance ToCBOR (SigKES MockKES) where
 instance FromCBOR (SigKES MockKES) where
   fromCBOR =
     SigMockKES <$
-      decodeListLen <*>
+      decodeListLenOf 2 <*>
       fromCBOR <*>
       fromCBOR
 
@@ -102,7 +102,7 @@ instance ToCBOR (SignKeyKES MockKES) where
 instance FromCBOR (SignKeyKES MockKES) where
   fromCBOR =
     SignKeyMockKES <$
-      decodeListLen <*>
+      decodeListLenOf 3 <*>
       fromCBOR <*>
       fromCBOR <*>
       fromCBOR


### PR DESCRIPTION
By ignoring the length of the list, we accept invalid CBOR.