### PR TITLE
 Make OutputVRF a newtype and provide Natural conversions 

### DIFF
--- a/cardano-crypto-class/cardano-crypto-class.cabal
+++ b/cardano-crypto-class/cardano-crypto-class.cabal
@@ -66,6 +66,7 @@ library
                      , cardano-prelude
                      , cryptonite
                      , deepseq
+                     , integer-gmp
                      , memory
                      , text
                      , transformers

--- a/cardano-crypto-class/src/Cardano/Crypto/VRF/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/VRF/Class.hs
@@ -14,8 +14,11 @@ module Cardano.Crypto.VRF.Class
   (
     -- * VRF algorithm class
     VRFAlgorithm (..)
+
+    -- ** VRF output
   , OutputVRF(..)
   , getOutputVRFNatural
+  , mkTestOutputVRF
 
     -- * 'CertifiedVRF' wrapper
   , CertifiedVRF (..)
@@ -56,7 +59,7 @@ import Cardano.Binary
 
 import Crypto.Random (MonadRandom)
 
-import Cardano.Crypto.Util (Empty, bytesToNatural)
+import Cardano.Crypto.Util (Empty, bytesToNatural, naturalToBytes)
 import Cardano.Crypto.Seed (Seed)
 import Cardano.Crypto.Hash.Class (HashAlgorithm, Hash, hashRaw)
 
@@ -192,6 +195,14 @@ newtype OutputVRF v = OutputVRF { getOutputVRFBytes :: ByteString }
 getOutputVRFNatural :: OutputVRF v -> Natural
 getOutputVRFNatural = bytesToNatural . getOutputVRFBytes
 
+-- | For testing purposes, make an 'OutputVRF' from a 'Natural'.
+--
+-- The 'OutputVRF' will be of the appropriate size for the 'VRFAlgorithm'.
+--
+mkTestOutputVRF :: forall v. VRFAlgorithm v => Natural -> OutputVRF v
+mkTestOutputVRF = OutputVRF . naturalToBytes sz
+  where
+    sz = fromIntegral (sizeOutputVRF (Proxy :: Proxy v))
 
 --
 -- Convenient CBOR encoding/decoding

--- a/cardano-crypto-class/src/Cardano/Crypto/VRF/Mock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/VRF/Mock.hs
@@ -131,7 +131,10 @@ instance FromCBOR (CertVRF MockVRF) where
   fromCBOR = decodeCertVRF
 
 
-evalVRF' :: ToCBOR a => a -> SignKeyVRF MockVRF -> (ByteString, CertVRF MockVRF)
+evalVRF' :: ToCBOR a
+         => a
+         -> SignKeyVRF MockVRF
+         -> (OutputVRF MockVRF, CertVRF MockVRF)
 evalVRF' a sk@(SignKeyMockVRF n) =
   let y = getHash $ hashWithSerialiser @MD5 id $ toCBOR a <> toCBOR sk
-  in (y, CertMockVRF n)
+  in (OutputVRF y, CertMockVRF n)

--- a/cardano-crypto-class/src/Cardano/Crypto/VRF/Simple.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/VRF/Simple.hs
@@ -169,9 +169,9 @@ instance VRFAlgorithm SimpleVRF where
     r <- getR
     let c = h $ toCBOR a <> toCBOR v <> toCBOR (pow r) <> toCBOR (h' (toCBOR a) r)
         s = mod (r + k * fromIntegral (bsToNat c)) q
-    return (y, CertSimpleVRF u (bsToNat c) s)
+    return (OutputVRF y, CertSimpleVRF u (bsToNat c) s)
 
-  verifyVRF () (VerKeySimpleVRF v) a (y, cert) =
+  verifyVRF () (VerKeySimpleVRF v) a (OutputVRF y, cert) =
     let u = certU cert
         c = certC cert
         c' = -fromIntegral c

--- a/cardano-crypto-praos/src/Cardano/Crypto/VRF/Praos.hs
+++ b/cardano-crypto-praos/src/Cardano/Crypto/VRF/Praos.hs
@@ -439,7 +439,7 @@ instance VRFAlgorithm PraosVRF where
   verifyVRF = \_ (VerKeyPraosVRF pk) msg (_, CertPraosVRF proof) ->
     isJust $! verify pk proof (serialize' msg)
 
-  sizeOutputVRF _ = fromIntegral crypto_vrf_proofbytes
+  sizeOutputVRF _ = fromIntegral crypto_vrf_outputbytes
   seedSizeVRF _ = fromIntegral crypto_vrf_seedbytes
 
   genKeyPairVRF = \cryptoseed ->

--- a/cardano-crypto-praos/src/Cardano/Crypto/VRF/Praos.hs
+++ b/cardano-crypto-praos/src/Cardano/Crypto/VRF/Praos.hs
@@ -433,7 +433,8 @@ instance VRFAlgorithm PraosVRF where
     let msgBS = serialize' msg
     proof <- maybe (error "Invalid Key") pure $ prove sk msgBS
     output <- maybe (error "Invalid Proof") pure $ outputFromProof proof
-    return $ output `seq` proof `seq` (outputBytes output, CertPraosVRF proof)
+    return $ output `seq` proof `seq`
+             (OutputVRF (outputBytes output), CertPraosVRF proof)
 
   verifyVRF = \_ (VerKeyPraosVRF pk) msg (_, CertPraosVRF proof) ->
     isJust $! verify pk proof (serialize' msg)

--- a/cardano-crypto-tests/src/Test/Crypto/VRF.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/VRF.hs
@@ -129,7 +129,8 @@ testVRFAlgorithm _ n =
       ]
 
     , testGroup "output"
-      [ testProperty "mkTestOutputVRF" $ prop_vrf_output_natural @Int @v
+      [ testProperty "sizeOutputVRF"   $ prop_vrf_output_size    @Int @v
+      , testProperty "mkTestOutputVRF" $ prop_vrf_output_natural @Int @v
       ]
 
     , testGroup "NoUnexpectedThunks"
@@ -163,6 +164,18 @@ prop_vrf_verify_neg seed a sk sk' =
     let (y, c) = withTestSeed seed $ evalVRF () a sk'
         vk = deriveVerKeyVRF sk
     in not $ verifyVRF () vk a (y, c)
+
+
+prop_vrf_output_size
+  :: forall a v. (Signable v a, VRFAlgorithm v, ContextVRF v ~ ())
+  => TestSeed
+  -> a
+  -> SignKeyVRF v
+  -> Property
+prop_vrf_output_size seed a sk =
+  let (out, _c) = withTestSeed seed $ evalVRF () a sk
+   in     BS.length (getOutputVRFBytes out)
+      === fromIntegral (sizeOutputVRF (Proxy :: Proxy v))
 
 prop_vrf_output_natural
   :: forall a v. (Signable v a, VRFAlgorithm v, ContextVRF v ~ ())


### PR DESCRIPTION
OutputVRF contains bytes. Previously it was a type alias for ByteString.
This makes it a proper newtype (with a phantom type param to match the
type of key, etc).

We provide an access function for getting the VRF bytes, and a
conversion into Natural, since we need that for our use cases.

We also provide a way to make test output values from a Natural.