### PR TITLE
Changes to the KES API

### DIFF
--- a/cardano-crypto-class/cardano-crypto-class.cabal
+++ b/cardano-crypto-class/cardano-crypto-class.cabal
@@ -44,6 +44,8 @@ library
                        Cardano.Crypto.KES.Mock
                        Cardano.Crypto.KES.NeverUsed
                        Cardano.Crypto.KES.Simple
+                       Cardano.Crypto.KES.Single
+                       Cardano.Crypto.KES.Sum
 
                        Cardano.Crypto.Seed
                        Cardano.Crypto.Util

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Class.hs
@@ -31,7 +31,6 @@ import Data.Typeable (Typeable)
 import GHC.Exts (Constraint)
 import GHC.Generics (Generic)
 import GHC.Stack
-import Numeric.Natural
 
 
 class ( Typeable v
@@ -67,10 +66,9 @@ class ( Typeable v
   hashVerKeyDSIGN :: HashAlgorithm h => VerKeyDSIGN v -> Hash h (VerKeyDSIGN v)
   hashVerKeyDSIGN = hashRaw rawSerialiseVerKeyDSIGN
 
-  -- | Abstract sizes for verification keys and signatures, specifies an upper
-  -- bound on the real byte sizes.
-  abstractSizeVKey :: proxy v -> Natural
-  abstractSizeSig  :: proxy v -> Natural
+  sizeVerKeyDSIGN  :: proxy v -> Word
+  sizeSignKeyDSIGN :: proxy v -> Word
+  sizeSigDSIGN     :: proxy v -> Word
 
 
   --
@@ -192,8 +190,9 @@ class ( Typeable v
   {-# MINIMAL
         algorithmNameDSIGN
       , deriveVerKeyDSIGN
-      , abstractSizeVKey
-      , abstractSizeSig
+      , sizeVerKeyDSIGN
+      , sizeSignKeyDSIGN
+      , sizeSigDSIGN
       , signDSIGN
       , verifyDSIGN
       , genKeyDSIGN

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Class.hs
@@ -109,7 +109,7 @@ class ( Typeable v
   genKeyDSIGN :: Seed -> SignKeyDSIGN v
 
   -- | The upper bound on the 'Seed' size needed by 'genKeyDSIGN'
-  seedSizeDSIGN :: proxy v -> Natural
+  seedSizeDSIGN :: proxy v -> Word
 
 
   --

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed25519.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed25519.hs
@@ -64,10 +64,10 @@ instance DSIGNAlgorithm Ed25519DSIGN where
 
     -- | Ed25519 key size is 32 octets
     -- (per <https://tools.ietf.org/html/rfc8032#section-5.1.6>)
-    abstractSizeVKey _ = 32
-
+    sizeVerKeyDSIGN  _ = 32
+    sizeSignKeyDSIGN _ = 32
     -- | Ed25519 signature size is 64 octets
-    abstractSizeSig  _ = 64
+    sizeSigDSIGN     _ = 64
 
     --
     -- Core algorithm operations

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed25519.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed25519.hs
@@ -15,22 +15,19 @@ module Cardano.Crypto.DSIGN.Ed25519
   )
 where
 
-import Cardano.Binary
-  ( Decoder
-  , Encoding
-  , FromCBOR (..)
-  , ToCBOR (..)
-  , serialize
-  )
-import Cardano.Crypto.DSIGN.Class
-import Cardano.Crypto.Seed
+import Data.ByteString.Lazy (toStrict)
+import Data.ByteArray as BA (ByteArrayAccess, convert)
+import GHC.Generics (Generic)
+
 import Cardano.Prelude (NFData, NoUnexpectedThunks, UseIsNormalForm(..))
+import Cardano.Binary (FromCBOR (..), ToCBOR (..), serialize)
+
 import Crypto.Error (CryptoFailable (..))
 import Crypto.PubKey.Ed25519 as Ed25519
-import Data.ByteArray (ByteArrayAccess, convert)
-import Data.ByteString (ByteString)
-import Data.ByteString.Lazy (toStrict)
-import GHC.Generics (Generic)
+
+import Cardano.Crypto.DSIGN.Class
+import Cardano.Crypto.Seed
+
 
 data Ed25519DSIGN
 
@@ -62,12 +59,6 @@ instance DSIGNAlgorithm Ed25519DSIGN where
 
     deriveVerKeyDSIGN (SignKeyEd25519DSIGN sk) = VerKeyEd25519DSIGN $ toPublic sk
 
-    -- | Ed25519 key size is 32 octets
-    -- (per <https://tools.ietf.org/html/rfc8032#section-5.1.6>)
-    sizeVerKeyDSIGN  _ = 32
-    sizeSignKeyDSIGN _ = 32
-    -- | Ed25519 signature size is 64 octets
-    sizeSigDSIGN     _ = 64
 
     --
     -- Core algorithm operations
@@ -98,9 +89,16 @@ instance DSIGNAlgorithm Ed25519DSIGN where
     -- raw serialise/deserialise
     --
 
-    rawSerialiseVerKeyDSIGN   = convert
-    rawSerialiseSignKeyDSIGN  = convert
-    rawSerialiseSigDSIGN      = convert
+    -- | Ed25519 key size is 32 octets
+    -- (per <https://tools.ietf.org/html/rfc8032#section-5.1.6>)
+    sizeVerKeyDSIGN  _ = 32
+    sizeSignKeyDSIGN _ = 32
+    -- | Ed25519 signature size is 64 octets
+    sizeSigDSIGN     _ = 64
+
+    rawSerialiseVerKeyDSIGN   = BA.convert
+    rawSerialiseSignKeyDSIGN  = BA.convert
+    rawSerialiseSigDSIGN      = BA.convert
 
     rawDeserialiseVerKeyDSIGN  = fmap VerKeyEd25519DSIGN
                                . cryptoFailableToMaybe . Ed25519.publicKey
@@ -109,46 +107,25 @@ instance DSIGNAlgorithm Ed25519DSIGN where
     rawDeserialiseSigDSIGN     = fmap SigEd25519DSIGN
                                . cryptoFailableToMaybe . Ed25519.signature
 
-    --
-    -- CBOR encoding/decoding
-    --
-
-    encodeVerKeyDSIGN = toCBOR
-    encodeSignKeyDSIGN = toCBOR
-    encodeSigDSIGN = toCBOR
-
-    decodeVerKeyDSIGN = fromCBOR
-    decodeSignKeyDSIGN = fromCBOR
-    decodeSigDSIGN = fromCBOR
-
 
 instance ToCBOR (VerKeyDSIGN Ed25519DSIGN) where
-  toCBOR = encodeBA
+  toCBOR = encodeVerKeyDSIGN
 
 instance FromCBOR (VerKeyDSIGN Ed25519DSIGN) where
-  fromCBOR = VerKeyEd25519DSIGN <$> decodeBA publicKey
+  fromCBOR = decodeVerKeyDSIGN
 
 instance ToCBOR (SignKeyDSIGN Ed25519DSIGN) where
-  toCBOR = encodeBA
+  toCBOR = encodeSignKeyDSIGN
 
 instance FromCBOR (SignKeyDSIGN Ed25519DSIGN) where
-  fromCBOR = SignKeyEd25519DSIGN <$> decodeBA secretKey
+  fromCBOR = decodeSignKeyDSIGN
 
 instance ToCBOR (SigDSIGN Ed25519DSIGN) where
-  toCBOR = encodeBA
+  toCBOR = encodeSigDSIGN
 
 instance FromCBOR (SigDSIGN Ed25519DSIGN) where
-  fromCBOR = SigEd25519DSIGN <$> decodeBA signature
+  fromCBOR = decodeSigDSIGN
 
-encodeBA :: ByteArrayAccess ba => ba -> Encoding
-encodeBA ba = let bs = convert ba :: ByteString in toCBOR bs
-
-decodeBA :: forall a s. (ByteString -> CryptoFailable a) -> Decoder s a
-decodeBA f = do
-  bs <- fromCBOR :: Decoder s ByteString
-  case f bs of
-    CryptoPassed a -> return a
-    CryptoFailed e -> fail $ "decodeBA: " ++ show e
 
 cryptoFailableToMaybe :: CryptoFailable a -> Maybe a
 cryptoFailableToMaybe (CryptoPassed a) = Just a

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed448.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed448.hs
@@ -15,22 +15,19 @@ module Cardano.Crypto.DSIGN.Ed448
   )
 where
 
-import Cardano.Binary
-  ( Decoder
-  , Encoding
-  , FromCBOR (..)
-  , ToCBOR (..)
-  , serialize
-  )
-import Cardano.Crypto.DSIGN.Class
-import Cardano.Crypto.Seed
+import Data.ByteString.Lazy (toStrict)
+import Data.ByteArray as BA (ByteArrayAccess, convert)
+import GHC.Generics (Generic)
+
 import Cardano.Prelude (NFData, NoUnexpectedThunks, UseIsNormalForm(..))
+import Cardano.Binary (FromCBOR (..), ToCBOR (..), serialize)
+
 import Crypto.Error (CryptoFailable (..))
 import Crypto.PubKey.Ed448 as Ed448
-import Data.ByteArray (ByteArrayAccess, convert)
-import Data.ByteString (ByteString)
-import Data.ByteString.Lazy (toStrict)
-import GHC.Generics (Generic)
+
+import Cardano.Crypto.DSIGN.Class
+import Cardano.Crypto.Seed
+
 
 data Ed448DSIGN
 
@@ -62,11 +59,6 @@ instance DSIGNAlgorithm Ed448DSIGN where
 
     deriveVerKeyDSIGN (SignKeyEd448DSIGN sk) = VerKeyEd448DSIGN $ toPublic sk
 
-    -- | Goldilocks points are 448 bits long
-    sizeVerKeyDSIGN  _ = 57
-    sizeSignKeyDSIGN _ = 57
-    sizeSigDSIGN     _ = 114
-
 
     --
     -- Core algorithm operations
@@ -97,9 +89,14 @@ instance DSIGNAlgorithm Ed448DSIGN where
     -- raw serialise/deserialise
     --
 
-    rawSerialiseVerKeyDSIGN   = convert
-    rawSerialiseSignKeyDSIGN  = convert
-    rawSerialiseSigDSIGN      = convert
+    -- | Goldilocks points are 448 bits long
+    sizeVerKeyDSIGN  _ = 57
+    sizeSignKeyDSIGN _ = 57
+    sizeSigDSIGN     _ = 114
+
+    rawSerialiseVerKeyDSIGN   = BA.convert
+    rawSerialiseSignKeyDSIGN  = BA.convert
+    rawSerialiseSigDSIGN      = BA.convert
 
     rawDeserialiseVerKeyDSIGN  = fmap VerKeyEd448DSIGN
                                . cryptoFailableToMaybe . Ed448.publicKey
@@ -108,46 +105,24 @@ instance DSIGNAlgorithm Ed448DSIGN where
     rawDeserialiseSigDSIGN     = fmap SigEd448DSIGN
                                . cryptoFailableToMaybe . Ed448.signature
 
-    --
-    -- CBOR encoding/decoding
-    --
-
-    encodeVerKeyDSIGN = toCBOR
-    encodeSignKeyDSIGN = toCBOR
-    encodeSigDSIGN = toCBOR
-
-    decodeVerKeyDSIGN = fromCBOR
-    decodeSignKeyDSIGN = fromCBOR
-    decodeSigDSIGN = fromCBOR
-
 
 instance ToCBOR (VerKeyDSIGN Ed448DSIGN) where
-  toCBOR = encodeBA
+  toCBOR = encodeVerKeyDSIGN
 
 instance FromCBOR (VerKeyDSIGN Ed448DSIGN) where
-  fromCBOR = VerKeyEd448DSIGN <$> decodeBA publicKey
+  fromCBOR = decodeVerKeyDSIGN
 
 instance ToCBOR (SignKeyDSIGN Ed448DSIGN) where
-  toCBOR = encodeBA
+  toCBOR = encodeSignKeyDSIGN
 
 instance FromCBOR (SignKeyDSIGN Ed448DSIGN) where
-  fromCBOR = SignKeyEd448DSIGN <$> decodeBA secretKey
+  fromCBOR = decodeSignKeyDSIGN
 
 instance ToCBOR (SigDSIGN Ed448DSIGN) where
-  toCBOR = encodeBA
+  toCBOR = encodeSigDSIGN
 
 instance FromCBOR (SigDSIGN Ed448DSIGN) where
-  fromCBOR = SigEd448DSIGN <$> decodeBA signature
-
-encodeBA :: ByteArrayAccess ba => ba -> Encoding
-encodeBA ba = let bs = convert ba :: ByteString in toCBOR bs
-
-decodeBA :: forall a s. (ByteString -> CryptoFailable a) -> Decoder s a
-decodeBA f = do
-  bs <- fromCBOR :: Decoder s ByteString
-  case f bs of
-    CryptoPassed a -> return a
-    CryptoFailed e -> fail $ "decodeBA: " ++ show e
+  fromCBOR = decodeSigDSIGN
 
 
 cryptoFailableToMaybe :: CryptoFailable a -> Maybe a

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed448.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed448.hs
@@ -62,9 +62,11 @@ instance DSIGNAlgorithm Ed448DSIGN where
 
     deriveVerKeyDSIGN (SignKeyEd448DSIGN sk) = VerKeyEd448DSIGN $ toPublic sk
 
-    -- | Goldilocks points are 448 bits long, so 64 byte is a good abstract size
-    abstractSizeVKey _ = 64
-    abstractSizeSig  _ = 64
+    -- | Goldilocks points are 448 bits long
+    sizeVerKeyDSIGN  _ = 57
+    sizeSignKeyDSIGN _ = 57
+    sizeSigDSIGN     _ = 114
+
 
     --
     -- Core algorithm operations

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Mock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Mock.hs
@@ -64,7 +64,7 @@ instance DSIGNAlgorithm MockDSIGN where
 
     abstractSizeVKey _ = 8 -- for 64 bit Int
     abstractSizeSig  _ = 1
-                       + (byteCount (Proxy :: Proxy ShortHash))
+                       + fromIntegral (sizeHash (Proxy :: Proxy ShortHash))
                        + 8 -- length tag + length
                            -- short hash + 64 bit
                            -- Int

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/NeverUsed.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/NeverUsed.hs
@@ -12,9 +12,10 @@ where
 
 import GHC.Generics (Generic)
 
-import Cardano.Binary
-import Cardano.Crypto.DSIGN.Class
 import Cardano.Prelude (NoUnexpectedThunks)
+
+import Cardano.Crypto.DSIGN.Class
+
 
 -- | DSIGN never used
 --
@@ -47,11 +48,11 @@ instance DSIGNAlgorithm NeverDSIGN where
   seedSizeDSIGN     _ = 0
   genKeyDSIGN       _ = NeverUsedSignKeyDSIGN
 
-  encodeVerKeyDSIGN  _ = toCBOR ()
-  encodeSignKeyDSIGN _ = toCBOR ()
-  encodeSigDSIGN     _ = toCBOR ()
+  rawSerialiseVerKeyDSIGN  _ = mempty
+  rawSerialiseSignKeyDSIGN _ = mempty
+  rawSerialiseSigDSIGN     _ = mempty
 
-  decodeVerKeyDSIGN  = return NeverUsedVerKeyDSIGN
-  decodeSignKeyDSIGN = return NeverUsedSignKeyDSIGN
-  decodeSigDSIGN     = return NeverUsedSigDSIGN
+  rawDeserialiseVerKeyDSIGN  _ = Just NeverUsedVerKeyDSIGN
+  rawDeserialiseSignKeyDSIGN _ = Just NeverUsedSignKeyDSIGN
+  rawDeserialiseSigDSIGN     _ = Just NeverUsedSigDSIGN
 

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/NeverUsed.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/NeverUsed.hs
@@ -37,8 +37,9 @@ instance DSIGNAlgorithm NeverDSIGN where
 
   deriveVerKeyDSIGN _ = NeverUsedVerKeyDSIGN
 
-  abstractSizeVKey _ = error "abstract size not available"
-  abstractSizeSig  _ = error "abstract size not available"
+  sizeVerKeyDSIGN  _ = 0
+  sizeSignKeyDSIGN _ = 0
+  sizeSigDSIGN     _ = 0
 
   signDSIGN   = error "DSIGN not available"
   verifyDSIGN = error "DSIGN not available"

--- a/cardano-crypto-class/src/Cardano/Crypto/Hash/Blake2b.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Hash/Blake2b.hs
@@ -17,10 +17,10 @@ data Blake2b_256
 
 instance HashAlgorithm Blake2b_224 where
   hashAlgorithmName _ = "blake2b_224"
-  byteCount _ = 28
+  sizeHash _ = 28
   digest _ = BA.convert . H.hash @_ @H.Blake2b_224
 
 instance HashAlgorithm Blake2b_256 where
   hashAlgorithmName _ = "blake2b_256"
-  byteCount _ = 32
+  sizeHash _ = 32
   digest _ = BA.convert . H.hash @_ @H.Blake2b_256

--- a/cardano-crypto-class/src/Cardano/Crypto/Hash/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Hash/Class.hs
@@ -48,6 +48,7 @@ class Typeable h => HashAlgorithm h where
 
   hashAlgorithmName :: proxy h -> String
 
+  -- | The size in bytes of the output of 'digest'
   sizeHash :: proxy h -> Word
 
   byteCount :: proxy h -> Natural

--- a/cardano-crypto-class/src/Cardano/Crypto/Hash/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Hash/Class.hs
@@ -47,9 +47,14 @@ class Typeable h => HashAlgorithm h where
 
   hashAlgorithmName :: proxy h -> String
 
+  sizeHash :: proxy h -> Word
+
   byteCount :: proxy h -> Natural
+  byteCount = fromIntegral . sizeHash
 
   digest :: HasCallStack => proxy h -> ByteString -> ByteString
+
+{-# DEPRECATED byteCount "Use sizeHash" #-}
 
 newtype Hash h a = UnsafeHash {getHash :: ByteString}
   deriving (Eq, Ord, Generic, NFData, NoUnexpectedThunks)

--- a/cardano-crypto-class/src/Cardano/Crypto/Hash/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Hash/Class.hs
@@ -7,6 +7,7 @@ module Cardano.Crypto.Hash.Class
   ( HashAlgorithm (..)
   , ByteString
   , Hash(..)
+  , castHash
   , hash
   , hashRaw
   , hashPair
@@ -78,6 +79,9 @@ instance (HashAlgorithm h, Typeable a) => FromCBOR (Hash h a) where
     if la == le
     then return $ UnsafeHash bs
     else fail $ "expected " ++ show le ++ " byte(s), but got " ++ show la
+
+castHash :: Hash h a -> Hash h b
+castHash (UnsafeHash h) = UnsafeHash h
 
 hash :: forall h a. (HashAlgorithm h, ToCBOR a) => a -> Hash h a
 hash = hashWithSerialiser toCBOR

--- a/cardano-crypto-class/src/Cardano/Crypto/Hash/MD5.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Hash/MD5.hs
@@ -14,7 +14,7 @@ data MD5
 
 instance HashAlgorithm MD5 where
   hashAlgorithmName _ = "md5"
-  byteCount _ = 16
+  sizeHash _ = 16
   digest _ = convert . H.hash
 
 convert :: H.Digest H.MD5 -> ByteString

--- a/cardano-crypto-class/src/Cardano/Crypto/Hash/NeverUsed.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Hash/NeverUsed.hs
@@ -9,5 +9,5 @@ data NeverHash
 
 instance HashAlgorithm NeverHash where
   hashAlgorithmName _ = "never"
-  byteCount _ = 0
+  sizeHash _ = 0
   digest = error "HASH not available"

--- a/cardano-crypto-class/src/Cardano/Crypto/Hash/SHA256.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Hash/SHA256.hs
@@ -14,7 +14,7 @@ data SHA256
 
 instance HashAlgorithm SHA256 where
   hashAlgorithmName _ = "sha256"
-  byteCount _ = 32
+  sizeHash _ = 32
   digest _ = convert . H.hash
 
 convert :: H.Digest H.SHA256 -> ByteString

--- a/cardano-crypto-class/src/Cardano/Crypto/Hash/Short.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Hash/Short.hs
@@ -17,8 +17,8 @@ data ShortHash
 
 instance HashAlgorithm ShortHash where
   hashAlgorithmName _ = "md5_short"
-  byteCount _ = 4
+  sizeHash _ = 4
   digest p =
-    B.take (fromIntegral $ byteCount p) .
+    B.take (fromIntegral (sizeHash p)) .
       BA.convert .
       H.hash @ByteString @H.MD5 -- Internally, treat it like MD5.

--- a/cardano-crypto-class/src/Cardano/Crypto/KES.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES.hs
@@ -8,3 +8,5 @@ import Cardano.Crypto.KES.Class as X
 import Cardano.Crypto.KES.Mock as X
 import Cardano.Crypto.KES.NeverUsed as X
 import Cardano.Crypto.KES.Simple as X
+import Cardano.Crypto.KES.Single as X
+import Cardano.Crypto.KES.Sum as X

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Class.hs
@@ -8,29 +8,43 @@
 
 -- | Abstract key evolving signatures.
 module Cardano.Crypto.KES.Class
-  ( KESAlgorithm (..)
-  , SignedKES (..)
+  (
+    -- * KES algorithm class
+    KESAlgorithm (..)
   , Period
+
+    -- * 'SignedKES' wrapper
+  , SignedKES (..)
   , signedKES
   , verifySignedKES
+
+    -- * CBOR encoding and decoding
+  , encodeVerKeyKES
+  , decodeVerKeyKES
+  , encodeSignKeyKES
+  , decodeSignKeyKES
+  , encodeSigKES
+  , decodeSigKES
   , encodeSignedKES
   , decodeSignedKES
   )
 where
 
-import Cardano.Binary (Decoder, decodeBytes, Encoding, encodeBytes,
-                       serializeEncoding', decodeFullDecoder)
-import Cardano.Crypto.Seed
-import Cardano.Crypto.Util (Empty)
-import Cardano.Crypto.Hash.Class (HashAlgorithm, Hash, hashRaw)
-import Cardano.Prelude (NoUnexpectedThunks)
 import Data.ByteString (ByteString)
-import Data.ByteString.Lazy as LBS (fromStrict)
+import qualified Data.ByteString as BS
 import Data.Kind (Type)
+import Data.Proxy (Proxy(..))
 import Data.Typeable (Typeable)
 import GHC.Exts (Constraint)
 import GHC.Generics (Generic)
 import GHC.Stack
+
+import Cardano.Prelude (NoUnexpectedThunks)
+import Cardano.Binary (Decoder, decodeBytes, Encoding, encodeBytes)
+
+import Cardano.Crypto.Seed
+import Cardano.Crypto.Util (Empty)
+import Cardano.Crypto.Hash.Class (HashAlgorithm, Hash, hashRaw)
 
 
 class ( Typeable v
@@ -65,10 +79,6 @@ class ( Typeable v
 
   hashVerKeyKES :: HashAlgorithm h => VerKeyKES v -> Hash h (VerKeyKES v)
   hashVerKeyKES = hashRaw rawSerialiseVerKeyKES
-
-  sizeVerKeyKES  :: proxy v -> Word
-  sizeSignKeyKES :: proxy v -> Word
-  sizeSigKES     :: proxy v -> Word
 
 
   --
@@ -140,101 +150,79 @@ class ( Typeable v
 
 
   --
-  -- Serialisation/(de)serialisation in raw format, no extra tags
-  --
-  -- default implementations in terms of the CBOR encode/decode
+  -- Serialisation/(de)serialisation in fixed-size raw format
   --
 
-  rawSerialiseVerKeyKES :: VerKeyKES v -> ByteString
-  rawSerialiseVerKeyKES = serializeEncoding' . encodeVerKeyKES
+  sizeVerKeyKES  :: proxy v -> Word
+  sizeSignKeyKES :: proxy v -> Word
+  sizeSigKES     :: proxy v -> Word
 
-  rawSerialiseSignKeyKES :: SignKeyKES v -> ByteString
-  rawSerialiseSignKeyKES = serializeEncoding' . encodeSignKeyKES
+  rawSerialiseVerKeyKES    :: VerKeyKES  v -> ByteString
+  rawSerialiseSignKeyKES   :: SignKeyKES v -> ByteString
+  rawSerialiseSigKES       :: SigKES     v -> ByteString
 
-  rawSerialiseSigKES :: SigKES v -> ByteString
-  rawSerialiseSigKES = serializeEncoding' . encodeSigKES
-
-  rawDeserialiseVerKeyKES :: ByteString -> Maybe (VerKeyKES v)
-  rawDeserialiseVerKeyKES =
-      either (const Nothing) Just
-    . decodeFullDecoder
-        "rawDeserialiseVerKeyKES"
-        decodeVerKeyKES
-    . LBS.fromStrict
-
+  rawDeserialiseVerKeyKES  :: ByteString -> Maybe (VerKeyKES v)
   rawDeserialiseSignKeyKES :: ByteString -> Maybe (SignKeyKES v)
-  rawDeserialiseSignKeyKES =
-      either (const Nothing) Just
-    . decodeFullDecoder
-        "rawDeserialiseVerKeyKES"
-        decodeSignKeyKES
-    . LBS.fromStrict
-
-  rawDeserialiseSigKES :: ByteString -> Maybe (SigKES v)
-  rawDeserialiseSigKES =
-      either (const Nothing) Just
-    . decodeFullDecoder
-        "rawDeserialiseVerKeyKES"
-        decodeSigKES
-    . LBS.fromStrict
+  rawDeserialiseSigKES     :: ByteString -> Maybe (SigKES v)
 
 
-  --
-  -- Convenient CBOR encoding/decoding
-  --
-  -- default implementations in terms of the raw (de)serialise
-  --
+--
+-- Convenient CBOR encoding/decoding
+--
+-- Implementations in terms of the raw (de)serialise
+--
 
-  encodeVerKeyKES :: VerKeyKES v -> Encoding
-  encodeVerKeyKES = encodeBytes . rawSerialiseVerKeyKES
+encodeVerKeyKES :: KESAlgorithm v => VerKeyKES v -> Encoding
+encodeVerKeyKES = encodeBytes . rawSerialiseVerKeyKES
 
-  encodeSignKeyKES :: SignKeyKES v -> Encoding
-  encodeSignKeyKES = encodeBytes . rawSerialiseSignKeyKES
+encodeSignKeyKES :: KESAlgorithm v => SignKeyKES v -> Encoding
+encodeSignKeyKES = encodeBytes . rawSerialiseSignKeyKES
 
-  encodeSigKES :: SigKES v -> Encoding
-  encodeSigKES = encodeBytes . rawSerialiseSigKES
+encodeSigKES :: KESAlgorithm v => SigKES v -> Encoding
+encodeSigKES = encodeBytes . rawSerialiseSigKES
 
-  decodeVerKeyKES :: Decoder s (VerKeyKES v)
-  decodeVerKeyKES = do
+decodeVerKeyKES :: forall v s. KESAlgorithm v => Decoder s (VerKeyKES v)
+decodeVerKeyKES = do
     bs <- decodeBytes
     case rawDeserialiseVerKeyKES bs of
-      Nothing -> fail "decodeVerKeyKES: cannot decode key"
       Just vk -> return vk
+      Nothing
+        | actual /= expected
+                    -> fail ("decodeVerKeyKES: wrong length, expected " ++
+                             show expected ++ " bytes but got " ++ show actual)
+        | otherwise -> fail "decodeVerKeyKES: cannot decode key"
+        where
+          expected = fromIntegral (sizeVerKeyKES (Proxy :: Proxy v))
+          actual   = BS.length bs
 
-  decodeSignKeyKES :: Decoder s (SignKeyKES v)
-  decodeSignKeyKES = do
+decodeSignKeyKES :: forall v s. KESAlgorithm v => Decoder s (SignKeyKES v)
+decodeSignKeyKES = do
     bs <- decodeBytes
     case rawDeserialiseSignKeyKES bs of
-      Nothing -> fail "decodeSignKeyKES: cannot decode key"
-      Just vk -> return vk
+      Just sk -> return sk
+      Nothing
+        | actual /= expected
+                    -> fail ("decodeSignKeyKES: wrong length, expected " ++
+                             show expected ++ " bytes but got " ++ show actual)
+        | otherwise -> fail "decodeSignKeyKES: cannot decode key"
+        where
+          expected = fromIntegral (sizeSignKeyKES (Proxy :: Proxy v))
+          actual   = BS.length bs
 
-  decodeSigKES :: Decoder s (SigKES v)
-  decodeSigKES = do
+decodeSigKES :: forall v s. KESAlgorithm v => Decoder s (SigKES v)
+decodeSigKES = do
     bs <- decodeBytes
     case rawDeserialiseSigKES bs of
-      Nothing -> fail "decodeSigKES: cannot decode key"
-      Just vk -> return vk
+      Just sig -> return sig
+      Nothing
+        | actual /= expected
+                    -> fail ("decodeSigKES: wrong length, expected " ++
+                             show expected ++ " bytes but got " ++ show actual)
+        | otherwise -> fail "decodeSigKES: cannot decode key"
+        where
+          expected = fromIntegral (sizeSigKES (Proxy :: Proxy v))
+          actual   = BS.length bs
 
-
-  {-# MINIMAL
-        algorithmNameKES
-      , deriveVerKeyKES
-      , sizeVerKeyKES
-      , sizeSignKeyKES
-      , sizeSigKES
-      , signKES
-      , verifyKES
-      , updateKES
-      , totalPeriodsKES
-      , genKeyKES
-      , seedSizeKES
-      , (rawSerialiseVerKeyKES    | encodeVerKeyKES)
-      , (rawSerialiseSignKeyKES   | encodeSignKeyKES)
-      , (rawSerialiseSigKES       | encodeSigKES)
-      , (rawDeserialiseVerKeyKES  | decodeVerKeyKES)
-      , (rawDeserialiseSignKeyKES | decodeSignKeyKES)
-      , (rawDeserialiseSigKES     | decodeSigKES)
-    #-}
 
 -- | The KES period. The KES evolution index.
 --

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Class.hs
@@ -31,7 +31,6 @@ import Data.Typeable (Typeable)
 import GHC.Exts (Constraint)
 import GHC.Generics (Generic)
 import GHC.Stack
-import Numeric.Natural (Natural)
 
 
 class ( Typeable v
@@ -125,7 +124,7 @@ class ( Typeable v
   genKeyKES :: Seed -> SignKeyKES v
 
   -- | The upper bound on the 'Seed' size needed by 'genKeyKES'
-  seedSizeKES :: proxy v -> Natural
+  seedSizeKES :: proxy v -> Word
 
 
   --
@@ -224,7 +223,7 @@ class ( Typeable v
 
 -- | The KES period. The KES evolution index.
 --
-type Period = Natural
+type Period = Word
 
 newtype SignedKES v a = SignedKES {getSig :: SigKES v}
   deriving Generic

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Class.hs
@@ -66,6 +66,10 @@ class ( Typeable v
   hashVerKeyKES :: HashAlgorithm h => VerKeyKES v -> Hash h (VerKeyKES v)
   hashVerKeyKES = hashRaw rawSerialiseVerKeyKES
 
+  sizeVerKeyKES  :: proxy v -> Word
+  sizeSignKeyKES :: proxy v -> Word
+  sizeSigKES     :: proxy v -> Word
+
 
   --
   -- Core algorithm operations
@@ -207,6 +211,9 @@ class ( Typeable v
   {-# MINIMAL
         algorithmNameKES
       , deriveVerKeyKES
+      , sizeVerKeyKES
+      , sizeSignKeyKES
+      , sizeSigKES
       , signKES
       , verifyKES
       , updateKES

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Class.hs
@@ -10,6 +10,7 @@
 module Cardano.Crypto.KES.Class
   ( KESAlgorithm (..)
   , SignedKES (..)
+  , Period
   , signedKES
   , verifySignedKES
   , encodeSignedKES
@@ -83,7 +84,7 @@ class ( Typeable v
   signKES
     :: (Signable v a, HasCallStack)
     => ContextKES v
-    -> Natural
+    -> Period
     -> a
     -> SignKeyKES v
     -> Maybe (SigKES v)
@@ -92,7 +93,7 @@ class ( Typeable v
     :: (Signable v a, HasCallStack)
     => ContextKES v
     -> VerKeyKES v
-    -> Natural
+    -> Period
     -> a
     -> SigKES v
     -> Either String ()
@@ -109,12 +110,12 @@ class ( Typeable v
     :: HasCallStack
     => ContextKES v
     -> SignKeyKES v
-    -> Natural
+    -> Period
     -> Maybe (SignKeyKES v)
 
   -- | Return the current KES period of a KES signing key.
   totalPeriodsKES
-    :: proxy v -> Natural
+    :: proxy v -> Period
 
 
   --
@@ -221,6 +222,9 @@ class ( Typeable v
       , (rawDeserialiseSigKES     | decodeSigKES)
     #-}
 
+-- | The KES period. The KES evolution index.
+--
+type Period = Natural
 
 newtype SignedKES v a = SignedKES {getSig :: SigKES v}
   deriving Generic
@@ -234,7 +238,7 @@ instance KESAlgorithm v => NoUnexpectedThunks (SignedKES v a)
 signedKES
   :: (KESAlgorithm v, Signable v a)
   => ContextKES v
-  -> Natural
+  -> Period
   -> a
   -> SignKeyKES v
   -> Maybe (SignedKES v a)
@@ -244,7 +248,7 @@ verifySignedKES
   :: (KESAlgorithm v, Signable v a)
   => ContextKES v
   -> VerKeyKES v
-  -> Natural
+  -> Period
   -> a
   -> SignedKES v a
   -> Either String ()

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Class.hs
@@ -87,7 +87,7 @@ class ( Typeable v
     -> Period
     -> a
     -> SignKeyKES v
-    -> Maybe (SigKES v)
+    -> SigKES v
 
   verifyKES
     :: (Signable v a, HasCallStack)
@@ -241,8 +241,8 @@ signedKES
   -> Period
   -> a
   -> SignKeyKES v
-  -> Maybe (SignedKES v a)
-signedKES ctxt time a key = SignedKES <$> signKES ctxt time a key
+  -> SignedKES v a
+signedKES ctxt time a key = SignedKES (signKES ctxt time a key)
 
 verifySignedKES
   :: (KESAlgorithm v, Signable v a)

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Class.hs
@@ -113,13 +113,6 @@ class ( Typeable v
     -> Maybe (SignKeyKES v)
 
   -- | Return the current KES period of a KES signing key.
-  currentPeriodKES
-    :: HasCallStack
-    => ContextKES v
-    -> SignKeyKES v
-    -> Natural
-
-  -- | Return the current KES period of a KES signing key.
   totalPeriodsKES
     :: proxy v -> Natural
 
@@ -217,7 +210,6 @@ class ( Typeable v
       , signKES
       , verifyKES
       , updateKES
-      , currentPeriodKES
       , totalPeriodsKES
       , genKeyKES
       , seedSizeKES

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Class.hs
@@ -87,7 +87,7 @@ class ( Typeable v
   signKES
     :: (Signable v a, HasCallStack)
     => ContextKES v
-    -> Period
+    -> Period  -- ^ The /current/ period for the key
     -> a
     -> SignKeyKES v
     -> SigKES v
@@ -96,24 +96,32 @@ class ( Typeable v
     :: (Signable v a, HasCallStack)
     => ContextKES v
     -> VerKeyKES v
-    -> Period
+    -> Period  -- ^ The /current/ period for the key
     -> a
     -> SigKES v
     -> Either String ()
 
-  -- | Update the KES signature key to the specified period. The intended
-  -- behavior is to return `Nothing` in the case that the key cannot be evolved
-  -- that far.
+  -- | Update the KES signature key to the /next/ period, given the /current/
+  -- period.
   --
-  -- The precondition is that the current KES period of the input key is before
-  -- the target period.
-  -- The postcondition is that in case a key is returned, its current KES period
-  -- corresponds to the target KES period.
+  -- It returns 'Nothing' if the cannot be evolved any further.
+  --
+  -- The precondition (to get a 'Just' result) is that the current KES period
+  -- of the input key is not the last period. The given period must be the
+  -- current KES period of the input key (not the next or target).
+  --
+  -- The postcondition is that in case a key is returned, its current KES
+  -- period is incremented by one compared to before.
+  --
+  -- Note that you must track the current period separately, and to skip to a
+  -- later period requires repeated use of this function, since it only
+  -- increments one period at once.
+  --
   updateKES
     :: HasCallStack
     => ContextKES v
     -> SignKeyKES v
-    -> Period
+    -> Period  -- ^ The /current/ period for the key, not the target period.
     -> Maybe (SignKeyKES v)
 
   -- | Return the current KES period of a KES signing key.

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Mock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Mock.hs
@@ -89,10 +89,10 @@ instance KnownNat t => KESAlgorithm (MockKES t) where
     signKES () j a (SignKeyMockKES vk k)
         | j == k
         , j  < totalPeriodsKES (Proxy @ (MockKES t))
-        = Just (SigMockKES (fromHash $ hash @H a) (SignKeyMockKES vk j))
+        = SigMockKES (fromHash $ hash @H a) (SignKeyMockKES vk j)
 
         | otherwise
-        = Nothing
+        = error ("MockKES.signKES: wrong period " ++ show j)
 
     verifyKES () vk j a (SigMockKES h (SignKeyMockKES vk' j')) =
         if    j  == j'

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Mock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Mock.hs
@@ -101,7 +101,6 @@ instance KnownNat t => KESAlgorithm (MockKES t) where
           then Right ()
           else Left "KES verification failed"
 
-    currentPeriodKES () (SignKeyMockKES _ k) = k
     totalPeriodsKES  _ = natVal (Proxy @ t)
 
     --

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Mock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Mock.hs
@@ -55,7 +55,7 @@ instance KnownNat t => KESAlgorithm (MockKES t) where
         deriving newtype (NoUnexpectedThunks, ToCBOR, FromCBOR)
 
     data SignKeyKES (MockKES t) =
-           SignKeyMockKES !(VerKeyKES (MockKES t)) !Natural
+           SignKeyMockKES !(VerKeyKES (MockKES t)) !Word
         deriving stock    (Show, Eq, Ord, Generic)
         deriving anyclass (NoUnexpectedThunks)
 
@@ -101,7 +101,7 @@ instance KnownNat t => KESAlgorithm (MockKES t) where
           then Right ()
           else Left "KES verification failed"
 
-    totalPeriodsKES  _ = natVal (Proxy @ t)
+    totalPeriodsKES  _ = fromIntegral (natVal (Proxy @ t))
 
     --
     -- Key generation

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/NeverUsed.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/NeverUsed.hs
@@ -12,9 +12,9 @@ where
 
 import GHC.Generics (Generic)
 
-import Cardano.Binary (toCBOR)
 import Cardano.Crypto.KES.Class
 import Cardano.Prelude (NoUnexpectedThunks)
+
 
 -- | KES never used
 --
@@ -37,10 +37,6 @@ instance KESAlgorithm NeverKES where
 
   deriveVerKeyKES _ = NeverUsedVerKeyKES
 
-  sizeVerKeyKES  _ = 0
-  sizeSignKeyKES _ = 0
-  sizeSigKES     _ = 0
-
   signKES   = error "KES not available"
   verifyKES = error "KES not available"
   updateKES = error "KES not available"
@@ -50,10 +46,15 @@ instance KESAlgorithm NeverKES where
   seedSizeKES     _ = 0
   genKeyKES       _ = NeverUsedSignKeyKES
 
-  encodeVerKeyKES  _ = toCBOR ()
-  encodeSignKeyKES _ = toCBOR ()
-  encodeSigKES     _ = toCBOR ()
+  sizeVerKeyKES  _ = 0
+  sizeSignKeyKES _ = 0
+  sizeSigKES     _ = 0
 
-  decodeVerKeyKES  = return NeverUsedVerKeyKES
-  decodeSignKeyKES = return NeverUsedSignKeyKES
-  decodeSigKES     = return NeverUsedSigKES
+  rawSerialiseVerKeyKES  _ = mempty
+  rawSerialiseSignKeyKES _ = mempty
+  rawSerialiseSigKES     _ = mempty
+
+  rawDeserialiseVerKeyKES  _ = Just NeverUsedVerKeyKES
+  rawDeserialiseSignKeyKES _ = Just NeverUsedSignKeyKES
+  rawDeserialiseSigKES     _ = Just NeverUsedSigKES
+

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/NeverUsed.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/NeverUsed.hs
@@ -41,7 +41,6 @@ instance KESAlgorithm NeverKES where
   verifyKES = error "KES not available"
   updateKES = error "KES not available"
 
-  currentPeriodKES  = error "KES not available"
   totalPeriodsKES _ = 0
 
   seedSizeKES     _ = 0

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/NeverUsed.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/NeverUsed.hs
@@ -37,6 +37,10 @@ instance KESAlgorithm NeverKES where
 
   deriveVerKeyKES _ = NeverUsedVerKeyKES
 
+  sizeVerKeyKES  _ = 0
+  sizeSignKeyKES _ = 0
+  sizeSigKES     _ = 0
+
   signKES   = error "KES not available"
   verifyKES = error "KES not available"
   updateKES = error "KES not available"

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Simple.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Simple.hs
@@ -79,8 +79,8 @@ instance (DSIGNAlgorithm d, Typeable d, KnownNat t) =>
 
     signKES ctxt j a (SignKeySimpleKES sks) =
         case sks !? fromIntegral j of
-          Nothing -> Nothing
-          Just sk -> Just $ SigSimpleKES (signDSIGN ctxt a sk)
+          Nothing -> error ("SimpleKES.signKES: period out of range " ++ show j)
+          Just sk -> SigSimpleKES (signDSIGN ctxt a sk)
 
     verifyKES ctxt (VerKeySimpleKES vks) j a (SigSimpleKES sig) =
         case vks !? fromIntegral j of

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Simple.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Simple.hs
@@ -91,8 +91,6 @@ instance (DSIGNAlgorithm d, Typeable d, KnownNat t) =>
       | to >= natVal (Proxy @ t) = Nothing
       | otherwise                = Just sk
 
-    currentPeriodKES _ _ = error "TODO: remove currentPeriodKES"
-
     totalPeriodsKES  _ = natVal (Proxy @ t)
 
 

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Simple.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Simple.hs
@@ -100,9 +100,9 @@ instance (DSIGNAlgorithm d, Typeable d, KnownNat t) =>
           Nothing -> Left "KES verification failed: out of range"
           Just vk -> verifyDSIGN ctxt vk a sig
 
-    updateKES _ sk to
-      | to >= fromIntegral (natVal (Proxy @ t)) = Nothing
-      | otherwise                               = Just sk
+    updateKES _ sk t
+      | t+1 < fromIntegral (natVal (Proxy @ t)) = Just sk
+      | otherwise                               = Nothing
 
     totalPeriodsKES  _ = fromIntegral (natVal (Proxy @ t))
 

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Simple.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Simple.hs
@@ -88,10 +88,10 @@ instance (DSIGNAlgorithm d, Typeable d, KnownNat t) =>
           Just vk -> verifyDSIGN ctxt vk a sig
 
     updateKES _ sk to
-      | to >= natVal (Proxy @ t) = Nothing
-      | otherwise                = Just sk
+      | to >= fromIntegral (natVal (Proxy @ t)) = Nothing
+      | otherwise                               = Just sk
 
-    totalPeriodsKES  _ = natVal (Proxy @ t)
+    totalPeriodsKES  _ = fromIntegral (natVal (Proxy @ t))
 
 
     --
@@ -100,13 +100,13 @@ instance (DSIGNAlgorithm d, Typeable d, KnownNat t) =>
 
     seedSizeKES _ =
         let seedSize = seedSizeDSIGN (Proxy :: Proxy d)
-            duration = natVal (Proxy @ t)
+            duration = fromIntegral (natVal (Proxy @ t))
          in duration * seedSize
 
     genKeyKES seed =
-        let seedSize = fromIntegral (seedSizeDSIGN (Proxy :: Proxy d))
-            duration = natVal (Proxy @ t)
-            seeds    = take (fromIntegral duration)
+        let seedSize = seedSizeDSIGN (Proxy :: Proxy d)
+            duration = fromIntegral (natVal (Proxy @ t))
+            seeds    = take duration
                      . map mkSeedFromBytes
                      $ unfoldr (getBytesFromSeed seedSize) seed
             sks      = map genKeyDSIGN seeds

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Single.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Single.hs
@@ -75,7 +75,7 @@ instance (DSIGNAlgorithm d, Typeable d) => KESAlgorithm (SingleKES d) where
     -- Metadata and basic key operations
     --
 
-    algorithmNameKES _ = algorithmNameDSIGN (Proxy :: Proxy d)
+    algorithmNameKES _ = algorithmNameDSIGN (Proxy :: Proxy d) ++ "_kes_2^0"
 
     deriveVerKeyKES (SignKeySingleKES sk) =
         VerKeySingleKES (deriveVerKeyDSIGN sk)

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Single.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Single.hs
@@ -1,0 +1,176 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | A standard signature scheme is a forward-secure signature scheme with a
+-- single time period.
+--
+-- This is the base case in the naive recursive implementation of the sum
+-- composition from section 3 of the \"MMM\" paper:
+--
+-- /Composition and Efficiency Tradeoffs for Forward-Secure Digital Signatures/
+-- By Tal Malkin, Daniele Micciancio and Sara Miner
+-- <https://eprint.iacr.org/2001/034>
+--
+-- Specfically it states:
+--
+-- > In order to unify the presentation, we regard standard signature schemes
+-- > as forward-seure signature schemes with one time period, namely T = 1.
+--
+-- So this module simply provides a wrapper 'SingleKES' that turns any
+-- 'DSIGNAlgorithm' into an instance of 'KESAlgorithm' with a single period.
+--
+-- See "Cardano.Crypto.KES.Sum" for the composition case.
+--
+module Cardano.Crypto.KES.Single (
+    SingleKES
+  , VerKeyKES (..)
+  , SignKeyKES (..)
+  , SigKES (..)
+  ) where
+
+import Data.Proxy (Proxy(..))
+import Data.Typeable (Typeable)
+import GHC.Generics (Generic)
+
+import Control.Exception (assert)
+
+import Cardano.Prelude (NoUnexpectedThunks)
+import Cardano.Binary (FromCBOR (..), ToCBOR (..))
+
+import Cardano.Crypto.Hash.Class
+import Cardano.Crypto.DSIGN.Class
+import qualified Cardano.Crypto.DSIGN as DSIGN
+import Cardano.Crypto.KES.Class
+
+
+-- | A standard signature scheme is a forward-secure signature scheme with a
+-- single time period.
+--
+data SingleKES d
+
+instance (DSIGNAlgorithm d, Typeable d) => KESAlgorithm (SingleKES d) where
+
+
+    --
+    -- Key and signature types
+    --
+
+    newtype VerKeyKES (SingleKES d) = VerKeySingleKES (VerKeyDSIGN d)
+        deriving Generic
+
+    newtype SignKeyKES (SingleKES d) = SignKeySingleKES (SignKeyDSIGN d)
+        deriving Generic
+
+    newtype SigKES (SingleKES d) = SigSingleKES (SigDSIGN d)
+        deriving Generic
+
+
+    --
+    -- Metadata and basic key operations
+    --
+
+    algorithmNameKES _ = algorithmNameDSIGN (Proxy :: Proxy d)
+
+    deriveVerKeyKES (SignKeySingleKES sk) =
+        VerKeySingleKES (deriveVerKeyDSIGN sk)
+
+    hashVerKeyKES (VerKeySingleKES vk) =
+        castHash (hashVerKeyDSIGN vk)
+
+
+    --
+    -- Core algorithm operations
+    --
+
+    type ContextKES (SingleKES d) = DSIGN.ContextDSIGN d
+    type Signable   (SingleKES d) = DSIGN.Signable     d
+
+    signKES ctxt t a (SignKeySingleKES sk) =
+        assert (t == 0) $
+        SigSingleKES (signDSIGN ctxt a sk)
+
+    verifyKES ctxt (VerKeySingleKES vk) t a (SigSingleKES sig) =
+        assert (t == 0) $
+        verifyDSIGN ctxt vk a sig
+
+    updateKES _ctx (SignKeySingleKES _sk) _to = Nothing
+
+    totalPeriodsKES  _ = 1
+
+    --
+    -- Key generation
+    --
+
+    seedSizeKES _ = seedSizeDSIGN (Proxy :: Proxy d)
+    genKeyKES seed = SignKeySingleKES (genKeyDSIGN seed)
+
+
+    --
+    -- raw serialise/deserialise
+    --
+
+    sizeVerKeyKES  _ = sizeVerKeyDSIGN  (Proxy :: Proxy d)
+    sizeSignKeyKES _ = sizeSignKeyDSIGN (Proxy :: Proxy d)
+    sizeSigKES     _ = sizeSigDSIGN     (Proxy :: Proxy d)
+
+    rawSerialiseVerKeyKES  (VerKeySingleKES  vk) = rawSerialiseVerKeyDSIGN vk
+    rawSerialiseSignKeyKES (SignKeySingleKES sk) = rawSerialiseSignKeyDSIGN sk
+    rawSerialiseSigKES     (SigSingleKES    sig) = rawSerialiseSigDSIGN sig
+
+    rawDeserialiseVerKeyKES  = fmap VerKeySingleKES  . rawDeserialiseVerKeyDSIGN
+    rawDeserialiseSignKeyKES = fmap SignKeySingleKES . rawDeserialiseSignKeyDSIGN
+    rawDeserialiseSigKES     = fmap SigSingleKES     . rawDeserialiseSigDSIGN
+
+
+--
+-- VerKey instances
+--
+
+deriving instance DSIGNAlgorithm d => Show (VerKeyKES (SingleKES d))
+deriving instance DSIGNAlgorithm d => Eq   (VerKeyKES (SingleKES d))
+
+instance DSIGNAlgorithm d => NoUnexpectedThunks (SignKeyKES (SingleKES d))
+
+instance DSIGNAlgorithm d => ToCBOR (VerKeyKES (SingleKES d)) where
+  toCBOR = encodeVerKeyKES
+
+instance DSIGNAlgorithm d => FromCBOR (VerKeyKES (SingleKES d)) where
+  fromCBOR = decodeVerKeyKES
+
+
+--
+-- SignKey instances
+--
+
+deriving instance DSIGNAlgorithm d => Show (SignKeyKES (SingleKES d))
+
+instance DSIGNAlgorithm d => NoUnexpectedThunks (VerKeyKES  (SingleKES d))
+
+instance DSIGNAlgorithm d => ToCBOR (SignKeyKES (SingleKES d)) where
+  toCBOR = encodeSignKeyKES
+
+instance DSIGNAlgorithm d => FromCBOR (SignKeyKES (SingleKES d)) where
+  fromCBOR = decodeSignKeyKES
+
+
+--
+-- Sig instances
+--
+
+deriving instance DSIGNAlgorithm d => Show (SigKES (SingleKES d))
+deriving instance DSIGNAlgorithm d => Eq   (SigKES (SingleKES d))
+
+instance DSIGNAlgorithm d => NoUnexpectedThunks (SigKES (SingleKES d))
+
+instance DSIGNAlgorithm d => ToCBOR (SigKES (SingleKES d)) where
+  toCBOR = encodeSigKES
+
+instance DSIGNAlgorithm d => FromCBOR (SigKES (SingleKES d)) where
+  fromCBOR = decodeSigKES
+

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Sum.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Sum.hs
@@ -1,0 +1,337 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | A key evolving signatures implementation.
+--
+-- It is a naive recursive implementation of the sum composition from
+-- section 3.1 of the \"MMM\" paper:
+--
+-- /Composition and Efficiency Tradeoffs for Forward-Secure Digital Signatures/
+-- By Tal Malkin, Daniele Micciancio and Sara Miner
+-- <https://eprint.iacr.org/2001/034>
+--
+-- Specfically we do the binary sum composition directly as in the paper, and
+-- then use that in a nested\/recursive fashion to construct a 7-level deep
+-- binary tree version.
+--
+-- This relies on "Cardano.Crypto.KES.Single" for the base case.
+--
+module Cardano.Crypto.KES.Sum (
+    SumKES
+  , VerKeyKES (..)
+  , SignKeyKES (..)
+  , SigKES (..)
+
+    -- * Type aliases for powers of binary sums
+  , Sum0KES
+  , Sum1KES
+  , Sum2KES
+  , Sum3KES
+  , Sum4KES
+  , Sum5KES
+  , Sum6KES
+  , Sum7KES
+  ) where
+
+import           Data.Word (Word8)
+import           Data.Proxy (Proxy(..))
+import           Data.Typeable (Typeable)
+import           GHC.Generics (Generic)
+import qualified Data.ByteString as BS
+import           Control.Monad (guard)
+
+import           Cardano.Prelude (NoUnexpectedThunks)
+import           Cardano.Binary (FromCBOR (..), ToCBOR (..))
+
+import           Cardano.Crypto.Seed
+import           Cardano.Crypto.Hash.Class
+import           Cardano.Crypto.KES.Class
+import           Cardano.Crypto.KES.Single (SingleKES)
+
+
+-- | A 2^0 period KES
+type Sum0KES d   = SingleKES d
+
+-- | A 2^1 period KES
+type Sum1KES d h = SumKES h (Sum0KES d)
+
+-- | A 2^2 period KES
+type Sum2KES d h = SumKES h (Sum1KES d h)
+
+-- | A 2^3 period KES
+type Sum3KES d h = SumKES h (Sum2KES d h)
+
+-- | A 2^4 period KES
+type Sum4KES d h = SumKES h (Sum3KES d h)
+
+-- | A 2^5 period KES
+type Sum5KES d h = SumKES h (Sum4KES d h)
+
+-- | A 2^6 period KES
+type Sum6KES d h = SumKES h (Sum5KES d h)
+
+-- | A 2^7 period KES
+type Sum7KES d h = SumKES h (Sum6KES d h)
+
+
+-- | A composition of two KES schemes to give a KES scheme with the sum of
+-- the time periods.
+--
+-- While we could do this with two independent KES schemes (i.e. two types)
+-- we only need it for two instances of the same scheme, and we save
+-- substantially on the size of the type and runtime dictionaries if we do it
+-- this way, especially when we start applying it recursively.
+--
+data SumKES h d
+
+instance (KESAlgorithm d, HashAlgorithm h, Typeable d)
+      => KESAlgorithm (SumKES h d) where
+
+
+    --
+    -- Key and signature types
+    --
+
+    -- | From Section 3,1:
+    --
+    -- The verification key @vk@ for the sum scheme is the hash of the
+    -- verification keys @vk_0, vk_1@ of the two constituent schemes.
+    --
+    newtype VerKeyKES (SumKES h d) =
+              VerKeySumKES (Hash h (VerKeyKES d, VerKeyKES d))
+        deriving Generic
+
+    -- | From Figure 3: @(sk_0, r_1, vk_0, vk_1)@
+    --
+    data SignKeyKES (SumKES h d) =
+           SignKeySumKES !(SignKeyKES d)
+                         !Seed
+                         !(VerKeyKES d)
+                         !(VerKeyKES d)
+        deriving Generic
+
+    -- | From Figure 3: @(sigma, vk_0, vk_1)@
+    --
+    data SigKES (SumKES h d) =
+           SigSumKES !(SigKES d)
+                     !(VerKeyKES d)
+                     !(VerKeyKES d)
+        deriving Generic
+
+
+    --
+    -- Metadata and basic key operations
+    --
+
+    algorithmNameKES _ = algorithmNameKES (Proxy :: Proxy d) ++ "x2"
+
+    deriveVerKeyKES (SignKeySumKES _ _ vk_0 vk_1) =
+        VerKeySumKES (hashPairOfVKeys (vk_0, vk_1))
+
+    -- The verification key in this scheme is actually a hash already
+    -- But the hashVerKeyKES 
+    hashVerKeyKES (VerKeySumKES vk) = castHash (hashRaw getHash vk)
+
+
+    --
+    -- Core algorithm operations
+    --
+
+    type Signable   (SumKES h d) = Signable   d
+    type ContextKES (SumKES h d) = ContextKES d
+
+    signKES ctxt t a (SignKeySumKES sk _r_1 vk_0 vk_1) =
+        SigSumKES sigma vk_0 vk_1
+      where
+        sigma | t < _T    = signKES ctxt  t       a sk
+              | otherwise = signKES ctxt (t - _T) a sk
+
+        _T = totalPeriodsKES (Proxy :: Proxy d)
+
+    verifyKES ctxt (VerKeySumKES vk) t a (SigSumKES sigma vk_0 vk_1)
+      | hashPairOfVKeys (vk_0, vk_1) /= vk
+                  = Left "Reject"
+      | t < _T    = verifyKES ctxt vk_0  t       a sigma
+      | otherwise = verifyKES ctxt vk_1 (t - _T) a sigma
+      where
+        _T = totalPeriodsKES (Proxy :: Proxy d)
+
+    updateKES ctx (SignKeySumKES sk r_1 vk_0 vk_1) t
+      | t+1 <  _T = do sk' <- updateKES ctx sk t
+                       return $ SignKeySumKES sk' r_1 vk_0 vk_1
+      | t+1 == _T = do let sk' = genKeyKES r_1
+                       return $ SignKeySumKES sk' zero vk_0 vk_1
+      | otherwise = do sk' <- updateKES ctx sk (t - _T)
+                       return $ SignKeySumKES sk' r_1 vk_0 vk_1
+      where
+        _T = totalPeriodsKES (Proxy :: Proxy d)
+        zero = zeroSeed (Proxy :: Proxy d)
+
+    totalPeriodsKES  _ = 2 * totalPeriodsKES (Proxy :: Proxy d)
+
+
+    --
+    -- Key generation
+    --
+
+    seedSizeKES _ = seedSizeKES (Proxy :: Proxy d)
+    genKeyKES r = SignKeySumKES sk_0 r1 vk_0 vk_1
+      where
+        (r0, r1) = expandSeed (Proxy :: Proxy h) r
+
+        sk_0 = genKeyKES r0
+        vk_0 = deriveVerKeyKES sk_0
+
+        sk_1 = genKeyKES r1
+        vk_1 = deriveVerKeyKES sk_1
+
+
+    --
+    -- raw serialise/deserialise
+    --
+
+    sizeVerKeyKES  _ = sizeHash       (Proxy :: Proxy h)
+    sizeSignKeyKES _ = sizeSignKeyKES (Proxy :: Proxy d)
+                     + seedSizeKES    (Proxy :: Proxy d)
+                     + sizeVerKeyKES  (Proxy :: Proxy d) * 2
+    sizeSigKES     _ = sizeSigKES     (Proxy :: Proxy d)
+                     + sizeVerKeyKES  (Proxy :: Proxy d) * 2
+
+    rawSerialiseVerKeyKES  (VerKeySumKES  vk) = getHash vk
+
+    rawSerialiseSignKeyKES (SignKeySumKES sk r_1 vk_0 vk_1) =
+      mconcat
+        [ rawSerialiseSignKeyKES sk
+        , getSeedBytes r_1
+        , rawSerialiseVerKeyKES vk_0
+        , rawSerialiseVerKeyKES vk_1
+        ]
+
+    rawSerialiseSigKES (SigSumKES sigma vk_0 vk_1) =
+      mconcat
+        [ rawSerialiseSigKES sigma
+        , rawSerialiseVerKeyKES vk_0
+        , rawSerialiseVerKeyKES vk_1
+        ]
+
+    rawDeserialiseVerKeyKES = fmap VerKeySumKES  . hashFromBytes
+
+    rawDeserialiseSignKeyKES b = do
+        guard (BS.length b == fromIntegral size_total)
+        sk   <- rawDeserialiseSignKeyKES b_sk
+        let r = mkSeedFromBytes          b_r
+        vk_0 <- rawDeserialiseVerKeyKES  b_vk0
+        vk_1 <- rawDeserialiseVerKeyKES  b_vk1
+        return (SignKeySumKES sk r vk_0 vk_1)
+      where
+        b_sk  = slice off_sk  size_sk b
+        b_r   = slice off_r   size_r  b
+        b_vk0 = slice off_vk0 size_vk b
+        b_vk1 = slice off_vk1 size_vk b
+
+        size_sk    = sizeSignKeyKES (Proxy :: Proxy d)
+        size_r     = seedSizeKES    (Proxy :: Proxy d)
+        size_vk    = sizeVerKeyKES  (Proxy :: Proxy d)
+        size_total = sizeSignKeyKES (Proxy :: Proxy (SumKES h d))
+
+        off_sk     = 0 :: Word
+        off_r      = size_sk
+        off_vk0    = off_r + size_r
+        off_vk1    = off_vk0 + size_vk
+
+    rawDeserialiseSigKES b = do
+        guard (BS.length b == fromIntegral size_total)
+        sigma <- rawDeserialiseSigKES    b_sig
+        vk_0  <- rawDeserialiseVerKeyKES b_vk0
+        vk_1  <- rawDeserialiseVerKeyKES b_vk1
+        return (SigSumKES sigma vk_0 vk_1)
+      where
+        b_sig = slice off_sig size_sig b
+        b_vk0 = slice off_vk0 size_vk  b
+        b_vk1 = slice off_vk1 size_vk  b
+
+        size_sig   = sizeSigKES    (Proxy :: Proxy d)
+        size_vk    = sizeVerKeyKES (Proxy :: Proxy d)
+        size_total = sizeSigKES    (Proxy :: Proxy (SumKES h d))
+
+        off_sig    = 0 :: Word
+        off_vk0    = size_sig
+        off_vk1    = off_vk0 + size_vk
+
+
+hashPairOfVKeys :: (KESAlgorithm d, HashAlgorithm h)
+                => (VerKeyKES d, VerKeyKES d)
+                -> Hash h (VerKeyKES d, VerKeyKES d)
+hashPairOfVKeys =
+    hashRaw $ \(a,b) ->
+      rawSerialiseVerKeyKES a <> rawSerialiseVerKeyKES b
+
+slice :: Word -> Word -> ByteString -> ByteString
+slice offset size = BS.take (fromIntegral size)
+                  . BS.drop (fromIntegral offset)
+
+zeroSeed :: KESAlgorithm d => Proxy d -> Seed
+zeroSeed p = mkSeedFromBytes (BS.replicate seedSize (0 :: Word8))
+  where
+    seedSize :: Int
+    seedSize = fromIntegral (seedSizeKES p)
+
+
+--
+-- VerKey instances
+--
+
+deriving instance Show (VerKeyKES (SumKES h d))
+deriving instance Eq   (VerKeyKES (SumKES h d))
+
+instance KESAlgorithm d => NoUnexpectedThunks (SignKeyKES (SumKES h d))
+
+instance (KESAlgorithm d, HashAlgorithm h, Typeable d)
+      => ToCBOR (VerKeyKES (SumKES h d)) where
+  toCBOR = encodeVerKeyKES
+
+instance (KESAlgorithm d, HashAlgorithm h, Typeable d)
+      => FromCBOR (VerKeyKES (SumKES h d)) where
+  fromCBOR = decodeVerKeyKES
+
+
+--
+-- SignKey instances
+--
+
+deriving instance KESAlgorithm d => Show (SignKeyKES (SumKES h d))
+
+instance KESAlgorithm d => NoUnexpectedThunks (VerKeyKES  (SumKES h d))
+
+instance (KESAlgorithm d, HashAlgorithm h, Typeable d)
+      => ToCBOR (SignKeyKES (SumKES h d)) where
+  toCBOR = encodeSignKeyKES
+
+instance (KESAlgorithm d, HashAlgorithm h, Typeable d)
+      => FromCBOR (SignKeyKES (SumKES h d)) where
+  fromCBOR = decodeSignKeyKES
+
+
+--
+-- Sig instances
+--
+
+deriving instance KESAlgorithm d => Show (SigKES (SumKES h d))
+deriving instance KESAlgorithm d => Eq   (SigKES (SumKES h d))
+
+instance KESAlgorithm d => NoUnexpectedThunks (SigKES (SumKES h d))
+
+instance (KESAlgorithm d, HashAlgorithm h, Typeable d)
+      => ToCBOR (SigKES (SumKES h d)) where
+  toCBOR = encodeSigKES
+
+instance (KESAlgorithm d, HashAlgorithm h, Typeable d)
+      => FromCBOR (SigKES (SumKES h d)) where
+  fromCBOR = decodeSigKES
+

--- a/cardano-crypto-class/src/Cardano/Crypto/Seed.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Seed.hs
@@ -19,7 +19,6 @@ module Cardano.Crypto.Seed
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import           Data.ByteArray as BA (convert)
-import           Numeric.Natural (Natural)
 
 import           Control.Exception (Exception(..), throw)
 
@@ -52,29 +51,29 @@ mkSeedFromBytes = Seed
 -- are available. This can be chained multiple times provided the seed is big
 -- enough to cover each use.
 --
-getBytesFromSeed :: Int -> Seed -> Maybe (ByteString, Seed)
+getBytesFromSeed :: Word -> Seed -> Maybe (ByteString, Seed)
 getBytesFromSeed n (Seed s)
-  | BS.length b == n = Just (b, Seed s')
-  | otherwise        = Nothing
+  | fromIntegral (BS.length b) == n = Just (b, Seed s')
+  | otherwise                       = Nothing
   where
-    (b, s') = BS.splitAt n s
+    (b, s') = BS.splitAt (fromIntegral n) s
 
 -- | Split a seed into two smaller seeds, the first of which is the given
 -- number of bytes large, and the second is the remaining. This will fail if
 -- not enough bytes are available. This can be chained multiple times provided
 -- the seed is big enough to cover each use.
 --
-splitSeed :: Int -> Seed -> Maybe (Seed, Seed)
+splitSeed :: Word -> Seed -> Maybe (Seed, Seed)
 splitSeed n (Seed s)
-  | BS.length b == n = Just (Seed b, Seed s')
-  | otherwise        = Nothing
+  | fromIntegral (BS.length b) == n = Just (Seed b, Seed s')
+  | otherwise                       = Nothing
   where
-    (b, s') = BS.splitAt n s
+    (b, s') = BS.splitAt (fromIntegral n) s
 
 
 -- | Obtain a 'Seed' by reading @n@ bytes of entropy from the operating system.
 --
-readSeedFromSystemEntropy :: Natural -> IO Seed
+readSeedFromSystemEntropy :: Word -> IO Seed
 readSeedFromSystemEntropy n = mkSeedFromBytes <$> getEntropy (fromIntegral n)
 
 --
@@ -112,7 +111,7 @@ getRandomBytesFromSeed n =
       StateT $ \s ->
         MaybeT $
           Identity $
-            getBytesFromSeed n s
+            getBytesFromSeed (fromIntegral n) s
 
 
 instance MonadRandom MonadRandomFromSeed where

--- a/cardano-crypto-class/src/Cardano/Crypto/Util.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Util.hs
@@ -1,23 +1,73 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE FlexibleInstances #-}
 
 {-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns #-}
 module Cardano.Crypto.Util
   ( Empty
-  , mockNonNegIntR
+  , getRandomWord64
+
+    -- * Simple serialisation used in mock instances
+  , readBinaryWord64
+  , writeBinaryWord64
+  , readBinaryNatural
+  , writeBinaryNatural
+  , splitsAt
   )
 where
 
-import Crypto.Random (MonadRandom (..))
-import Data.ByteString (ByteString, unpack)
-import Data.List (foldl')
+import           Data.Word
+import           Numeric.Natural
+import           Data.Bits
+import qualified Data.ByteString as BS
+import           Data.ByteString (ByteString)
+
+import           Crypto.Random (MonadRandom (..))
+
 
 class Empty a
-
 instance Empty a
 
-mockNonNegIntR :: MonadRandom m => m Int
-mockNonNegIntR = abs . toInt <$> getRandomBytes 8
+
+--
+-- Random source used in some mock instances
+--
+
+getRandomWord64 :: MonadRandom m => m Word64
+getRandomWord64 = readBinaryWord64 <$> getRandomBytes 8
+
+
+--
+-- Really simple serialisation used in some mock instances
+--
+
+readBinaryWord64 :: ByteString -> Word64
+readBinaryWord64 =
+  BS.foldl' (\acc w8 -> unsafeShiftL acc 8 + fromIntegral w8) 0
+
+
+readBinaryNatural :: ByteString -> Natural
+readBinaryNatural =
+  BS.foldl' (\acc w8 -> unsafeShiftL acc 8 + fromIntegral w8) 0
+
+
+writeBinaryWord64 :: Word64 -> ByteString
+writeBinaryWord64 =
+    BS.reverse . fst
+  . BS.unfoldrN 8 (\w -> Just (fromIntegral w, unsafeShiftR w 8))
+
+writeBinaryNatural :: Int -> Natural -> ByteString
+writeBinaryNatural bytes =
+    BS.reverse . fst
+  . BS.unfoldrN bytes (\w -> Just (fromIntegral w, unsafeShiftR w 8))
+
+splitsAt :: [Int] -> ByteString -> [ByteString]
+splitsAt szs0 bs0 =
+    go 0 szs0 bs0
   where
-    toInt :: ByteString -> Int
-    toInt =
-      foldl' (\acc w8 -> acc * 256 + fromIntegral w8) 0 . unpack
+    go !_   [] bs
+      | BS.null bs         = []
+      | otherwise          = [bs]
+
+    go !off (sz:szs) bs
+      | BS.length bs >= sz = BS.take sz bs : go (off+sz) szs (BS.drop sz bs)
+      | otherwise          = []

--- a/cardano-crypto-class/src/Cardano/Crypto/Util.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Util.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE FlexibleInstances #-}
 
-{-# OPTIONS_GHC -fno-warn-incomplete-uni-patterns #-}
 module Cardano.Crypto.Util
   ( Empty
   , getRandomWord64

--- a/cardano-crypto-class/src/Cardano/Crypto/VRF/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/VRF/Class.hs
@@ -8,38 +8,45 @@
 
 -- | Abstract Verifiable Random Functions.
 module Cardano.Crypto.VRF.Class
-  ( VRFAlgorithm (..)
+  (
+    -- * VRF algorithm class
+    VRFAlgorithm (..)
+
+    -- * 'CertifiedVRF' wrapper
   , CertifiedVRF (..)
   , evalCertified
   , verifyCertified
-  )
+
+    -- * CBOR encoding and decoding
+  , encodeVerKeyVRF
+  , decodeVerKeyVRF
+  , encodeSignKeyVRF
+  , decodeSignKeyVRF
+  , encodeCertVRF
+  , decodeCertVRF
+)
 where
 
-import Cardano.Binary
-  ( Decoder
-  , Encoding
-  , FromCBOR (..)
-  , ToCBOR (..)
-  , encodeListLen
-  , enforceSize
-  , decodeBytes
-  , encodeBytes
-  , serializeEncoding'
-  , decodeFullDecoder
-  )
-import Cardano.Crypto.Util (Empty)
-import Cardano.Crypto.Seed (Seed)
-import Cardano.Crypto.Hash.Class (HashAlgorithm, Hash, hashRaw)
-import Cardano.Prelude (NoUnexpectedThunks)
-import Crypto.Random (MonadRandom)
 import Data.ByteString (ByteString)
-import Data.ByteString.Lazy as LBS (fromStrict)
+import qualified Data.ByteString as BS
+import Numeric.Natural
 import Data.Kind (Type)
+import Data.Proxy (Proxy(..))
 import Data.Typeable (Typeable)
 import GHC.Exts (Constraint)
 import GHC.Generics (Generic)
 import GHC.Stack
-import Numeric.Natural
+
+import Cardano.Prelude (NoUnexpectedThunks)
+import Cardano.Binary
+         (Decoder, Encoding, FromCBOR (..), ToCBOR (..),
+          encodeListLen, enforceSize, decodeBytes, encodeBytes)
+
+import Crypto.Random (MonadRandom)
+
+import Cardano.Crypto.Util (Empty)
+import Cardano.Crypto.Seed (Seed)
+import Cardano.Crypto.Hash.Class (HashAlgorithm, Hash, hashRaw)
 
 
 class ( Typeable v
@@ -74,10 +81,6 @@ class ( Typeable v
 
   hashVerKeyVRF :: HashAlgorithm h => VerKeyVRF v -> Hash h (VerKeyVRF v)
   hashVerKeyVRF = hashRaw rawSerialiseVerKeyVRF
-
-  sizeVerKeyVRF  :: proxy v -> Word
-  sizeSignKeyVRF :: proxy v -> Word
-  sizeCertVRF    :: proxy v -> Word
 
 
   --
@@ -122,100 +125,78 @@ class ( Typeable v
 
 
   --
-  -- Serialisation/(de)serialisation in raw format, no extra tags
-  --
-  -- default implementations in terms of the CBOR encode/decode
+  -- Serialisation/(de)serialisation in fixed-size raw format
   --
 
-  rawSerialiseVerKeyVRF :: VerKeyVRF v -> ByteString
-  rawSerialiseVerKeyVRF = serializeEncoding' . encodeVerKeyVRF
+  sizeVerKeyVRF  :: proxy v -> Word
+  sizeSignKeyVRF :: proxy v -> Word
+  sizeCertVRF    :: proxy v -> Word
 
-  rawSerialiseSignKeyVRF :: SignKeyVRF v -> ByteString
-  rawSerialiseSignKeyVRF = serializeEncoding' . encodeSignKeyVRF
+  rawSerialiseVerKeyVRF    :: VerKeyVRF  v -> ByteString
+  rawSerialiseSignKeyVRF   :: SignKeyVRF v -> ByteString
+  rawSerialiseCertVRF      :: CertVRF    v -> ByteString
 
-  rawSerialiseCertVRF :: CertVRF v -> ByteString
-  rawSerialiseCertVRF = serializeEncoding' . encodeCertVRF
-
-  rawDeserialiseVerKeyVRF :: ByteString -> Maybe (VerKeyVRF v)
-  rawDeserialiseVerKeyVRF =
-      either (const Nothing) Just
-    . decodeFullDecoder
-        "rawDeserialiseVerKeyVRF"
-        decodeVerKeyVRF
-    . LBS.fromStrict
-
+  rawDeserialiseVerKeyVRF  :: ByteString -> Maybe (VerKeyVRF  v)
   rawDeserialiseSignKeyVRF :: ByteString -> Maybe (SignKeyVRF v)
-  rawDeserialiseSignKeyVRF =
-      either (const Nothing) Just
-    . decodeFullDecoder
-        "rawDeserialiseVerKeyVRF"
-        decodeSignKeyVRF
-    . LBS.fromStrict
-
-  rawDeserialiseCertVRF :: ByteString -> Maybe (CertVRF v)
-  rawDeserialiseCertVRF =
-      either (const Nothing) Just
-    . decodeFullDecoder
-        "rawDeserialiseVerKeyVRF"
-        decodeCertVRF
-    . LBS.fromStrict
+  rawDeserialiseCertVRF    :: ByteString -> Maybe (CertVRF    v)
 
 
-  --
-  -- Convenient CBOR encoding/decoding
-  --
-  -- default implementations in terms of the raw (de)serialise
-  --
+--
+-- Convenient CBOR encoding/decoding
+--
+-- Implementations in terms of the raw (de)serialise
+--
 
-  encodeVerKeyVRF :: VerKeyVRF v -> Encoding
-  encodeVerKeyVRF = encodeBytes . rawSerialiseVerKeyVRF
+encodeVerKeyVRF :: VRFAlgorithm v => VerKeyVRF v -> Encoding
+encodeVerKeyVRF = encodeBytes . rawSerialiseVerKeyVRF
 
-  encodeSignKeyVRF :: SignKeyVRF v -> Encoding
-  encodeSignKeyVRF = encodeBytes . rawSerialiseSignKeyVRF
+encodeSignKeyVRF :: VRFAlgorithm v => SignKeyVRF v -> Encoding
+encodeSignKeyVRF = encodeBytes . rawSerialiseSignKeyVRF
 
-  encodeCertVRF :: CertVRF v -> Encoding
-  encodeCertVRF = encodeBytes . rawSerialiseCertVRF
+encodeCertVRF :: VRFAlgorithm v => CertVRF v -> Encoding
+encodeCertVRF = encodeBytes . rawSerialiseCertVRF
 
-  decodeVerKeyVRF :: Decoder s (VerKeyVRF v)
-  decodeVerKeyVRF = do
+decodeVerKeyVRF :: forall v s. VRFAlgorithm v => Decoder s (VerKeyVRF v)
+decodeVerKeyVRF = do
     bs <- decodeBytes
     case rawDeserialiseVerKeyVRF bs of
-      Nothing -> fail "decodeVerKeyVRF: cannot decode key"
       Just vk -> return vk
+      Nothing
+        | actual /= expected
+                    -> fail ("decodeVerKeyVRF: wrong length, expected " ++
+                             show expected ++ " bytes but got " ++ show actual)
+        | otherwise -> fail "decodeVerKeyVRF: cannot decode key"
+        where
+          expected = fromIntegral (sizeVerKeyVRF (Proxy :: Proxy v))
+          actual   = BS.length bs
 
-  decodeSignKeyVRF :: Decoder s (SignKeyVRF v)
-  decodeSignKeyVRF = do
+decodeSignKeyVRF :: forall v s. VRFAlgorithm v => Decoder s (SignKeyVRF v)
+decodeSignKeyVRF = do
     bs <- decodeBytes
     case rawDeserialiseSignKeyVRF bs of
-      Nothing -> fail "decodeSignKeyVRF: cannot decode key"
-      Just vk -> return vk
+      Just sk -> return sk
+      Nothing
+        | actual /= expected
+                    -> fail ("decodeSignKeyVRF: wrong length, expected " ++
+                             show expected ++ " bytes but got " ++ show actual)
+        | otherwise -> fail "decodeSignKeyVRF: cannot decode key"
+        where
+          expected = fromIntegral (sizeSignKeyVRF (Proxy :: Proxy v))
+          actual   = BS.length bs
 
-  decodeCertVRF :: Decoder s (CertVRF v)
-  decodeCertVRF = do
+decodeCertVRF :: forall v s. VRFAlgorithm v => Decoder s (CertVRF v)
+decodeCertVRF = do
     bs <- decodeBytes
     case rawDeserialiseCertVRF bs of
-      Nothing -> fail "decodeCertVRF: cannot decode key"
-      Just vk -> return vk
-
-
-  {-# MINIMAL
-        algorithmNameVRF
-      , deriveVerKeyVRF
-      , sizeVerKeyVRF
-      , sizeSignKeyVRF
-      , sizeCertVRF
-      , evalVRF
-      , verifyVRF
-      , maxVRF
-      , genKeyVRF
-      , seedSizeVRF
-      , (rawSerialiseVerKeyVRF    | encodeVerKeyVRF)
-      , (rawSerialiseSignKeyVRF   | encodeSignKeyVRF)
-      , (rawSerialiseCertVRF      | encodeCertVRF)
-      , (rawDeserialiseVerKeyVRF  | decodeVerKeyVRF)
-      , (rawDeserialiseSignKeyVRF | decodeSignKeyVRF)
-      , (rawDeserialiseCertVRF    | decodeCertVRF)
-    #-}
+      Just crt -> return crt
+      Nothing
+        | actual /= expected
+                    -> fail ("decodeCertVRF: wrong length, expected " ++
+                             show expected ++ " bytes but got " ++ show actual)
+        | otherwise -> fail "decodeCertVRF: cannot decode key"
+        where
+          expected = fromIntegral (sizeCertVRF (Proxy :: Proxy v))
+          actual   = BS.length bs
 
 
 data CertifiedVRF v a

--- a/cardano-crypto-class/src/Cardano/Crypto/VRF/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/VRF/Class.hs
@@ -75,6 +75,10 @@ class ( Typeable v
   hashVerKeyVRF :: HashAlgorithm h => VerKeyVRF v -> Hash h (VerKeyVRF v)
   hashVerKeyVRF = hashRaw rawSerialiseVerKeyVRF
 
+  sizeVerKeyVRF  :: proxy v -> Word
+  sizeSignKeyVRF :: proxy v -> Word
+  sizeCertVRF    :: proxy v -> Word
+
 
   --
   -- Core algorithm operations
@@ -197,6 +201,9 @@ class ( Typeable v
   {-# MINIMAL
         algorithmNameVRF
       , deriveVerKeyVRF
+      , sizeVerKeyVRF
+      , sizeSignKeyVRF
+      , sizeCertVRF
       , evalVRF
       , verifyVRF
       , maxVRF

--- a/cardano-crypto-class/src/Cardano/Crypto/VRF/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/VRF/Class.hs
@@ -114,7 +114,7 @@ class ( Typeable v
   genKeyVRF :: Seed -> SignKeyVRF v
 
   -- | The upper bound on the 'Seed' size needed by 'genKeyVRF'
-  seedSizeVRF :: proxy v -> Natural
+  seedSizeVRF :: proxy v -> Word
 
 
   --

--- a/cardano-crypto-class/src/Cardano/Crypto/VRF/Mock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/VRF/Mock.hs
@@ -57,7 +57,7 @@ instance VRFAlgorithm MockVRF where
 
   verifyVRF () (VerKeyMockVRF n) a c = evalVRF' a (SignKeyMockVRF n) == c
 
-  maxVRF _ = 2 ^ (8 * byteCount (Proxy :: Proxy MD5)) - 1
+  maxVRF _ = 2 ^ (8 * sizeHash (Proxy :: Proxy MD5)) - 1
 
   --
   -- Key generation

--- a/cardano-crypto-class/src/Cardano/Crypto/VRF/Mock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/VRF/Mock.hs
@@ -35,13 +35,13 @@ instance VRFAlgorithm MockVRF where
   --
 
   newtype VerKeyVRF MockVRF = VerKeyMockVRF Word64
-      deriving (Show, Eq, Ord, Generic, NoUnexpectedThunks, ToCBOR, FromCBOR)
+      deriving (Show, Eq, Ord, Generic, NoUnexpectedThunks)
 
   newtype SignKeyVRF MockVRF = SignKeyMockVRF Word64
-      deriving (Show, Eq, Ord, Generic, NoUnexpectedThunks, ToCBOR, FromCBOR)
+      deriving (Show, Eq, Ord, Generic, NoUnexpectedThunks)
 
   newtype CertVRF MockVRF = CertMockVRF Word64
-      deriving (Show, Eq, Ord, Generic, NoUnexpectedThunks, ToCBOR, FromCBOR)
+      deriving (Show, Eq, Ord, Generic, NoUnexpectedThunks)
 
   --
   -- Metadata and basic key operations
@@ -50,10 +50,6 @@ instance VRFAlgorithm MockVRF where
   algorithmNameVRF _ = "mock"
 
   deriveVerKeyVRF (SignKeyMockVRF n) = VerKeyMockVRF n
-
-  sizeVerKeyVRF  _ = 8
-  sizeSignKeyVRF _ = 8
-  sizeCertVRF    _ = 8
 
 
   --
@@ -81,6 +77,10 @@ instance VRFAlgorithm MockVRF where
   --
   -- raw serialise/deserialise
   --
+
+  sizeVerKeyVRF  _ = 8
+  sizeSignKeyVRF _ = 8
+  sizeCertVRF    _ = 8
 
   rawSerialiseVerKeyVRF  (VerKeyMockVRF  k) = writeBinaryWord64 k
   rawSerialiseSignKeyVRF (SignKeyMockVRF k) = writeBinaryWord64 k
@@ -111,16 +111,23 @@ instance VRFAlgorithm MockVRF where
     = Nothing
 
 
-  --
-  -- CBOR encoding/decoding
-  --
+instance ToCBOR (VerKeyVRF MockVRF) where
+  toCBOR = encodeVerKeyVRF
 
-  encodeVerKeyVRF  = toCBOR
-  decodeVerKeyVRF  = fromCBOR
-  encodeSignKeyVRF = toCBOR
-  decodeSignKeyVRF = fromCBOR
-  encodeCertVRF    = toCBOR
-  decodeCertVRF    = fromCBOR
+instance FromCBOR (VerKeyVRF MockVRF) where
+  fromCBOR = decodeVerKeyVRF
+
+instance ToCBOR (SignKeyVRF MockVRF) where
+  toCBOR = encodeSignKeyVRF
+
+instance FromCBOR (SignKeyVRF MockVRF) where
+  fromCBOR = decodeSignKeyVRF
+
+instance ToCBOR (CertVRF MockVRF) where
+  toCBOR = encodeCertVRF
+
+instance FromCBOR (CertVRF MockVRF) where
+  fromCBOR = decodeCertVRF
 
 
 evalVRF' :: ToCBOR a => a -> SignKeyVRF MockVRF -> (Natural, CertVRF MockVRF)

--- a/cardano-crypto-class/src/Cardano/Crypto/VRF/NeverUsed.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/VRF/NeverUsed.hs
@@ -37,6 +37,10 @@ instance VRFAlgorithm NeverVRF where
 
   deriveVerKeyVRF _ = NeverUsedVerKeyVRF
 
+  sizeVerKeyVRF  _ = 0
+  sizeSignKeyVRF _ = 0
+  sizeCertVRF    _ = 0
+
   evalVRF = error "VRF unavailable"
 
   verifyVRF = error "VRF unavailable"

--- a/cardano-crypto-class/src/Cardano/Crypto/VRF/NeverUsed.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/VRF/NeverUsed.hs
@@ -12,9 +12,10 @@ where
 
 import GHC.Generics (Generic)
 
-import Cardano.Binary (FromCBOR (..), ToCBOR (..))
-import Cardano.Crypto.VRF.Class
 import Cardano.Prelude (NoUnexpectedThunks)
+
+import Cardano.Crypto.VRF.Class
+
 
 -- | VRF not available
 --
@@ -37,10 +38,6 @@ instance VRFAlgorithm NeverVRF where
 
   deriveVerKeyVRF _ = NeverUsedVerKeyVRF
 
-  sizeVerKeyVRF  _ = 0
-  sizeSignKeyVRF _ = 0
-  sizeCertVRF    _ = 0
-
   evalVRF = error "VRF unavailable"
 
   verifyVRF = error "VRF unavailable"
@@ -50,15 +47,14 @@ instance VRFAlgorithm NeverVRF where
   genKeyVRF _ = NeverUsedSignKeyVRF
   seedSizeVRF _ = 0
 
-  encodeVerKeyVRF  _ = error "VRF unavailable"
-  decodeVerKeyVRF    = error "VRF unavailable"
-  encodeSignKeyVRF _ = error "VRF unavailable"
-  decodeSignKeyVRF   = error "VRF unavailable"
-  encodeCertVRF    _ = error "VRF unavailable"
-  decodeCertVRF      = error "VRF unavailable"
+  sizeVerKeyVRF  _ = 0
+  sizeSignKeyVRF _ = 0
+  sizeCertVRF    _ = 0
 
-instance ToCBOR (CertVRF NeverVRF) where
-  toCBOR _ = toCBOR ()
+  rawSerialiseVerKeyVRF  _ = mempty
+  rawSerialiseSignKeyVRF _ = mempty
+  rawSerialiseCertVRF    _ = mempty
 
-instance FromCBOR (CertVRF NeverVRF) where
-  fromCBOR = (\() -> NeverUsedCertVRF) <$> fromCBOR
+  rawDeserialiseVerKeyVRF  _ = Just NeverUsedVerKeyVRF
+  rawDeserialiseSignKeyVRF _ = Just NeverUsedSignKeyVRF
+  rawDeserialiseCertVRF    _ = Just NeverUsedCertVRF

--- a/cardano-crypto-class/src/Cardano/Crypto/VRF/Simple.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/VRF/Simple.hs
@@ -150,7 +150,7 @@ instance VRFAlgorithm SimpleVRF where
             toCBOR (h' (toCBOR a) s <> pow' u c')
     in b1 && c == rhs
 
-  maxVRF _ = 2 ^ (8 * byteCount (Proxy :: Proxy H)) - 1
+  maxVRF _ = 2 ^ (8 * sizeHash (Proxy :: Proxy H)) - 1
 
   --
   -- Key generation

--- a/cardano-crypto-class/src/Cardano/Crypto/VRF/Simple.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/VRF/Simple.hs
@@ -22,9 +22,7 @@ import           GHC.Generics (Generic)
 import           Numeric.Natural (Natural)
 
 import           Cardano.Prelude (NoUnexpectedThunks, UseIsNormalForm(..))
-import           Cardano.Binary
-                   (Encoding, FromCBOR (..), ToCBOR (..),
-                    encodeListLen, enforceSize)
+import           Cardano.Binary (Encoding, FromCBOR (..), ToCBOR (..))
 
 import           Crypto.Number.Generate (generateBetween)
 import qualified Crypto.PubKey.ECC.Prim as C
@@ -99,11 +97,10 @@ instance VRFAlgorithm SimpleVRF where
 
   newtype VerKeyVRF SimpleVRF = VerKeySimpleVRF Point
     deriving stock   (Show, Eq, Generic)
-    deriving newtype (ToCBOR, FromCBOR, NoUnexpectedThunks)
+    deriving newtype (NoUnexpectedThunks)
 
   newtype SignKeyVRF SimpleVRF = SignKeySimpleVRF C.PrivateNumber
     deriving stock   (Show, Eq, Generic)
-    deriving newtype (ToCBOR, FromCBOR)
     deriving NoUnexpectedThunks via UseIsNormalForm C.PrivateNumber
 
   data CertVRF SimpleVRF
@@ -221,29 +218,22 @@ instance VRFAlgorithm SimpleVRF where
     = Nothing
 
 
-  --
-  -- CBOR encoding/decoding
-  --
 
-  encodeVerKeyVRF  = toCBOR
-  decodeVerKeyVRF  = fromCBOR
-  encodeSignKeyVRF = toCBOR
-  decodeSignKeyVRF = fromCBOR
-  encodeCertVRF    = toCBOR
-  decodeCertVRF    = fromCBOR
+instance ToCBOR (VerKeyVRF SimpleVRF) where
+  toCBOR = encodeVerKeyVRF
 
+instance FromCBOR (VerKeyVRF SimpleVRF) where
+  fromCBOR = decodeVerKeyVRF
+
+instance ToCBOR (SignKeyVRF SimpleVRF) where
+  toCBOR = encodeSignKeyVRF
+
+instance FromCBOR (SignKeyVRF SimpleVRF) where
+  fromCBOR = decodeSignKeyVRF
 
 instance ToCBOR (CertVRF SimpleVRF) where
-  toCBOR cvrf =
-    encodeListLen 3 <>
-      toCBOR (certU cvrf) <>
-      toCBOR (certC cvrf) <>
-      toCBOR (certS cvrf)
+  toCBOR = encodeCertVRF
 
 instance FromCBOR (CertVRF SimpleVRF) where
-  fromCBOR =
-    CertSimpleVRF <$
-      enforceSize "CertVRF SimpleVRF" 3 <*>
-      fromCBOR <*>
-      fromCBOR <*>
-      fromCBOR
+  fromCBOR = decodeCertVRF
+

--- a/cardano-crypto-class/src/Cardano/Crypto/VRF/Simple.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/VRF/Simple.hs
@@ -17,24 +17,25 @@ module Cardano.Crypto.VRF.Simple
   )
 where
 
-import Cardano.Binary
-  ( Encoding
-  , FromCBOR (..)
-  , ToCBOR (..)
-  , encodeListLen
-  , enforceSize
-  )
-import Cardano.Crypto.Hash
-import Cardano.Crypto.Seed
-import Cardano.Crypto.VRF.Class
-import Cardano.Prelude (NoUnexpectedThunks, UseIsNormalForm(..))
-import Crypto.Number.Generate (generateBetween)
+import           Data.Proxy (Proxy (..))
+import           GHC.Generics (Generic)
+import           Numeric.Natural (Natural)
+
+import           Cardano.Prelude (NoUnexpectedThunks, UseIsNormalForm(..))
+import           Cardano.Binary
+                   (Encoding, FromCBOR (..), ToCBOR (..),
+                    encodeListLen, enforceSize)
+
+import           Crypto.Number.Generate (generateBetween)
 import qualified Crypto.PubKey.ECC.Prim as C
 import qualified Crypto.PubKey.ECC.Types as C
-import Crypto.Random (MonadRandom (..))
-import Data.Proxy (Proxy (..))
-import GHC.Generics (Generic)
-import Numeric.Natural (Natural)
+import           Crypto.Random (MonadRandom (..))
+
+import           Cardano.Crypto.Hash
+import           Cardano.Crypto.Seed
+import           Cardano.Crypto.Util
+import           Cardano.Crypto.VRF.Class
+
 
 data SimpleVRF
 
@@ -42,6 +43,7 @@ type H = MD5
 
 curve :: C.Curve
 curve = C.getCurveByName C.SEC_t113r1
+-- C.curveSizeBits curve = 113 bits, 15 bytes
 
 q :: Integer
 q = C.ecc_n $ C.common_curve curve
@@ -106,9 +108,9 @@ instance VRFAlgorithm SimpleVRF where
 
   data CertVRF SimpleVRF
     = CertSimpleVRF
-        { certU :: Point
-        , certC :: Natural
-        , certS :: Integer
+        { certU :: Point    -- 15 byte point numbers, round up to 16
+        , certC :: Natural  -- md5 hash, so 16 bytes
+        , certS :: Integer  -- at most q, so 15 bytes, round up to 16
         }
     deriving stock    (Show, Eq, Generic)
     deriving anyclass (NoUnexpectedThunks)
@@ -121,6 +123,11 @@ instance VRFAlgorithm SimpleVRF where
 
   deriveVerKeyVRF (SignKeySimpleVRF k) =
     VerKeySimpleVRF $ pow k
+
+  sizeVerKeyVRF  _ = 32
+  sizeSignKeyVRF _ = 16
+  sizeCertVRF    _ = 64
+
 
   --
   -- Core algorithm operations
@@ -152,6 +159,7 @@ instance VRFAlgorithm SimpleVRF where
 
   maxVRF _ = 2 ^ (8 * sizeHash (Proxy :: Proxy H)) - 1
 
+
   --
   -- Key generation
   --
@@ -159,6 +167,59 @@ instance VRFAlgorithm SimpleVRF where
   seedSizeVRF _  = 16 * 10 -- size of SEC_t113r1 * up to 10 iterations
   genKeyVRF seed = SignKeySimpleVRF
                      (runMonadRandomWithSeed seed (C.scalarGenerate curve))
+
+
+  --
+  -- raw serialise/deserialise
+  --
+
+  -- All the integers here are 15 or 16 bytes big, we round up to 16.
+
+  rawSerialiseVerKeyVRF (VerKeySimpleVRF (Point C.PointO)) =
+      error "rawSerialiseVerKeyVRF: Point at infinity"
+  rawSerialiseVerKeyVRF (VerKeySimpleVRF (Point (C.Point p1 p2))) =
+      writeBinaryNatural 16 (fromInteger p1)
+   <> writeBinaryNatural 16 (fromInteger p2)
+
+  rawSerialiseSignKeyVRF (SignKeySimpleVRF sk) =
+      writeBinaryNatural 16 (fromInteger sk)
+
+  rawSerialiseCertVRF (CertSimpleVRF (Point C.PointO) _ _) =
+      error "rawSerialiseCertVRF: Point at infinity"
+  rawSerialiseCertVRF (CertSimpleVRF (Point (C.Point p1 p2)) c s) =
+      writeBinaryNatural 16 (fromInteger p1)
+   <> writeBinaryNatural 16 (fromInteger p2)
+   <> writeBinaryNatural 16 c
+   <> writeBinaryNatural 16 (fromInteger s)
+
+  rawDeserialiseVerKeyVRF bs
+    | [p1b, p2b] <- splitsAt [16,16] bs
+    , let p1 = toInteger (readBinaryNatural p1b)
+          p2 = toInteger (readBinaryNatural p2b)
+    = Just $! VerKeySimpleVRF (Point (C.Point p1 p2))
+
+    | otherwise
+    = Nothing
+
+  rawDeserialiseSignKeyVRF bs
+    | [skb] <- splitsAt [16] bs
+    , let sk = toInteger (readBinaryNatural skb)
+    = Just $! SignKeySimpleVRF sk
+
+    | otherwise
+    = Nothing
+
+  rawDeserialiseCertVRF bs
+    | [p1b, p2b, cb, sb] <- splitsAt [16,16,16,16] bs
+    , let p1 = toInteger (readBinaryNatural p1b)
+          p2 = toInteger (readBinaryNatural p2b)
+          c  =            readBinaryNatural cb
+          s  = toInteger (readBinaryNatural sb)
+    = Just $! CertSimpleVRF (Point (C.Point p1 p2)) c s
+
+    | otherwise
+    = Nothing
+
 
   --
   -- CBOR encoding/decoding

--- a/cardano-crypto-class/test/Test/Crypto/DSIGN.hs
+++ b/cardano-crypto-class/test/Test/Crypto/DSIGN.hs
@@ -69,6 +69,18 @@ testDSIGNAlgorithm _ n =
                                                       rawDeserialiseSigDSIGN
         ]
 
+      , testGroup "size"
+        [ testProperty "VerKey"  $ prop_size_serialise @(VerKeyDSIGN v)
+                                                       rawSerialiseVerKeyDSIGN
+                                                       (sizeVerKeyDSIGN (Proxy @ v))
+        , testProperty "SignKey" $ prop_size_serialise @(SignKeyDSIGN v)
+                                                       rawSerialiseSignKeyDSIGN
+                                                       (sizeSignKeyDSIGN (Proxy @ v))
+        , testProperty "Sig"     $ prop_size_serialise @(SigDSIGN v)
+                                                       rawSerialiseSigDSIGN
+                                                       (sizeSigDSIGN (Proxy @ v))
+        ]
+
       , testGroup "direct CBOR"
         [ testProperty "VerKey"  $ prop_cbor_with @(VerKeyDSIGN v)
                                                   encodeVerKeyDSIGN

--- a/cardano-crypto-class/test/Test/Crypto/DSIGN.hs
+++ b/cardano-crypto-class/test/Test/Crypto/DSIGN.hs
@@ -9,24 +9,17 @@ module Test.Crypto.DSIGN
   )
 where
 
-import Cardano.Binary (FromCBOR, ToCBOR (..))
-import Cardano.Crypto.DSIGN
-  ( DSIGNAlgorithm (..)
-  , Ed25519DSIGN
-  , Ed448DSIGN
-  , MockDSIGN
-  )
 import Data.Proxy (Proxy (..))
+
+import Cardano.Binary (FromCBOR, ToCBOR (..))
+
+import Cardano.Crypto.DSIGN
+
 import Test.Crypto.Util
 import Test.QuickCheck ((=/=), (===), (==>), Arbitrary(..), Gen, Property)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.QuickCheck (testProperty)
 
--- import           Ouroboros.Consensus.Util.Orphans ()
--- import           Ouroboros.Consensus.Util.Random (Seed, withSeed)
-
--- import           Ouroboros.Network.Testing.Serialise (Serialise(..), prop_cbor)
--- import           Test.Util.Orphans.Arbitrary ()
 
 --
 -- The list of all tests

--- a/cardano-crypto-class/test/Test/Crypto/DSIGN.hs
+++ b/cardano-crypto-class/test/Test/Crypto/DSIGN.hs
@@ -3,7 +3,9 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
 module Test.Crypto.DSIGN
   ( tests
   )

--- a/cardano-crypto-class/test/Test/Crypto/DSIGN.hs
+++ b/cardano-crypto-class/test/Test/Crypto/DSIGN.hs
@@ -104,6 +104,10 @@ testDSIGNAlgorithm _ n =
       ]
     ]
 
+
+-- | If we sign a message @a@ with the signing key, then we can verify the
+-- signature using the corresponding verification key.
+--
 prop_dsign_verify_pos
   :: forall a v. (DSIGNAlgorithm v, Signable v a, ContextDSIGN v ~ ())
   => a
@@ -114,6 +118,11 @@ prop_dsign_verify_pos a sk =
       vk = deriveVerKeyDSIGN sk
   in verifyDSIGN () vk a sig === Right ()
 
+
+-- | If we sign a message @a@ with one signing key, if we try to verify the
+-- signature (and message @a@) using a verification key corresponding to a
+-- different signing key, then the verification fails.
+--
 prop_dsign_verify_neg_key
   :: forall a v. (DSIGNAlgorithm v, Eq (SignKeyDSIGN v), Signable v a, ContextDSIGN v ~ ())
   => a
@@ -122,10 +131,14 @@ prop_dsign_verify_neg_key
   -> Property
 prop_dsign_verify_neg_key a sk sk' =
   sk /= sk' ==>
-    let sig = signDSIGN () a sk'
-        vk = deriveVerKeyDSIGN sk
-    in verifyDSIGN () vk a sig =/= Right ()
+    let sig = signDSIGN () a sk
+        vk' = deriveVerKeyDSIGN sk'
+    in verifyDSIGN () vk' a sig =/= Right ()
 
+
+-- | If we sign a message @a@ with one signing key, if we try to verify the
+-- signature with a message other than @a@, then the verification fails.
+--
 prop_dsign_verify_neg_msg
   :: forall a v. (Eq a, DSIGNAlgorithm v, Signable v a, ContextDSIGN v ~ ())
   => a

--- a/cardano-crypto-class/test/Test/Crypto/Hash.hs
+++ b/cardano-crypto-class/test/Test/Crypto/Hash.hs
@@ -35,7 +35,7 @@ testHashAlgorithm
   -> TestTree
 testHashAlgorithm _ n =
   testGroup n
-    [ testProperty "byte count" $ prop_hash_correct_byteCount @h @[Int]
+    [ testProperty "hash size" $ prop_hash_correct_sizeHash @h @[Int]
     , testProperty "serialise" $ prop_hash_cbor @h
     , testProperty "show/fromString" $ prop_hash_show_fromString @h @Float
     ]
@@ -43,12 +43,12 @@ testHashAlgorithm _ n =
 prop_hash_cbor :: HashAlgorithm h => Hash h Int -> Property
 prop_hash_cbor = prop_cbor
 
-prop_hash_correct_byteCount
+prop_hash_correct_sizeHash
   :: forall h a. HashAlgorithm h
   => Hash h a
   -> Property
-prop_hash_correct_byteCount h =
-  (SB.length $ getHash h) === (fromIntegral $ byteCount (Proxy :: Proxy h))
+prop_hash_correct_sizeHash h =
+  SB.length (getHash h) === fromIntegral (sizeHash (Proxy :: Proxy h))
 
 prop_hash_show_fromString :: Hash h a -> Property
 prop_hash_show_fromString h = h === fromString (show h)

--- a/cardano-crypto-class/test/Test/Crypto/Hash.hs
+++ b/cardano-crypto-class/test/Test/Crypto/Hash.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
 module Test.Crypto.Hash
   ( tests
   )

--- a/cardano-crypto-class/test/Test/Crypto/KES.hs
+++ b/cardano-crypto-class/test/Test/Crypto/KES.hs
@@ -76,6 +76,18 @@ testKESAlgorithm _p n =
                                                       rawDeserialiseSigKES
         ]
 
+      , testGroup "size"
+        [ testProperty "VerKey"  $ prop_size_serialise @(VerKeyKES v)
+                                                       rawSerialiseVerKeyKES
+                                                       (sizeVerKeyKES (Proxy @ v))
+        , testProperty "SignKey" $ prop_size_serialise @(SignKeyKES v)
+                                                       rawSerialiseSignKeyKES
+                                                       (sizeSignKeyKES (Proxy @ v))
+        , testProperty "Sig"     $ prop_size_serialise @(SigKES v)
+                                                       rawSerialiseSigKES
+                                                       (sizeSigKES (Proxy @ v))
+        ]
+
       , testGroup "direct CBOR"
         [ testProperty "VerKey"  $ prop_cbor_with @(VerKeyKES v)
                                                   encodeVerKeyKES
@@ -238,8 +250,8 @@ prop_verifyKES_negative_period sk_0 x =
             ]
 
 
--- | Check 'prop_raw_serialise' and 'prop_cbor_with' for 'VerKeyKES' on /all/
--- the KES key evolutions.
+-- | Check 'prop_raw_serialise', 'prop_cbor_with' and 'prop_size_serialise'
+-- for 'VerKeyKES' on /all/ the KES key evolutions.
 --
 prop_serialise_VerKeyKES
   :: forall v.
@@ -251,11 +263,13 @@ prop_serialise_VerKeyKES sk_0 =
                               rawDeserialiseVerKeyKES vk
        .&. prop_cbor_with encodeVerKeyKES
                           decodeVerKeyKES vk
+       .&. prop_size_serialise rawSerialiseVerKeyKES
+                               (sizeVerKeyKES (Proxy @ v)) vk
       | vk <- map deriveVerKeyKES (allUpdatesKES sk_0) ]
 
 
--- | Check 'prop_raw_serialise' and 'prop_cbor_with' for 'SignKeyKES' on /all/
--- the KES key evolutions.
+-- | Check 'prop_raw_serialise', 'prop_cbor_with' and 'prop_size_serialise'
+-- for 'SignKeyKES' on /all/ the KES key evolutions.
 --
 prop_serialise_SignKeyKES
   :: forall v.
@@ -267,11 +281,13 @@ prop_serialise_SignKeyKES sk_0 =
                               rawDeserialiseSignKeyKES sk
        .&. prop_cbor_with encodeSignKeyKES
                           decodeSignKeyKES sk
+       .&. prop_size_serialise rawSerialiseSignKeyKES
+                               (sizeSignKeyKES (Proxy @ v)) sk
       | sk <- allUpdatesKES sk_0 ]
 
 
--- | Check 'prop_raw_serialise' and 'prop_cbor_with' for 'SigKES' on /all/
--- the KES key evolutions.
+-- | Check 'prop_raw_serialise', 'prop_cbor_with' and 'prop_size_serialise'
+-- for 'SigKES' on /all/ the KES key evolutions.
 --
 prop_serialise_SigKES
   :: forall v a.
@@ -283,6 +299,8 @@ prop_serialise_SigKES sk_0 x =
                               rawDeserialiseSigKES sig
        .&. prop_cbor_with encodeSigKES
                           decodeSigKES sig
+       .&. prop_size_serialise rawSerialiseSigKES
+                               (sizeSigKES (Proxy @ v)) sig
       | (t, sk) <- zip [0..] (allUpdatesKES sk_0)
       , let sig = signKES () t x sk
       ]

--- a/cardano-crypto-class/test/Test/Crypto/KES.hs
+++ b/cardano-crypto-class/test/Test/Crypto/KES.hs
@@ -20,6 +20,7 @@ import Data.List (unfoldr)
 
 import Cardano.Binary (FromCBOR, ToCBOR(..))
 import Cardano.Crypto.DSIGN
+import Cardano.Crypto.Hash
 import Cardano.Crypto.KES
 import qualified Cardano.Crypto.KES as KES
 
@@ -38,12 +39,21 @@ tests =
   testGroup "Crypto.KES"
   [ testKESAlgorithm (Proxy :: Proxy (MockKES 7))               "MockKES"
   , testKESAlgorithm (Proxy :: Proxy (SimpleKES Ed448DSIGN 7))  "SimpleKES"
+  , testKESAlgorithm (Proxy :: Proxy (SingleKES Ed25519DSIGN))  "SingleKES"
+  , testKESAlgorithm (Proxy :: Proxy (Sum1KES Ed25519DSIGN Blake2b_256)) "Sum1KES"
+  , testKESAlgorithm (Proxy :: Proxy (Sum2KES Ed25519DSIGN Blake2b_256)) "Sum2KES"
+  , testKESAlgorithm (Proxy :: Proxy (Sum5KES Ed25519DSIGN Blake2b_256)) "Sum5KES"
   ]
 
 -- We normally ensure that we avoid naively comparing signing keys by not
 -- providing instances, but for tests it is fine, so we provide the orphan
 -- instance here.
 deriving instance Eq (SignKeyDSIGN d) => Eq (SignKeyKES (SimpleKES d t))
+
+deriving instance Eq (SignKeyDSIGN d)
+               => Eq (SignKeyKES (SingleKES d))
+deriving instance (KESAlgorithm d, Eq (SignKeyKES d))
+               => Eq (SignKeyKES (SumKES h d))
 
 testKESAlgorithm
   :: forall v proxy.

--- a/cardano-crypto-class/test/Test/Crypto/KES.hs
+++ b/cardano-crypto-class/test/Test/Crypto/KES.hs
@@ -24,8 +24,8 @@ import Cardano.Crypto.KES
 import qualified Cardano.Crypto.KES as KES
 
 import Test.QuickCheck
-import Test.Tasty (TestTree, testGroup)
-import Test.Tasty.QuickCheck (testProperty)
+import Test.Tasty (TestTree, testGroup, adjustOption)
+import Test.Tasty.QuickCheck (testProperty, QuickCheckMaxSize(..))
 
 import Test.Crypto.Util hiding (label)
 
@@ -36,8 +36,8 @@ import Test.Crypto.Util hiding (label)
 tests :: TestTree
 tests =
   testGroup "Crypto.KES"
-  [ testKESAlgorithm (Proxy :: Proxy (MockKES 42))              "MockKES"
-  , testKESAlgorithm (Proxy :: Proxy (SimpleKES Ed448DSIGN 42)) "SimpleKES (with Ed448)"
+  [ testKESAlgorithm (Proxy :: Proxy (MockKES 7))               "MockKES"
+  , testKESAlgorithm (Proxy :: Proxy (SimpleKES Ed448DSIGN 7))  "SimpleKES"
   ]
 
 -- We normally ensure that we avoid naively comparing signing keys by not
@@ -123,7 +123,8 @@ testKESAlgorithm _p n =
       [ testProperty "positive"           $ prop_verifyKES_positive         @v @Int
       , testProperty "negative (key)"     $ prop_verifyKES_negative_key     @v @Int
       , testProperty "negative (message)" $ prop_verifyKES_negative_message @v @Int
-      , testProperty "negative (period)"  $ prop_verifyKES_negative_period  @v @Int
+      , adjustOption (\(QuickCheckMaxSize sz) -> QuickCheckMaxSize (min sz 50)) $
+        testProperty "negative (period)"  $ prop_verifyKES_negative_period  @v @Int
       ]
 
     , testGroup "serialisation of all KES evolutions"

--- a/cardano-crypto-class/test/Test/Crypto/KES.hs
+++ b/cardano-crypto-class/test/Test/Crypto/KES.hs
@@ -8,7 +8,7 @@
 {-# LANGUAGE TypeApplications     #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-{-# OPTIONS_GHC -fno-warn-orphans #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
 
 module Test.Crypto.KES
   ( tests
@@ -242,8 +242,9 @@ prop_verifyKES_negative_message sk_0 x x' =
             ]
 
 -- | If we sign a message @a@ with one list of signing key evolutions, if we
--- try to verify the signature (and message @a@) using a verification key
--- corresponding to a different key period, then the verification fails.
+-- try to verify the signature (and message @a@) using the right verification
+-- key but at a different period than the key used for signing, then the
+-- verification fails.
 --
 prop_verifyKES_negative_period
   :: forall v a.

--- a/cardano-crypto-class/test/Test/Crypto/KES.hs
+++ b/cardano-crypto-class/test/Test/Crypto/KES.hs
@@ -17,7 +17,6 @@ where
 
 import Data.Proxy (Proxy(..))
 import Data.List (unfoldr)
-import Numeric.Natural (Natural)
 
 import Cardano.Binary (FromCBOR, ToCBOR(..))
 import Cardano.Crypto.DSIGN
@@ -298,8 +297,8 @@ allUpdatesKES :: forall v. (KESAlgorithm v, ContextKES v ~ ())
 allUpdatesKES sk_0 =
     sk_0 : unfoldr update (sk_0, 0)
   where
-    update :: (SignKeyKES v, Natural)
-           -> Maybe (SignKeyKES v, (SignKeyKES v, Natural))
+    update :: (SignKeyKES v, Period)
+           -> Maybe (SignKeyKES v, (SignKeyKES v, Period))
     update (sk, n) =
       case updateKES () sk (n+1) of
         Nothing  -> Nothing

--- a/cardano-crypto-class/test/Test/Crypto/KES.hs
+++ b/cardano-crypto-class/test/Test/Crypto/KES.hs
@@ -259,13 +259,15 @@ prop_serialise_VerKeyKES
   => SignKeyKES v -> Property
 prop_serialise_VerKeyKES sk_0 =
     conjoin
-      [    prop_raw_serialise rawSerialiseVerKeyKES
+      [ counterexample ("period " ++ show (t :: Int)) $
+        counterexample ("vkey " ++ show vk) $
+           prop_raw_serialise rawSerialiseVerKeyKES
                               rawDeserialiseVerKeyKES vk
        .&. prop_cbor_with encodeVerKeyKES
                           decodeVerKeyKES vk
        .&. prop_size_serialise rawSerialiseVerKeyKES
                                (sizeVerKeyKES (Proxy @ v)) vk
-      | vk <- map deriveVerKeyKES (allUpdatesKES sk_0) ]
+      | (t, vk) <- zip [0..] (map deriveVerKeyKES (allUpdatesKES sk_0)) ]
 
 
 -- | Check 'prop_raw_serialise', 'prop_cbor_with' and 'prop_size_serialise'
@@ -277,13 +279,15 @@ prop_serialise_SignKeyKES
   => SignKeyKES v -> Property
 prop_serialise_SignKeyKES sk_0 =
     conjoin
-      [    prop_raw_serialise rawSerialiseSignKeyKES
+      [ counterexample ("period " ++ show (t :: Int)) $
+        counterexample ("skey " ++ show sk) $
+           prop_raw_serialise rawSerialiseSignKeyKES
                               rawDeserialiseSignKeyKES sk
        .&. prop_cbor_with encodeSignKeyKES
                           decodeSignKeyKES sk
        .&. prop_size_serialise rawSerialiseSignKeyKES
                                (sizeSignKeyKES (Proxy @ v)) sk
-      | sk <- allUpdatesKES sk_0 ]
+      | (t, sk) <- zip [0..] (allUpdatesKES sk_0) ]
 
 
 -- | Check 'prop_raw_serialise', 'prop_cbor_with' and 'prop_size_serialise'
@@ -295,7 +299,10 @@ prop_serialise_SigKES
   => SignKeyKES v -> a -> Property
 prop_serialise_SigKES sk_0 x =
     conjoin
-      [    prop_raw_serialise rawSerialiseSigKES
+      [ counterexample ("period " ++ show t) $
+        counterexample ("vkey "   ++ show sk) $
+        counterexample ("sig "    ++ show sig) $
+           prop_raw_serialise rawSerialiseSigKES
                               rawDeserialiseSigKES sig
        .&. prop_cbor_with encodeSigKES
                           decodeSigKES sig
@@ -317,10 +324,10 @@ allUpdatesKES sk_0 =
   where
     update :: (SignKeyKES v, Period)
            -> Maybe (SignKeyKES v, (SignKeyKES v, Period))
-    update (sk, n) =
-      case updateKES () sk (n+1) of
+    update (sk, t) =
+      case updateKES () sk t of
         Nothing  -> Nothing
-        Just sk' -> Just (sk', (sk', n+1))
+        Just sk' -> Just (sk', (sk', t+1))
 
 
 --

--- a/cardano-crypto-class/test/Test/Crypto/KES.hs
+++ b/cardano-crypto-class/test/Test/Crypto/KES.hs
@@ -176,7 +176,7 @@ prop_verifyKES_positive sk_0 xs =
               verifyKES () vk t x sig === Right ()
             | let vk = deriveVerKeyKES sk_0
             , (t, x, sk) <- zip3 [0..] xs (allUpdatesKES sk_0)
-            , let Just sig = signKES () t x sk
+            , let sig = signKES () t x sk
             ]
   where
     totalPeriods :: Int
@@ -198,7 +198,7 @@ prop_verifyKES_negative_key sk_0 sk'_0 x =
             | let sks = allUpdatesKES sk_0
                   vk' = deriveVerKeyKES sk'_0
             , (t, sk) <- zip [0..] sks
-            , let Just sig = signKES () t x sk
+            , let sig = signKES () t x sk
             ]
 
 -- | If we sign a message @a@ with one list of signing key evolutions, if we
@@ -216,7 +216,7 @@ prop_verifyKES_negative_message sk_0 x x' =
             | let sks = allUpdatesKES sk_0
                   vk  = deriveVerKeyKES sk_0
             , (t, sk) <- zip [0..] sks
-            , let Just sig = signKES () t x sk
+            , let sig = signKES () t x sk
             ]
 
 -- | If we sign a message @a@ with one list of signing key evolutions, if we
@@ -233,7 +233,7 @@ prop_verifyKES_negative_period sk_0 x =
             | let sks = allUpdatesKES sk_0
                   vk  = deriveVerKeyKES sk_0
             , (t, sk) <- zip [0..] sks
-            , let Just sig = signKES () t x sk
+            , let sig = signKES () t x sk
             , (t', _) <- zip [0..] sks
             , t /= t'
             ]
@@ -285,7 +285,7 @@ prop_serialise_SigKES sk_0 x =
        .&. prop_cbor_with encodeSigKES
                           decodeSigKES sig
       | (t, sk) <- zip [0..] (allUpdatesKES sk_0)
-      , let Just sig = signKES () t x sk
+      , let sig = signKES () t x sk
       ]
 
 
@@ -325,6 +325,6 @@ instance (KES.Signable v Int, KESAlgorithm v, ContextKES v ~ ())
   arbitrary = do
     a <- arbitrary :: Gen Int
     sk <- arbitrary
-    let Just sig = signKES () 0 a sk
+    let sig = signKES () 0 a sk
     return sig
   shrink = const []

--- a/cardano-crypto-class/test/Test/Crypto/KES.hs
+++ b/cardano-crypto-class/test/Test/Crypto/KES.hs
@@ -41,8 +41,7 @@ tests =
 -- We normally ensure that we avoid naively comparing signing keys by not
 -- providing instances, but for tests it is fine, so we provide the orphan
 -- instance here.
-deriving instance (DSIGNAlgorithm d, Eq (SignKeyDSIGN d))
-               => Eq (SignKeyKES (SimpleKES d t))
+deriving instance Eq (SignKeyDSIGN d) => Eq (SignKeyKES (SimpleKES d t))
 
 testKESAlgorithm
   :: forall v proxy.

--- a/cardano-crypto-class/test/Test/Crypto/Util.hs
+++ b/cardano-crypto-class/test/Test/Crypto/Util.hs
@@ -21,11 +21,6 @@ module Test.Crypto.Util
 
     -- * Seeds
   , arbitrarySeedOfSize
-
-  , -- * Natural Numbers
-    genNat
-  , genNatBetween
-  , shrinkNat
   )
 where
 
@@ -43,17 +38,14 @@ import Crypto.Random
   )
 import Data.ByteString as BS (ByteString, pack)
 import Data.Word (Word64)
-import Numeric.Natural (Natural)
 import Test.QuickCheck
   ( (.&&.)
   , (===)
   , Arbitrary
   , Gen
-  , NonNegative (..)
   , Property
   , arbitrary
   , arbitraryBoundedIntegral
-  , choose
   , counterexample
   , property
   , shrink
@@ -96,7 +88,7 @@ instance Arbitrary TestSeed where
 -- Seeds
 --------------------------------------------------------------------------------
 
-arbitrarySeedOfSize :: Natural -> Gen Seed
+arbitrarySeedOfSize :: Word -> Gen Seed
 arbitrarySeedOfSize sz =
   (mkSeedFromBytes . BS.pack) <$> vector (fromIntegral sz)
 
@@ -159,19 +151,3 @@ prop_cbor_direct_vs_class :: ToCBOR a
 prop_cbor_direct_vs_class encoder x =
   toFlatTerm (encoder x) === toFlatTerm (toCBOR x)
 
-
---------------------------------------------------------------------------------
--- Natural numbers
---------------------------------------------------------------------------------
-genNatBetween :: Natural -> Natural -> Gen Natural
-genNatBetween from to = do
-  i <- choose (toInteger from, toInteger to)
-  return $ fromIntegral i
-
-genNat :: Gen Natural
-genNat = do
-  NonNegative i <- arbitrary :: Gen (NonNegative Integer)
-  return $ fromIntegral i
-
-shrinkNat :: Natural -> [Natural]
-shrinkNat = map fromIntegral . shrink . toInteger

--- a/cardano-crypto-class/test/Test/Crypto/Util.hs
+++ b/cardano-crypto-class/test/Test/Crypto/Util.hs
@@ -74,12 +74,7 @@ nullTestSeed = TestSeed (0, 0, 0, 0, 0)
 
 instance Arbitrary TestSeed where
   arbitrary =
-    (\w1 w2 w3 w4 w5 -> TestSeed (w1, w2, w3, w4, w5)) <$>
-      gen <*>
-      gen <*>
-      gen <*>
-      gen <*>
-      gen
+      TestSeed <$> ((,,,,) <$> gen <*> gen <*> gen <*> gen <*> gen)
     where
       gen :: Gen Word64
       gen = arbitraryBoundedIntegral

--- a/cardano-crypto-class/test/Test/Crypto/Util.hs
+++ b/cardano-crypto-class/test/Test/Crypto/Util.hs
@@ -11,6 +11,7 @@ module Test.Crypto.Util
   , prop_cbor_valid
   , prop_cbor_roundtrip
   , prop_raw_serialise
+  , prop_size_serialise
   , prop_cbor_direct_vs_class
 
     -- * Test Seed
@@ -36,7 +37,7 @@ import Crypto.Random
   , drgNewTest
   , withDRG
   )
-import Data.ByteString as BS (ByteString, pack)
+import Data.ByteString as BS (ByteString, pack, length)
 import Data.Word (Word64)
 import Test.QuickCheck
   ( (.&&.)
@@ -150,4 +151,9 @@ prop_cbor_direct_vs_class :: ToCBOR a
                           -> a -> Property
 prop_cbor_direct_vs_class encoder x =
   toFlatTerm (encoder x) === toFlatTerm (toCBOR x)
+
+
+prop_size_serialise :: (a -> ByteString) -> Word -> a -> Property
+prop_size_serialise serialise size x =
+    BS.length (serialise x) === fromIntegral size
 

--- a/cardano-crypto-class/test/Test/Crypto/VRF.hs
+++ b/cardano-crypto-class/test/Test/Crypto/VRF.hs
@@ -59,6 +59,18 @@ testVRFAlgorithm _ n =
                                                       rawDeserialiseCertVRF
         ]
 
+      , testGroup "size"
+        [ testProperty "VerKey"  $ prop_size_serialise @(VerKeyVRF v)
+                                                       rawSerialiseVerKeyVRF
+                                                       (sizeVerKeyVRF (Proxy @ v))
+        , testProperty "SignKey" $ prop_size_serialise @(SignKeyVRF v)
+                                                       rawSerialiseSignKeyVRF
+                                                       (sizeSignKeyVRF (Proxy @ v))
+        , testProperty "Cert"    $ prop_size_serialise @(CertVRF v)
+                                                       rawSerialiseCertVRF
+                                                       (sizeCertVRF (Proxy @ v))
+        ]
+
       , testGroup "direct CBOR"
         [ testProperty "VerKey"  $ prop_cbor_with @(VerKeyVRF v)
                                                   encodeVerKeyVRF


### PR DESCRIPTION
A number of tweaks to the KES API and its instances:
* Significantly simplify the "simple" KES instance, to loosen constraints and allow for subsequent API changes
* Rewrite the KES tests to make them comprehensible, and shorter
* Remove `currentPeriodKES`. This follows the MMM paper design where the KES functions take the period as an argument rather than remembering the current period. So go all the way and remove it.
* Make `signKES` not return a `Maybe` result.
* Use `Word` rather than `Natural` in various places in the API
* Change the interface for `updateKES` so it takes the _current_ KES period, not the target. This follows the pattern from the MMM paper.
* Add a recursive KES sum construction from the MMM paper. This demonstrates that the KES API is complete in some sense since it can actually be used recursively.

Other bundled changes:
* add `sizeHash` in the `Hash` class, replacing the badly named `byteCount`
* Make all serialised representations fixed size, and test this. This is for DSIGN, KES and VRF.
* Simplify the CBOR encode/decode functions by doing them in terms of the fixed-size serialisation functions. Again for DSIGN, KES and VRF.
