### PR TITLE
HasCallStack in EpochInfo

### DIFF
--- a/slotting/src/Cardano/Slotting/EpochInfo/Impl.hs
+++ b/slotting/src/Cardano/Slotting/EpochInfo/Impl.hs
@@ -11,10 +11,10 @@ import Cardano.Slotting.Slot (EpochNo (..), EpochSize (..), SlotNo (..))
 
 fixedSizeEpochInfo :: Monad m => EpochSize -> EpochInfo m
 fixedSizeEpochInfo (EpochSize size) = EpochInfo
-  { epochInfoSize = \_ ->
+  { epochInfoSize_ = \_ ->
       return $ EpochSize size,
-    epochInfoFirst = \(EpochNo epochNo) ->
+    epochInfoFirst_ = \(EpochNo epochNo) ->
       return $ SlotNo (epochNo * size),
-    epochInfoEpoch = \(SlotNo slot) ->
+    epochInfoEpoch_ = \(SlotNo slot) ->
       return $ EpochNo (slot `div` size)
   }


### PR DESCRIPTION
This is important, because the EpochInfo required by the Shelley ledger is
`EpochInfo Identity`, but that is really not possible, the `EpochInfo` we will
feed it has a limited range (and must do). We should fix Shelley, but until
such time, having the callstack available makes debugging a lot easier.