### PR TITLE
In Praos VRF, use useAsCStringLen.

### DIFF
--- a/cardano-crypto-praos/src/Cardano/Crypto/VRF/Praos.hs
+++ b/cardano-crypto-praos/src/Cardano/Crypto/VRF/Praos.hs
@@ -38,6 +38,7 @@ module Cardano.Crypto.VRF.Praos
   , vrfKeySizeVRF
 
   -- * Seed and key generation
+  , Seed
   , genSeed
   , keypairFromSeed
 
@@ -187,6 +188,16 @@ mkSeed = do
 
 -- | Generate a random seed.
 -- Uses 'randombytes_buf' to create random data.
+--
+-- This function provides an alternative way of generating seeds specifically
+-- for the 'PraosVRF' algorithm. Unlike the 'genKeyPairVRF' method, which uses
+-- a 'ByteString'-based 'Cardano.Crypto.Seed.Seed', this seed generation method
+-- bypasses the GHC heap, keeping the seed in C-allocated memory instead.
+--
+-- This provides two advantages:
+-- 1. It avoids the overhead of unnecessary GHC-side heap allocations.
+-- 2. It avoids leaking the seed via the GHC heap; the 'Seed' type itself
+--    takes care of zeroing out its memory upon finalization.
 genSeed :: IO Seed
 genSeed = do
   seed <- mkSeed


### PR DESCRIPTION
As per security audit:

- `useAsCString` appends a NUL byte; this isn't harmful per se, but completely unnecessary; also, we can perform an additional length check to make sure we can never overrun the input buffer.
- `genSeed` isn't needed, since generating keys via the `VRF` typeclass pulls entropy from a seed passed in by the caller, but because our `Seed` bypasses the GHC heap, which can be interesting in some situations, we will keep exposing it, but add documentation here to clarify the situation.
- We also expose our PraosVRF-specific `Seed` type in order to make `genSeed` practically usable