### PR TITLE
Add Eq instance for SignKeyKES

### DIFF
--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Class.hs
@@ -31,6 +31,7 @@ class ( Typeable v
       , Show (VerKeyDSIGN v)
       , Eq (VerKeyDSIGN v)
       , Show (SignKeyDSIGN v)
+      , Eq (SignKeyDSIGN v)
       , Show (SigDSIGN v)
       , Eq (SigDSIGN v)
       , NoUnexpectedThunks (SigDSIGN     v)

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Class.hs
@@ -31,6 +31,7 @@ class ( Typeable v
       , Show (VerKeyKES v)
       , Eq (VerKeyKES v)
       , Show (SignKeyKES v)
+      , Eq (SignKeyKES v)
       , Show (SigKES v)
       , Eq (SigKES v)
       , NoUnexpectedThunks (SigKES     v)

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Simple.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Simple.hs
@@ -110,6 +110,8 @@ instance (DSIGNAlgorithm d, Typeable d) => FromCBOR (VerKeyKES (SimpleKES d)) wh
 
 deriving instance DSIGNAlgorithm d => Show (SignKeyKES (SimpleKES d))
 
+deriving instance DSIGNAlgorithm d => Eq (SignKeyKES (SimpleKES d))
+
 instance (DSIGNAlgorithm d, Typeable d) => ToCBOR (SignKeyKES (SimpleKES d)) where
   toCBOR (SignKeySimpleKES (vks, stuff)) =
     encodeListLen 2 <>

--- a/cardano-crypto-class/src/Cardano/Crypto/VRF/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/VRF/Class.hs
@@ -37,6 +37,7 @@ class ( Typeable v
       , Show (VerKeyVRF v)
       , Eq (VerKeyVRF v)
       , Show (SignKeyVRF v)
+      , Eq (SignKeyVRF v)
       , Show (CertVRF v)
       , Eq (CertVRF v)
       , FromCBOR (CertVRF v)


### PR DESCRIPTION
- Needed for round trip testing in cardano-node
- Also added `Eq` constraints so in future the relevant `Eq` instances will need to be defined.