### PR TITLE
Change genKeyKES to take MLockedFiniteBytes (SeedSizeKES v)

### DIFF
--- a/cardano-crypto-class/cardano-crypto-class.cabal
+++ b/cardano-crypto-class/cardano-crypto-class.cabal
@@ -64,8 +64,8 @@ library
                        Cardano.Crypto.Libsodium.Init
                        Cardano.Crypto.Libsodium.Memory
                        Cardano.Crypto.Libsodium.Memory.Internal
-                       Cardano.Crypto.Libsodium.SecureBytes
-                       Cardano.Crypto.Libsodium.SecureBytes.Internal
+                       Cardano.Crypto.Libsodium.MLockedBytes
+                       Cardano.Crypto.Libsodium.MLockedBytes.Internal
                        Cardano.Crypto.Libsodium.UnsafeC
 
   build-depends:       aeson

--- a/cardano-crypto-class/cardano-crypto-class.cabal
+++ b/cardano-crypto-class/cardano-crypto-class.cabal
@@ -48,6 +48,7 @@ library
                        Cardano.Crypto.KES.Single
                        Cardano.Crypto.KES.Sum
 
+                       Cardano.Crypto.FiniteBytes
                        Cardano.Crypto.Seed
                        Cardano.Crypto.Util
 
@@ -67,7 +68,9 @@ library
                      , cryptonite
                      , deepseq
                      , integer-gmp
+                     , ghc-prim
                      , memory
+                     , primitive
                      , text
                      , transformers
                      , vector

--- a/cardano-crypto-class/cardano-crypto-class.cabal
+++ b/cardano-crypto-class/cardano-crypto-class.cabal
@@ -58,6 +58,15 @@ library
                        Cardano.Crypto.VRF.Simple
 
                        Cardano.Crypto.Libsodium
+                       Cardano.Crypto.Libsodium.C
+                       Cardano.Crypto.Libsodium.Constants
+                       Cardano.Crypto.Libsodium.Hash
+                       Cardano.Crypto.Libsodium.Init
+                       Cardano.Crypto.Libsodium.Memory
+                       Cardano.Crypto.Libsodium.Memory.Internal
+                       Cardano.Crypto.Libsodium.SecureBytes
+                       Cardano.Crypto.Libsodium.SecureBytes.Internal
+                       Cardano.Crypto.Libsodium.UnsafeC
 
   build-depends:       aeson
                      , base
@@ -95,6 +104,7 @@ test-suite test-memory-example
   main-is:             Main.hs
 
   build-depends:       base
+                     , bytestring
                      , cardano-crypto-class
 
   if os(linux) || os(osx)

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Class.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -5,6 +6,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeApplications #-}
 
 -- | Abstract digital signatures.
 module Cardano.Crypto.DSIGN.Class
@@ -27,7 +29,7 @@ module Cardano.Crypto.DSIGN.Class
   , decodeSigDSIGN
   , encodeSignedDSIGN
   , decodeSignedDSIGN
-  
+
     -- * Encoded 'Size' expresssions
   , encodedVerKeyDSIGNSizeExpr
   , encodedSignKeyDESIGNSizeExpr
@@ -43,6 +45,7 @@ import Data.Typeable (Typeable)
 import GHC.Exts (Constraint)
 import GHC.Generics (Generic)
 import GHC.Stack
+import GHC.TypeLits (KnownNat, Nat, natVal)
 
 import Cardano.Prelude (NoUnexpectedThunks)
 import Cardano.Binary (Decoder, decodeBytes, Encoding, encodeBytes, Size, withWordSize)
@@ -62,9 +65,11 @@ class ( Typeable v
       , NoUnexpectedThunks (SigDSIGN     v)
       , NoUnexpectedThunks (SignKeyDSIGN v)
       , NoUnexpectedThunks (VerKeyDSIGN  v)
+      , KnownNat (SeedSizeDSIGN v)
       )
       => DSIGNAlgorithm v where
 
+  type SeedSizeDSIGN v :: Nat
 
   --
   -- Key and signature types
@@ -124,6 +129,7 @@ class ( Typeable v
 
   -- | The upper bound on the 'Seed' size needed by 'genKeyDSIGN'
   seedSizeDSIGN :: proxy v -> Word
+  seedSizeDSIGN _ = fromInteger (natVal (Proxy @(SeedSizeDSIGN v)))
 
 
   --

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed25519.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed25519.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
@@ -32,6 +33,7 @@ import Cardano.Crypto.Seed
 data Ed25519DSIGN
 
 instance DSIGNAlgorithm Ed25519DSIGN where
+    type SeedSizeDSIGN Ed25519DSIGN = 32
 
     --
     -- Key and signature types
@@ -80,7 +82,6 @@ instance DSIGNAlgorithm Ed25519DSIGN where
     -- Key generation
     --
 
-    seedSizeDSIGN _  = 32
     genKeyDSIGN seed =
         let sk = runMonadRandomWithSeed seed Ed25519.generateSecretKey
          in SignKeyEd25519DSIGN sk

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed448.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed448.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE DerivingVia #-}
@@ -32,6 +33,7 @@ import Cardano.Crypto.Seed
 data Ed448DSIGN
 
 instance DSIGNAlgorithm Ed448DSIGN where
+    type SeedSizeDSIGN Ed448DSIGN = 57
 
     --
     -- Key and signature types
@@ -80,7 +82,6 @@ instance DSIGNAlgorithm Ed448DSIGN where
     -- Key generation
     --
 
-    seedSizeDSIGN _  = 57
     genKeyDSIGN seed =
         let sk = runMonadRandomWithSeed seed Ed448.generateSecretKey
          in SignKeyEd448DSIGN sk

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Mock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Mock.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
@@ -36,6 +37,7 @@ import Cardano.Crypto.Util
 data MockDSIGN
 
 instance DSIGNAlgorithm MockDSIGN where
+    type SeedSizeDSIGN MockDSIGN = 8
 
     --
     -- Key and signature types
@@ -82,7 +84,6 @@ instance DSIGNAlgorithm MockDSIGN where
     -- Key generation
     --
 
-    seedSizeDSIGN _    = 8
     genKeyDSIGN seed   =
       SignKeyMockDSIGN (runMonadRandomWithSeed seed getRandomWord64)
 

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/NeverUsed.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/NeverUsed.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -24,6 +25,7 @@ import Cardano.Crypto.DSIGN.Class
 data NeverDSIGN
 
 instance DSIGNAlgorithm NeverDSIGN where
+  type SeedSizeDSIGN NeverDSIGN = 0
 
   data VerKeyDSIGN  NeverDSIGN = NeverUsedVerKeyDSIGN
      deriving (Show, Eq, Ord, Generic, NoUnexpectedThunks)
@@ -45,7 +47,6 @@ instance DSIGNAlgorithm NeverDSIGN where
   signDSIGN   = error "DSIGN not available"
   verifyDSIGN = error "DSIGN not available"
 
-  seedSizeDSIGN     _ = 0
   genKeyDSIGN       _ = NeverUsedSignKeyDSIGN
 
   rawSerialiseVerKeyDSIGN  _ = mempty

--- a/cardano-crypto-class/src/Cardano/Crypto/FiniteBytes.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/FiniteBytes.hs
@@ -1,0 +1,113 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE KindSignatures      #-}
+{-# LANGUAGE MagicHash           #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE UnboxedTuples       #-}
+module Cardano.Crypto.FiniteBytes
+  (
+    FiniteBytes,
+    -- * Conversions
+    fromBytes,
+    toBytes,
+  ) where
+
+
+import Control.Monad.Primitive  (primitive_)
+import Data.Char (ord)
+import Data.Primitive.ByteArray (ByteArray (..), MutableByteArray (..), byteArrayFromListN, copyByteArrayToAddr, newByteArray, unsafeFreezeByteArray, foldrByteArray)
+import Data.Proxy (Proxy (..))
+import Data.String (IsString (..))
+import Data.Word (Word8)
+import Foreign.Ptr (FunPtr, castPtr)
+import Foreign.Storable (Storable (..))
+import GHC.TypeLits (KnownNat, Nat, natVal)
+import Numeric (showHex)
+
+import GHC.Exts (Int (..))
+import GHC.Prim (copyAddrToByteArray#)
+import GHC.Ptr (Ptr (..))
+
+-- $setup
+-- >>> :set -XDataKinds -XTypeApplications -XOverloadedStrings
+-- >>> import Cardano.Crypto.FiniteBytes
+
+-- | @n@ bytes. 'Storable'.
+data FiniteBytes (n :: Nat) = FiniteBytes ByteArray
+
+instance Show (FiniteBytes n) where
+    showsPrec _ (FiniteBytes ba)
+        = showChar '"'
+        . foldrByteArray (\w acc -> show8 w . acc) id ba
+        . showChar '"'
+      where
+        show8 :: Word8 -> ShowS
+        show8 w | w < 16    = showChar '0' . showHex w
+                | otherwise = showHex w
+
+-- |
+--
+-- If given 'String' is too long, it is truncated,
+-- If it is too short, it is padded with zeros.
+--
+-- Padding and truncation make it behave like an integer mod @n*8@.
+--
+-- >>> "abcdef" :: FiniteBytes 4
+-- "63646566"
+--
+-- >>> "foo" :: FiniteBytes 8
+-- "0000000000666f6f"
+--
+-- Non-ASCII codepoints are silently truncated to 0..255 range.
+--
+-- >>> "\x1234\x5678" :: FiniteBytes 2
+-- "3478"
+--
+-- 'FiniteBytes' created with 'fromString' contains /unpinned/
+-- 'ByteArray'.
+--
+instance KnownNat n => IsString (FiniteBytes n) where
+    fromString s = fromBytes (map (fromIntegral . ord) s)
+
+-- | See 'fromBytes'.
+toBytes :: FiniteBytes n -> [Word8]
+toBytes (FiniteBytes ba) = foldrByteArray (:) [] ba
+
+-- | See @'IsString' ('FiniteBytes' n)@ instance.
+--
+-- >>> toBytes . (id @(FiniteBytes 4)) . fromBytes $ [1,2,3,4]
+-- [1,2,3,4]
+--
+-- >>> toBytes . (id @(FiniteBytes 4)) . fromBytes $ [1,2]
+-- [0,0,1,2]
+--
+-- >>> toBytes . (id @(FiniteBytes 4)) . fromBytes $ [1,2,3,4,5,6]
+-- [3,4,5,6]
+-- 
+fromBytes :: forall n. KnownNat n => [Word8] -> FiniteBytes n
+fromBytes ws0 = FiniteBytes (byteArrayFromListN size ws)
+  where
+    size :: Int
+    size = fromInteger (natVal (Proxy :: Proxy n))
+
+    ws :: [Word8]
+    ws = reverse
+        $ take size
+        $ (++ repeat 0)
+        $ reverse ws0
+
+instance KnownNat n => Storable (FiniteBytes n) where
+    sizeOf _          = fromInteger (natVal (Proxy :: Proxy n))
+    alignment _       = alignment (undefined :: FunPtr (Int -> Int))
+
+    peek (Ptr addr#) = do
+        let size :: Int
+            size = fromInteger (natVal (Proxy :: Proxy n))
+        marr@(MutableByteArray marr#) <- newByteArray size
+        primitive_ $ copyAddrToByteArray# addr# marr# 0# (case size of I# s -> s)
+        arr <- unsafeFreezeByteArray marr
+        return (FiniteBytes arr)
+
+    poke p (FiniteBytes arr) = do
+        let size :: Int
+            size = fromInteger (natVal (Proxy :: Proxy n))
+        copyByteArrayToAddr (castPtr p) arr 0 size

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Mock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Mock.hs
@@ -47,6 +47,7 @@ data MockKES (t :: Nat)
 -- keys. Mock KES is more suitable for a basic testnet, since it doesn't suffer
 -- from the performance implications of shuffling a giant list of keys around
 instance KnownNat t => KESAlgorithm (MockKES t) where
+    type SeedSizeKES (MockKES t) = 8
 
     --
     -- Key and signature types
@@ -113,9 +114,8 @@ instance KnownNat t => KESAlgorithm (MockKES t) where
     -- Key generation
     --
 
-    seedSizeKES _ = 8
     genKeyKES seed =
-        let vk = VerKeyMockKES (runMonadRandomWithSeed seed getRandomWord64)
+        let vk = VerKeyMockKES (runMonadRandomWithSeed (mlfbToSeed seed) getRandomWord64)
          in SignKeyMockKES vk 0
 
 

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/NeverUsed.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/NeverUsed.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -23,6 +24,7 @@ import Cardano.Prelude (NoUnexpectedThunks)
 data NeverKES
 
 instance KESAlgorithm NeverKES where
+  type SeedSizeKES NeverKES = 0
 
   data VerKeyKES  NeverKES = NeverUsedVerKeyKES
       deriving (Show, Eq, Ord, Generic, NoUnexpectedThunks)
@@ -43,7 +45,6 @@ instance KESAlgorithm NeverKES where
 
   totalPeriodsKES _ = 0
 
-  seedSizeKES     _ = 0
   genKeyKES       _ = NeverUsedSignKeyKES
 
   sizeVerKeyKES  _ = 0

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Simple.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Simple.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -36,6 +37,8 @@ import           Cardano.Crypto.KES.Class
 import           Cardano.Crypto.Seed
 import           Cardano.Crypto.Util
 
+import qualified GHC.TypeLits
+
 
 data SimpleKES d (t :: Nat)
 
@@ -60,9 +63,10 @@ pattern SignKeySimpleKES v <- ThunkySignKeySimpleKES v
 
 {-# COMPLETE SignKeySimpleKES #-}
 
-instance (DSIGNAlgorithm d, Typeable d, KnownNat t) =>
+instance (DSIGNAlgorithm d, Typeable d, KnownNat t, KnownNat (SeedSizeDSIGN d GHC.TypeLits.* t)) =>
          KESAlgorithm (SimpleKES d t) where
 
+    type SeedSizeKES (SimpleKES d t) = SeedSizeDSIGN d GHC.TypeLits.* t
 
     --
     -- Key and signature types
@@ -124,8 +128,9 @@ instance (DSIGNAlgorithm d, Typeable d, KnownNat t) =>
             duration = fromIntegral (natVal (Proxy @ t))
          in duration * seedSize
 
-    genKeyKES seed =
-        let seedSize = seedSizeDSIGN (Proxy :: Proxy d)
+    genKeyKES mlfb =
+        let seed     = mlfbToSeed mlfb
+            seedSize = seedSizeDSIGN (Proxy :: Proxy d)
             duration = fromIntegral (natVal (Proxy @ t))
             seeds    = take duration
                      . map mkSeedFromBytes
@@ -193,31 +198,31 @@ instance DSIGNAlgorithm d => NoUnexpectedThunks (SigKES     (SimpleKES d t))
 instance DSIGNAlgorithm d => NoUnexpectedThunks (SignKeyKES (SimpleKES d t))
 instance DSIGNAlgorithm d => NoUnexpectedThunks (VerKeyKES  (SimpleKES d t))
 
-instance (DSIGNAlgorithm d, Typeable d, KnownNat t)
+instance (DSIGNAlgorithm d, Typeable d, KnownNat t, KnownNat (SeedSizeDSIGN d GHC.TypeLits.* t))
       => ToCBOR (VerKeyKES (SimpleKES d t)) where
   toCBOR = encodeVerKeyKES
   encodedSizeExpr _size = encodedVerKeyKESSizeExpr
 
-instance (DSIGNAlgorithm d, Typeable d, KnownNat t)
+instance (DSIGNAlgorithm d, Typeable d, KnownNat t, KnownNat (SeedSizeDSIGN d GHC.TypeLits.* t))
       => FromCBOR (VerKeyKES (SimpleKES d t)) where
   fromCBOR = decodeVerKeyKES
 
 
-instance (DSIGNAlgorithm d, Typeable d, KnownNat t)
+instance (DSIGNAlgorithm d, Typeable d, KnownNat t, KnownNat (SeedSizeDSIGN d GHC.TypeLits.* t))
       => ToCBOR (SignKeyKES (SimpleKES d t)) where
   toCBOR = encodeSignKeyKES
   encodedSizeExpr _size = encodedSignKeyKESSizeExpr
 
-instance (DSIGNAlgorithm d, Typeable d, KnownNat t)
+instance (DSIGNAlgorithm d, Typeable d, KnownNat t, KnownNat (SeedSizeDSIGN d GHC.TypeLits.* t))
       => FromCBOR (SignKeyKES (SimpleKES d t)) where
   fromCBOR = decodeSignKeyKES
 
-instance (DSIGNAlgorithm d, Typeable d, KnownNat t)
+instance (DSIGNAlgorithm d, Typeable d, KnownNat t, KnownNat (SeedSizeDSIGN d GHC.TypeLits.* t))
       => ToCBOR (SigKES (SimpleKES d t)) where
   toCBOR = encodeSigKES
   encodedSizeExpr _size = encodedSigKESSizeExpr
 
-instance (DSIGNAlgorithm d, Typeable d, KnownNat t)
+instance (DSIGNAlgorithm d, Typeable d, KnownNat t, KnownNat (SeedSizeDSIGN d GHC.TypeLits.* t))
       => FromCBOR (SigKES (SimpleKES d t)) where
   fromCBOR = decodeSigKES
 

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Single.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Single.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -43,6 +44,7 @@ import Control.Exception (assert)
 import Cardano.Prelude (NoUnexpectedThunks)
 import Cardano.Binary (FromCBOR (..), ToCBOR (..))
 
+import Cardano.Crypto.Seed (mlfbToSeed)
 import Cardano.Crypto.Hash.Class
 import Cardano.Crypto.DSIGN.Class
 import qualified Cardano.Crypto.DSIGN as DSIGN
@@ -55,7 +57,7 @@ import Cardano.Crypto.KES.Class
 data SingleKES d
 
 instance (DSIGNAlgorithm d, Typeable d) => KESAlgorithm (SingleKES d) where
-
+    type SeedSizeKES (SingleKES d) = SeedSizeDSIGN d
 
     --
     -- Key and signature types
@@ -108,7 +110,7 @@ instance (DSIGNAlgorithm d, Typeable d) => KESAlgorithm (SingleKES d) where
     --
 
     seedSizeKES _ = seedSizeDSIGN (Proxy :: Proxy d)
-    genKeyKES seed = SignKeySingleKES (genKeyDSIGN seed)
+    genKeyKES seed = SignKeySingleKES (genKeyDSIGN (mlfbToSeed seed))
 
 
     --

--- a/cardano-crypto-class/src/Cardano/Crypto/Libsodium.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Libsodium.hs
@@ -1,25 +1,25 @@
 module Cardano.Crypto.Libsodium (
   -- * Initialization
   sodiumInit,
-  -- * Secure memory management
-  SecureForeignPtr,
-  withSecureForeignPtr,
-  allocSecureForeignPtr,
-  finalizeSecureForeignPtr,
-  traceSecureForeignPtr,
-  -- * Secure bytes
-  SecureFiniteBytes,
-  sfbFromByteString,
-  sfbToByteString,
+  -- * MLocked memory management
+  MLockedForeignPtr,
+  withMLockedForeignPtr,
+  allocMLockedForeignPtr,
+  finalizeMLockedForeignPtr,
+  traceMLockedForeignPtr,
+  -- * MLocked bytes
+  MLockedFiniteBytes,
+  mlfbFromByteString,
+  mlfbToByteString,
   -- * Hashing
   SodiumHashAlgorithm (..),
-  digestSecureStorable,
-  digestSecureFB,
-  digestSecureBS,
+  digestMLockedStorable,
+  digestMLockedFB,
+  digestMLockedBS,
   expandHash,
 ) where
 
 import Cardano.Crypto.Libsodium.Hash
 import Cardano.Crypto.Libsodium.Init
 import Cardano.Crypto.Libsodium.Memory
-import Cardano.Crypto.Libsodium.SecureBytes
+import Cardano.Crypto.Libsodium.MLockedBytes

--- a/cardano-crypto-class/src/Cardano/Crypto/Libsodium.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Libsodium.hs
@@ -1,103 +1,25 @@
-{-# LANGUAGE CApiFFI             #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-module Cardano.Crypto.Libsodium
-  ( -- * High level interface
-    sodiumInit
+module Cardano.Crypto.Libsodium (
+  -- * Initialization
+  sodiumInit,
+  -- * Secure memory management
+  SecureForeignPtr,
+  withSecureForeignPtr,
+  allocSecureForeignPtr,
+  finalizeSecureForeignPtr,
+  traceSecureForeignPtr,
+  -- * Secure bytes
+  SecureFiniteBytes,
+  sfbFromByteString,
+  sfbToByteString,
+  -- * Hashing
+  SodiumHashAlgorithm (..),
+  digestSecureStorable,
+  digestSecureFB,
+  digestSecureBS,
+  expandHash,
+) where
 
-  , allocSecureForeignPtr
-
-    -- * Low-level interface
-    -- ** Initialization
-  , c_sodium_init
-
-    -- ** Zeroing memory
-  , c_sodium_memzero
-
-    -- ** Guarded heap allocations
-  , c_sodium_malloc
-  , c_sodium_free_funptr
-  ) where
-
-import Control.Monad (when, unless)
-import Foreign.C.Error (errnoToIOError, getErrno)
-import Foreign.C.Types (CSize (..))
-import Foreign.ForeignPtr (ForeignPtr, newForeignPtr)
-import Foreign.Ptr (FunPtr, Ptr, nullPtr)
-import Foreign.Storable (Storable (alignment, sizeOf))
-import GHC.IO.Exception (ioException)
-
--------------------------------------------------------------------------------
--- Initialization
--------------------------------------------------------------------------------
-
--- @sodiumInit@ initializes the library and should be called before any other
--- function provided by Sodium. It is safe to call this function more than once
--- and from different threads -- subsequent calls won't have any effects.
---
--- <https://libsodium.gitbook.io/doc/usage>
-sodiumInit :: IO ()
-sodiumInit = do
-    res <- c_sodium_init
-    -- sodium_init() returns 0 on success, -1 on failure, and 1 if the library
-    -- had already been initialized.
-    unless (res == 0 || res == 1) $ fail "sodium_init failed"
-
--------------------------------------------------------------------------------
--- Acquiring memory
--------------------------------------------------------------------------------
-
--- | Allocate secure memory using 'c_sodium_malloc'.
---
--- <https://libsodium.gitbook.io/doc/memory_management>
---
-allocSecureForeignPtr :: Storable a => IO (ForeignPtr a)
-allocSecureForeignPtr = impl undefined where
-    impl :: forall b. Storable b => b -> IO (ForeignPtr b)
-    impl b = do
-        ptr <- c_sodium_malloc size
-        when (ptr == nullPtr) $ do
-            errno <- getErrno
-            ioException $ errnoToIOError "allocSecureForeingPtr: c_sodium_malloc" errno Nothing Nothing
-
-        newForeignPtr c_sodium_free_funptr ptr
-
-      where
-        size :: CSize
-        size = fromIntegral size''
-
-        size' :: Int
-        size' = sizeOf b
-
-        align :: Int
-        align = alignment b
-
-        size'' :: Int
-        size''
-            | m == 0    = size'
-            | otherwise = (q + 1) * align
-          where
-            (q,m) = size' `divMod` align
-
--------------------------------------------------------------------------------
--- Low-level c-bindings
--------------------------------------------------------------------------------
-
--- | @void sodium_init():@
---
--- <https://libsodium.gitbook.io/doc/usage>
-foreign import capi "sodium.h sodium_init"  c_sodium_init :: IO Int
-
--- | @void sodium_memzero(void * const pnt, const size_t len);@
---
--- <https://libsodium.gitbook.io/doc/memory_management#zeroing-memory>
-foreign import capi "sodium.h sodium_memzero" c_sodium_memzero :: Ptr a -> CSize -> IO ()
-
--- | @void *sodium_malloc(size_t size);@
---
--- <https://libsodium.gitbook.io/doc/memory_management>
-foreign import capi "sodium.h sodium_malloc" c_sodium_malloc :: CSize -> IO (Ptr a)
-
--- | @void sodium_free(void *ptr);@
---
--- <https://libsodium.gitbook.io/doc/memory_management>
-foreign import capi "sodium.h &sodium_free" c_sodium_free_funptr :: FunPtr (Ptr a -> IO ())
+import Cardano.Crypto.Libsodium.Hash
+import Cardano.Crypto.Libsodium.Init
+import Cardano.Crypto.Libsodium.Memory
+import Cardano.Crypto.Libsodium.SecureBytes

--- a/cardano-crypto-class/src/Cardano/Crypto/Libsodium/C.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Libsodium/C.hs
@@ -1,0 +1,129 @@
+{-# LANGUAGE CApiFFI             #-}
+{-# LANGUAGE DerivingStrategies  #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+module Cardano.Crypto.Libsodium.C (
+    -- * Initialization
+    c_sodium_init,
+    -- * Memory management
+    c_sodium_memzero,
+    c_sodium_malloc,
+    c_sodium_free,
+    c_sodium_free_funptr,
+    -- * Hashing
+    -- ** SHA256
+    c_crypto_hash_sha256,
+    CryptoSha256State,
+    c_crypto_hash_sha256_final,
+    c_crypto_hash_sha256_init,
+    c_crypto_hash_sha256_update,
+    -- ** Blake2b 256
+    c_crypto_generichash,
+    CryptoBlake2b256State,
+    c_crypto_generichash_final,
+    c_crypto_generichash_init,
+    c_crypto_generichash_update,
+    -- * Helpers
+    c_sodium_compare,
+    -- * Constants
+    CRYPTO_SHA256_BYTES,
+    CRYPTO_SHA512_BYTES,
+    CRYPTO_BLAKE2B_256_BYTES,
+    CRYPTO_SHA256_STATE_SIZE,
+    CRYPTO_SHA512_STATE_SIZE,
+    CRYPTO_BLAKE2B_256_STATE_SIZE,
+    ) where
+
+import Foreign.C.Types
+import Foreign.Ptr (FunPtr, Ptr)
+import Foreign.Storable (Storable)
+
+import Cardano.Crypto.Libsodium.Constants
+import Cardano.Crypto.FiniteBytes
+
+-------------------------------------------------------------------------------
+-- Initialization
+-------------------------------------------------------------------------------
+
+-- | @void sodium_init();@
+--
+-- <https://libsodium.gitbook.io/doc/usage>
+foreign import capi "sodium.h sodium_init"  c_sodium_init :: IO Int
+
+-------------------------------------------------------------------------------
+-- Memory management
+-------------------------------------------------------------------------------
+
+-- | @void sodium_memzero(void * const pnt, const size_t len);@
+--
+-- <https://libsodium.gitbook.io/doc/memory_management#zeroing-memory>
+foreign import capi "sodium.h sodium_memzero" c_sodium_memzero :: Ptr a -> CSize -> IO ()
+
+-- | @void *sodium_malloc(size_t size);@
+--
+-- <https://libsodium.gitbook.io/doc/memory_management>
+foreign import capi "sodium.h sodium_malloc" c_sodium_malloc :: CSize -> IO (Ptr a)
+--
+-- | @void sodium_free(void *ptr);@
+--
+-- <https://libsodium.gitbook.io/doc/memory_management>
+foreign import capi "sodium.h sodium_free" c_sodium_free :: Ptr a -> IO ()
+
+-- | @void sodium_free(void *ptr);@
+--
+-- <https://libsodium.gitbook.io/doc/memory_management>
+foreign import capi "sodium.h &sodium_free" c_sodium_free_funptr :: FunPtr (Ptr a -> IO ())
+
+-------------------------------------------------------------------------------
+-- Hashing: SHA256
+-------------------------------------------------------------------------------
+
+-- | @int crypto_hash_sha256(unsigned char *out, const unsigned char *in, unsigned long long inlen);@
+--
+-- <https://libsodium.gitbook.io/doc/advanced/sha-2_hash_function>
+foreign import capi "sodium.h crypto_hash_sha256" c_crypto_hash_sha256 :: Ptr (FiniteBytes CRYPTO_SHA256_BYTES) -> Ptr CUChar -> CULLong -> IO Int
+
+newtype CryptoSha256State = CryptoSha256State (FiniteBytes CRYPTO_SHA256_STATE_SIZE)
+  deriving newtype Storable
+
+-- | @int crypto_hash_sha256_init(crypto_hash_sha256_state *state);@
+foreign import capi "sodium.h crypto_hash_sha256_init" c_crypto_hash_sha256_init :: Ptr CryptoSha256State -> IO Int
+
+-- | @int crypto_hash_sha256_update(crypto_hash_sha256_state *state, const unsigned char *in, unsigned long long inlen);@
+foreign import capi "sodium.h crypto_hash_sha256_update" c_crypto_hash_sha256_update :: Ptr CryptoSha256State -> Ptr CUChar -> CULLong -> IO Int
+
+-- | @int crypto_hash_sha256_final(crypto_hash_sha256_state *state, unsigned char *out);@
+foreign import capi "sodium.h crypto_hash_sha256_final" c_crypto_hash_sha256_final :: Ptr CryptoSha256State -> Ptr (FiniteBytes CRYPTO_SHA256_BYTES) -> IO Int
+
+-------------------------------------------------------------------------------
+-- Hashing: Blake2b
+-------------------------------------------------------------------------------
+
+-- | @int crypto_generichash(unsigned char *out, size_t outlen, const unsigned char *in, unsigned long long inlen, const unsigned char *key, size_t keylen);@
+--
+-- <https://libsodium.gitbook.io/doc/hashing/generic_hashing>
+foreign import capi "sodium.h crypto_generichash" c_crypto_generichash
+    :: Ptr out -> CSize
+    -> Ptr CUChar -> CULLong
+    -> Ptr key -> CSize
+    -> IO Int
+
+newtype CryptoBlake2b256State = CryptoBlake2b256State (FiniteBytes CRYPTO_BLAKE2B_256_STATE_SIZE)
+  deriving newtype Storable
+
+-- | @int crypto_generichash_init(crypto_generichash_state *state, const unsigned char *key, const size_t keylen, const size_t outlen);@
+foreign import capi "sodium.h crypto_generichash_init" c_crypto_generichash_init :: Ptr CryptoSha256State -> Ptr key -> CSize -> CSize -> IO Int
+
+-- | @int crypto_generichash_update(crypto_generichash_state *state, const unsigned char *in, unsigned long long inlen);@
+foreign import capi "sodium.h crypto_generichash_update" c_crypto_generichash_update :: Ptr CryptoSha256State -> Ptr CUChar -> CULLong -> IO Int
+
+-- | @int crypto_generichash_final(crypto_generichash_state *state, unsigned char *out, const size_t outlen);@
+foreign import capi "sodium.h crypto_generichash_final" c_crypto_generichash_final :: Ptr CryptoSha256State -> Ptr out -> CSize -> IO Int
+
+-------------------------------------------------------------------------------
+-- Helpers
+-------------------------------------------------------------------------------
+
+-- | @int sodium_compare(const void * const b1_, const void * const b2_, size_t len);@
+--
+-- <https://libsodium.gitbook.io/doc/helpers#comparing-large-numbers>
+foreign import capi "sodium.h sodium_compare" c_sodium_compare :: Ptr a -> Ptr a -> CSize -> IO Int

--- a/cardano-crypto-class/src/Cardano/Crypto/Libsodium/Constants.hsc
+++ b/cardano-crypto-class/src/Cardano/Crypto/Libsodium/Constants.hsc
@@ -1,0 +1,24 @@
+{-# LANGUAGE DataKinds #-}
+module Cardano.Crypto.Libsodium.Constants (
+    CRYPTO_SHA256_BYTES,
+    CRYPTO_SHA512_BYTES,
+    CRYPTO_BLAKE2B_256_BYTES,
+    CRYPTO_SHA256_STATE_SIZE,
+    CRYPTO_SHA512_STATE_SIZE,
+    CRYPTO_BLAKE2B_256_STATE_SIZE,
+    )  where
+
+#include <sodium.h>
+
+-- From https://libsodium.gitbook.io/doc/advanced/sha-2_hash_function
+-- and https://libsodium.gitbook.io/doc/hashing/generic_hashing
+
+type CRYPTO_SHA256_BYTES = #{const crypto_hash_sha256_BYTES}
+type CRYPTO_SHA512_BYTES = #{const crypto_hash_sha512_BYTES}
+type CRYPTO_BLAKE2B_256_BYTES = #{const crypto_generichash_BYTES}
+
+type CRYPTO_SHA256_STATE_SIZE = #{size crypto_hash_sha256_state}
+type CRYPTO_SHA512_STATE_SIZE = #{size crypto_hash_sha512_state}
+type CRYPTO_BLAKE2B_256_STATE_SIZE = #{size crypto_generichash_state}
+
+

--- a/cardano-crypto-class/src/Cardano/Crypto/Libsodium/Hash.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Libsodium/Hash.hs
@@ -1,0 +1,134 @@
+{-# LANGUAGE CApiFFI #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE RoleAnnotations #-}
+{-# LANGUAGE TypeApplications #-}
+module Cardano.Crypto.Libsodium.Hash (
+    SodiumHashAlgorithm (..),
+    digestSecureStorable,
+    digestSecureFB,
+    digestSecureBS,
+    expandHash,
+) where
+
+import Control.Exception (bracket)
+import Control.Monad (unless)
+import Data.Proxy (Proxy (..))
+import Foreign.C.Error (errnoToIOError, getErrno)
+import Foreign.C.Types (CSize)
+import Foreign.Ptr (Ptr, castPtr, nullPtr, plusPtr)
+import Foreign.Storable (Storable (sizeOf, poke))
+import Data.Word (Word8)
+import GHC.IO.Exception (ioException)
+import GHC.TypeLits
+import System.IO.Unsafe (unsafeDupablePerformIO)
+import GHC.IO.Handle.Text (memcpy)
+
+import qualified Data.ByteString as SB
+
+import Cardano.Crypto.Hash (HashAlgorithm, SHA256, Blake2b_256)
+import Cardano.Crypto.FiniteBytes (FiniteBytes)
+import Cardano.Crypto.Libsodium.C
+import Cardano.Crypto.Libsodium.Memory.Internal
+import Cardano.Crypto.Libsodium.SecureBytes.Internal
+
+-------------------------------------------------------------------------------
+-- Type-Class
+-------------------------------------------------------------------------------
+
+class (HashAlgorithm h, KnownNat (SizeHash h)) => SodiumHashAlgorithm h where
+    -- | The size in bytes of the output of 'digest'
+    type SizeHash h :: Nat
+
+    digestSecure
+        :: proxy h
+        -> Ptr a  -- ^ input
+        -> Int    -- ^ input length
+        -> IO (SecureFiniteBytes (SizeHash h))
+
+    -- TODO: provide interface for multi-part?
+    -- That will be useful to hashing ('1' <> oldseed).
+
+digestSecureStorable
+    :: forall h a proxy. (SodiumHashAlgorithm h, Storable a)
+    => proxy h -> Ptr a -> IO (SecureFiniteBytes (SizeHash h))
+digestSecureStorable p ptr =
+  digestSecure p ptr ((sizeOf (undefined :: a)))
+
+digestSecureFB
+    :: forall h n proxy. (SodiumHashAlgorithm h, KnownNat n)
+    => proxy h -> Ptr (FiniteBytes n) -> IO (SecureFiniteBytes (SizeHash h))
+digestSecureFB = digestSecureStorable
+
+digestSecureBS
+    :: forall h proxy. (SodiumHashAlgorithm h)
+    => proxy h -> SB.ByteString -> IO (SecureFiniteBytes (SizeHash h))
+digestSecureBS p bs = SB.useAsCStringLen bs $ \(ptr, len) -> do
+    digestSecure p (castPtr ptr) len
+
+-------------------------------------------------------------------------------
+-- Hash expansion
+-------------------------------------------------------------------------------
+
+expandHash
+    :: forall h proxy. SodiumHashAlgorithm h
+    => proxy h
+    -> (SecureFiniteBytes (SizeHash h))
+    -> (SecureFiniteBytes (SizeHash h), SecureFiniteBytes (SizeHash h))
+expandHash h (SFB sfptr) = unsafeDupablePerformIO $ do
+    withSecureForeignPtr sfptr $ \ptr -> do
+        l <- bracket (sodiumMalloc size1) sodiumFree $ \ptr' -> do
+            poke ptr' (1 :: Word8)
+            _ <- memcpy (castPtr (plusPtr ptr' 1)) ptr size
+            digestSecure h ptr' (fromIntegral size1)
+
+        r <- bracket (sodiumMalloc size1) sodiumFree $ \ptr' -> do
+            poke ptr' (2 :: Word8)
+            _ <- memcpy (castPtr (plusPtr ptr' 1)) ptr size
+            digestSecure h ptr' (fromIntegral size1)
+
+        return (l, r)
+  where
+    size1 :: CSize
+    size1 = size + 1
+
+    size :: CSize
+    size = fromInteger $ natVal (Proxy @(SizeHash h))
+
+-------------------------------------------------------------------------------
+-- Instances
+-------------------------------------------------------------------------------
+
+instance SodiumHashAlgorithm SHA256 where
+    type SizeHash SHA256 = CRYPTO_SHA256_BYTES
+
+    digestSecure :: forall proxy a. proxy SHA256 -> Ptr a -> Int -> IO (SecureFiniteBytes (SizeHash SHA256))
+    digestSecure _ input inputlen = do
+        output <- allocSecureForeignPtr
+        withSecureForeignPtr output $ \output' -> do
+            res <- c_crypto_hash_sha256 (castPtr output') (castPtr input) (fromIntegral inputlen)
+            unless (res == 0) $ do
+                errno <- getErrno
+                ioException $ errnoToIOError "digestSecure @SHA256: c_crypto_hash_sha256" errno Nothing Nothing
+
+        return (SFB output)
+
+instance SodiumHashAlgorithm Blake2b_256 where
+    type SizeHash Blake2b_256 = CRYPTO_BLAKE2B_256_BYTES
+
+    digestSecure :: forall proxy a. proxy Blake2b_256 -> Ptr a -> Int -> IO (SecureFiniteBytes (SizeHash Blake2b_256))
+    digestSecure _ input inputlen = do
+        output <- allocSecureForeignPtr
+        withSecureForeignPtr output $ \output' -> do
+            res <- c_crypto_generichash
+                output' (fromInteger $ natVal (Proxy @CRYPTO_BLAKE2B_256_BYTES))  -- output
+                (castPtr input) (fromIntegral inputlen)  -- input
+                nullPtr 0                                -- key, unused
+            unless (res == 0) $ do
+                errno <- getErrno
+                ioException $ errnoToIOError "digestSecure @Blake2b_256: c_crypto_hash_sha256" errno Nothing Nothing
+
+        return (SFB output)

--- a/cardano-crypto-class/src/Cardano/Crypto/Libsodium/Init.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Libsodium/Init.hs
@@ -1,0 +1,21 @@
+module Cardano.Crypto.Libsodium.Init (
+  sodiumInit,
+) where
+
+import Control.Monad (unless)
+
+import Cardano.Crypto.Libsodium.C
+
+-- @sodiumInit@ initializes the library and should be called before any other
+-- function provided by Sodium. It is safe to call this function more than once
+-- and from different threads -- subsequent calls won't have any effects.
+--
+-- <https://libsodium.gitbook.io/doc/usage>
+sodiumInit :: IO ()
+sodiumInit = do
+    res <- c_sodium_init
+    -- sodium_init() returns 0 on success, -1 on failure, and 1 if the library
+    -- had already been initialized.
+    unless (res == 0 || res == 1) $ fail "sodium_init failed"
+
+

--- a/cardano-crypto-class/src/Cardano/Crypto/Libsodium/MLockedBytes.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Libsodium/MLockedBytes.hs
@@ -1,0 +1,7 @@
+module Cardano.Crypto.Libsodium.MLockedBytes (
+    MLockedFiniteBytes,
+    mlfbFromByteString,
+    mlfbToByteString,
+) where
+
+import Cardano.Crypto.Libsodium.MLockedBytes.Internal

--- a/cardano-crypto-class/src/Cardano/Crypto/Libsodium/Memory.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Libsodium/Memory.hs
@@ -1,0 +1,10 @@
+module Cardano.Crypto.Libsodium.Memory (
+  -- * High-level memory management
+  SecureForeignPtr, -- TODO: hide
+  withSecureForeignPtr,
+  allocSecureForeignPtr,
+  finalizeSecureForeignPtr,
+  traceSecureForeignPtr,
+) where
+
+import Cardano.Crypto.Libsodium.Memory.Internal

--- a/cardano-crypto-class/src/Cardano/Crypto/Libsodium/Memory.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Libsodium/Memory.hs
@@ -1,10 +1,10 @@
 module Cardano.Crypto.Libsodium.Memory (
   -- * High-level memory management
-  SecureForeignPtr, -- TODO: hide
-  withSecureForeignPtr,
-  allocSecureForeignPtr,
-  finalizeSecureForeignPtr,
-  traceSecureForeignPtr,
+  MLockedForeignPtr, -- TODO: hide
+  withMLockedForeignPtr,
+  allocMLockedForeignPtr,
+  finalizeMLockedForeignPtr,
+  traceMLockedForeignPtr,
 ) where
 
 import Cardano.Crypto.Libsodium.Memory.Internal

--- a/cardano-crypto-class/src/Cardano/Crypto/Libsodium/Memory/Internal.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Libsodium/Memory/Internal.hs
@@ -1,0 +1,83 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+module Cardano.Crypto.Libsodium.Memory.Internal (
+  -- * High-level memory management
+  SecureForeignPtr (..),
+  withSecureForeignPtr,
+  allocSecureForeignPtr,
+  finalizeSecureForeignPtr,
+  traceSecureForeignPtr,
+  -- * Low-level memory function
+  sodiumMalloc,
+  sodiumFree,
+) where
+
+import Control.Monad (when)
+import Data.Coerce (coerce)
+import Foreign.C.Error (errnoToIOError, getErrno)
+import Foreign.C.Types (CSize (..))
+import Foreign.ForeignPtr (ForeignPtr, newForeignPtr, withForeignPtr, finalizeForeignPtr)
+import Foreign.Ptr (Ptr, nullPtr)
+import Foreign.Storable (Storable (alignment, sizeOf, peek))
+import GHC.IO.Exception (ioException)
+
+import Cardano.Prelude (NoUnexpectedThunks, OnlyCheckIsWHNF (..))
+import Cardano.Crypto.Libsodium.C
+
+-- | Foreign pointer to securely allocated memory.
+newtype SecureForeignPtr a = SFP { _unwrapSecureForeignPtr :: ForeignPtr a }
+  deriving NoUnexpectedThunks via OnlyCheckIsWHNF "SecureForeignPtr" (SecureForeignPtr a)
+
+withSecureForeignPtr :: forall a b. SecureForeignPtr a -> (Ptr a -> IO b) -> IO b
+withSecureForeignPtr = coerce (withForeignPtr @a @b)
+
+finalizeSecureForeignPtr :: forall a. SecureForeignPtr a -> IO ()
+finalizeSecureForeignPtr = coerce (finalizeForeignPtr @a)
+
+traceSecureForeignPtr :: (Storable a, Show a) => SecureForeignPtr a -> IO ()
+traceSecureForeignPtr fptr = withSecureForeignPtr fptr $ \ptr -> do
+    a <- peek ptr
+    print a
+
+{-# DEPRECATED traceSecureForeignPtr "Don't leave traceSecureForeignPtr in production" #-}
+
+-- | Allocate secure memory using 'c_sodium_malloc'.
+--
+-- <https://libsodium.gitbook.io/doc/memory_management>
+--
+allocSecureForeignPtr :: Storable a => IO (SecureForeignPtr a)
+allocSecureForeignPtr = impl undefined where
+    impl :: forall b. Storable b => b -> IO (SecureForeignPtr b)
+    impl b = do
+        ptr <- sodiumMalloc size
+        fmap SFP (newForeignPtr c_sodium_free_funptr ptr)
+
+      where
+        size :: CSize
+        size = fromIntegral size''
+
+        size' :: Int
+        size' = sizeOf b
+
+        align :: Int
+        align = alignment b
+
+        size'' :: Int
+        size''
+            | m == 0    = size'
+            | otherwise = (q + 1) * align
+          where
+            (q,m) = size' `divMod` align
+
+sodiumMalloc :: CSize -> IO (Ptr a)
+sodiumMalloc size = do
+    ptr <- c_sodium_malloc size
+    when (ptr == nullPtr) $ do
+        errno <- getErrno
+        ioException $ errnoToIOError "c_sodium_malloc" errno Nothing Nothing
+    return ptr
+
+sodiumFree :: Ptr a -> IO ()
+sodiumFree = c_sodium_free

--- a/cardano-crypto-class/src/Cardano/Crypto/Libsodium/SecureBytes.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Libsodium/SecureBytes.hs
@@ -1,7 +1,0 @@
-module Cardano.Crypto.Libsodium.SecureBytes (
-    SecureFiniteBytes,
-    sfbFromByteString,
-    sfbToByteString,
-) where
-
-import Cardano.Crypto.Libsodium.SecureBytes.Internal

--- a/cardano-crypto-class/src/Cardano/Crypto/Libsodium/SecureBytes.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Libsodium/SecureBytes.hs
@@ -1,0 +1,7 @@
+module Cardano.Crypto.Libsodium.SecureBytes (
+    SecureFiniteBytes,
+    sfbFromByteString,
+    sfbToByteString,
+) where
+
+import Cardano.Crypto.Libsodium.SecureBytes.Internal

--- a/cardano-crypto-class/src/Cardano/Crypto/Libsodium/SecureBytes/Internal.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Libsodium/SecureBytes/Internal.hs
@@ -1,0 +1,70 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+module Cardano.Crypto.Libsodium.SecureBytes.Internal (
+    SecureFiniteBytes (..),
+    sfbFromByteString,
+    sfbToByteString,
+) where
+
+import Control.DeepSeq (NFData (..))
+import Data.Proxy (Proxy (..))
+import Foreign.C.Types (CSize (..))
+import Foreign.ForeignPtr (castForeignPtr)
+import Foreign.Ptr (castPtr)
+import GHC.IO.Handle.Text (memcpy)
+import GHC.TypeLits (KnownNat, natVal)
+import System.IO.Unsafe (unsafeDupablePerformIO)
+
+import Cardano.Crypto.Libsodium.Memory.Internal
+import Cardano.Crypto.Libsodium.C
+import Cardano.Prelude (NoUnexpectedThunks, OnlyCheckIsWHNF (..))
+
+import qualified Cardano.Crypto.FiniteBytes as FB
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Internal as BSI
+
+newtype SecureFiniteBytes n = SFB (SecureForeignPtr (FB.FiniteBytes n))
+  deriving NoUnexpectedThunks via OnlyCheckIsWHNF "SecureFiniteBytes" (SecureFiniteBytes n)
+
+instance KnownNat n => Eq (SecureFiniteBytes n) where
+    x == y = compare x y == EQ
+
+instance KnownNat n => Ord (SecureFiniteBytes n) where
+    compare (SFB x) (SFB y) = unsafeDupablePerformIO $
+        withSecureForeignPtr x $ \x' ->
+        withSecureForeignPtr y $ \y' -> do
+            res <- c_sodium_compare x' y' (CSize (fromIntegral size))
+            return (compare res 0)
+      where
+        size = natVal (Proxy @n)
+
+instance KnownNat n => Show (SecureFiniteBytes n) where
+    showsPrec d _ = showParen (d > 10)
+        $ showString "_ :: SecureFiniteBytes"
+        . showsPrec 11 (natVal (Proxy @n))
+        
+    
+instance NFData (SecureFiniteBytes n) where
+    rnf (SFB p) = seq p ()
+
+sfbFromByteString :: forall n. KnownNat n => BS.ByteString -> SecureFiniteBytes n
+sfbFromByteString bs = unsafeDupablePerformIO $ BS.useAsCStringLen bs $ \(ptrBS, len) -> do
+    fptr <- allocSecureForeignPtr
+    withSecureForeignPtr fptr $ \ptr -> do
+        _ <- memcpy (castPtr ptr) ptrBS (fromIntegral (min len size))
+        return ()
+    return (SFB fptr)
+  where
+    size  :: Int
+    size = fromInteger (natVal (Proxy @n))
+
+-- | /Note:/ the resulting 'BS.ByteString' will still refer to secure memory,
+-- but the types don't prevent it from be exposed.
+--
+sfbToByteString :: forall n. KnownNat n => SecureFiniteBytes n -> BS.ByteString
+sfbToByteString (SFB (SFP fptr)) = BSI.PS (castForeignPtr fptr) 0 size where
+    size  :: Int
+    size = fromInteger (natVal (Proxy @n))
+

--- a/cardano-crypto-class/src/Cardano/Crypto/Libsodium/UnsafeC.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Libsodium/UnsafeC.hs
@@ -1,0 +1,10 @@
+{-# LANGUAGE CApiFFI             #-}
+module Cardano.Crypto.Libsodium.UnsafeC (
+    c_sodium_compare_unsafe,
+    ) where
+
+import Foreign.C.Types (CSize (..))
+import Foreign.Ptr (Ptr)
+
+-- | Unsafe variant of 'c_sodium_compare'.
+foreign import capi unsafe "sodium.h sodium_compare" c_sodium_compare_unsafe :: Ptr a -> Ptr a -> CSize -> IO Int

--- a/cardano-crypto-class/src/Cardano/Crypto/Seed.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Seed.hs
@@ -17,6 +17,9 @@ module Cardano.Crypto.Seed
   , getBytesFromSeedT
   , runMonadRandomWithSeed
   , SeedBytesExhausted(..)
+    -- * Libsodium co-op
+  , sfbToSeed
+  , sfbFromSeed
   ) where
 
 import           Data.ByteString (ByteString)
@@ -35,6 +38,7 @@ import           Cardano.Crypto.Hash.Class (HashAlgorithm(digest))
 
 import           Cardano.Prelude (NoUnexpectedThunks)
 
+import qualified Cardano.Crypto.Libsodium as NaCl
 
 -- | A seed contains a finite number of bytes, and is used for seeding
 -- cryptographic algorithms including key generation.
@@ -143,3 +147,10 @@ getRandomBytesFromSeed n =
 instance MonadRandom MonadRandomFromSeed where
   getRandomBytes n = BA.convert <$> getRandomBytesFromSeed n
 
+-- Libsodium co-op
+
+sfbToSeed :: NaCl.SodiumHashAlgorithm h => proxy h -> NaCl.SecureFiniteBytes (NaCl.SizeHash h) -> Seed
+sfbToSeed _ = mkSeedFromBytes . NaCl.sfbToByteString
+
+sfbFromSeed :: NaCl.SodiumHashAlgorithm h => proxy h -> Seed -> NaCl.SecureFiniteBytes (NaCl.SizeHash h)
+sfbFromSeed _ = NaCl.sfbFromByteString . getSeedBytes

--- a/cardano-crypto-class/src/Cardano/Crypto/Seed.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Seed.hs
@@ -18,8 +18,8 @@ module Cardano.Crypto.Seed
   , runMonadRandomWithSeed
   , SeedBytesExhausted(..)
     -- * Libsodium co-op
-  , sfbToSeed
-  , sfbFromSeed
+  , mlfbToSeed
+  , mlfbFromSeed
   ) where
 
 import           Data.ByteString (ByteString)
@@ -31,6 +31,7 @@ import           Control.Exception (Exception(..), throw)
 import           Data.Functor.Identity
 import           Control.Monad.Trans.Maybe
 import           Control.Monad.Trans.State
+import           GHC.TypeLits (KnownNat)
 
 import           Crypto.Random (MonadRandom(..))
 import           Crypto.Random.Entropy (getEntropy)
@@ -149,8 +150,8 @@ instance MonadRandom MonadRandomFromSeed where
 
 -- Libsodium co-op
 
-sfbToSeed :: NaCl.SodiumHashAlgorithm h => proxy h -> NaCl.SecureFiniteBytes (NaCl.SizeHash h) -> Seed
-sfbToSeed _ = mkSeedFromBytes . NaCl.sfbToByteString
+mlfbToSeed :: KnownNat n => NaCl.MLockedFiniteBytes n -> Seed
+mlfbToSeed = mkSeedFromBytes . NaCl.mlfbToByteString
 
-sfbFromSeed :: NaCl.SodiumHashAlgorithm h => proxy h -> Seed -> NaCl.SecureFiniteBytes (NaCl.SizeHash h)
-sfbFromSeed _ = NaCl.sfbFromByteString . getSeedBytes
+mlfbFromSeed :: KnownNat n => Seed -> NaCl.MLockedFiniteBytes n
+mlfbFromSeed = NaCl.mlfbFromByteString . getSeedBytes

--- a/cardano-crypto-tests/cardano-crypto-tests.cabal
+++ b/cardano-crypto-tests/cardano-crypto-tests.cabal
@@ -38,6 +38,7 @@ library
                      , cryptonite
                      , formatting
                      , QuickCheck
+                     , quickcheck-instances
                      , tasty
                      , tasty-quickcheck
 

--- a/cardano-crypto-tests/src/Test/Crypto/Hash.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/Hash.hs
@@ -81,8 +81,8 @@ prop_libsodium_model
   :: forall h. NaCl.SodiumHashAlgorithm h
   => Proxy h -> SB.ByteString -> Property
 prop_libsodium_model p bs = ioProperty $ do
-  sfb <- NaCl.digestSecureBS p bs
-  let actual = NaCl.sfbToByteString sfb
+  mlfb <- NaCl.digestMLockedBS p bs
+  let actual = NaCl.mlfbToByteString mlfb
   return (expected === actual)
   where
     expected = digest p bs

--- a/cardano-crypto-tests/src/Test/Crypto/Hash.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/Hash.hs
@@ -18,10 +18,8 @@ import Test.QuickCheck
 import Test.QuickCheck.Instances ()
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.QuickCheck (testProperty)
-import Foreign.Storable (peek)
 
 import qualified Cardano.Crypto.Libsodium as NaCl
-import qualified Cardano.Crypto.FiniteBytes as FB
 
 --
 -- The list of all tests
@@ -83,9 +81,8 @@ prop_libsodium_model
   :: forall h. NaCl.SodiumHashAlgorithm h
   => Proxy h -> SB.ByteString -> Property
 prop_libsodium_model p bs = ioProperty $ do
-  NaCl.UnsafeHash hashPtr <- NaCl.digestSecureBS p bs
-  bytes <- NaCl.withSecureForeignPtr hashPtr peek
-  let actual = SB.pack (FB.toBytes bytes)
+  sfb <- NaCl.digestSecureBS p bs
+  let actual = NaCl.sfbToByteString sfb
   return (expected === actual)
   where
     expected = digest p bs

--- a/cardano-crypto-tests/src/Test/Crypto/KES.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/KES.hs
@@ -17,10 +17,12 @@ where
 
 import Data.Proxy (Proxy(..))
 import Data.List (unfoldr)
+import GHC.TypeLits (KnownNat, natVal)
 
 import Cardano.Binary (FromCBOR, ToCBOR(..))
 import Cardano.Crypto.DSIGN
 import Cardano.Crypto.Hash
+import Cardano.Crypto.Seed
 import Cardano.Crypto.KES
 import qualified Cardano.Crypto.KES as KES
 import qualified Cardano.Crypto.Libsodium as NaCl
@@ -362,9 +364,7 @@ instance KESAlgorithm v => Arbitrary (VerKeyKES v) where
   shrink = const []
 
 instance KESAlgorithm v => Arbitrary (SignKeyKES v) where
-  arbitrary = genKeyKES <$> arbitrarySeedOfSize seedSize
-    where
-      seedSize = seedSizeKES (Proxy :: Proxy v)
+  arbitrary = genKeyKES <$> arbitrary
   shrink = const []
 
 instance (KES.Signable v Int, KESAlgorithm v, ContextKES v ~ ())
@@ -375,3 +375,6 @@ instance (KES.Signable v Int, KESAlgorithm v, ContextKES v ~ ())
     let sig = signKES () 0 a sk
     return sig
   shrink = const []
+
+instance KnownNat n => Arbitrary (NaCl.MLockedFiniteBytes n) where
+    arbitrary = mlfbFromSeed <$> arbitrarySeedOfSize (fromIntegral (natVal (Proxy @n)))

--- a/cardano-crypto-tests/src/Test/Crypto/KES.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/KES.hs
@@ -23,13 +23,13 @@ import Cardano.Crypto.DSIGN
 import Cardano.Crypto.Hash
 import Cardano.Crypto.KES
 import qualified Cardano.Crypto.KES as KES
+import qualified Cardano.Crypto.Libsodium as NaCl
 
 import Test.QuickCheck
 import Test.Tasty (TestTree, testGroup, adjustOption)
 import Test.Tasty.QuickCheck (testProperty, QuickCheckMaxSize(..))
 
 import Test.Crypto.Util hiding (label)
-
 
 --
 -- The list of all tests
@@ -52,7 +52,7 @@ deriving instance Eq (SignKeyDSIGN d) => Eq (SignKeyKES (SimpleKES d t))
 
 deriving instance Eq (SignKeyDSIGN d)
                => Eq (SignKeyKES (SingleKES d))
-deriving instance (KESAlgorithm d, Eq (SignKeyKES d))
+deriving instance (KESAlgorithm d, NaCl.SodiumHashAlgorithm h, Eq (SignKeyKES d))
                => Eq (SignKeyKES (SumKES h d))
 
 testKESAlgorithm

--- a/cardano-crypto-tests/test/Main.hs
+++ b/cardano-crypto-tests/test/Main.hs
@@ -5,9 +5,12 @@ import qualified Test.Crypto.Hash (tests)
 import qualified Test.Crypto.KES (tests)
 import qualified Test.Crypto.VRF (tests)
 import Test.Tasty
+import Cardano.Crypto.Libsodium (sodiumInit)
 
 main :: IO ()
-main = defaultMain tests
+main = do
+    sodiumInit
+    defaultMain tests
 
 tests :: TestTree
 tests =

--- a/shell.nix
+++ b/shell.nix
@@ -39,6 +39,9 @@ let
     # *all* dependencies are provided by Nix.
     exactDeps = false;
 
+    NIX_SSL_CERT_FILE = "/etc/ssl/certs/ca-bundle.crt";
+    SSL_CERT_FILE = "/etc/ssl/certs/ca-bundle.crt";
+
     inherit withHoogle;
   };
 

--- a/shell.nix
+++ b/shell.nix
@@ -26,13 +26,13 @@ let
     buildInputs = with haskellPackages; [
       cabal-install
       ghcid
+      gitAndTools.git
       hlint
       weeder
       nix
       niv
       pkgconfig
       sqlite-interactive
-      git
     ];
 
     # Prevents cabal from choosing alternate plans, so that


### PR DESCRIPTION
Some test fails because signing algorithms' seed size is not yet available on type level, so  I hard coded 32 (which it is for ed25519 but not universally).

The next steps:
- Add SeedSizeDSIGN associated type family (and for ver,sign,and sig size).
- Think what to do with Ed448 i.e. in situation where hash size and dsign seed size don't match. Is Ed448 important?
- Make a subclass of  DSIGNAlgorithm which operates on `SecureFiniteBytes` / `FiniteBytes` and bind ed25519 from libsodium to it.

