### PR TITLE
increase the size of ShortHash from 4 to 8 bytes

### DIFF
--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Mock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Mock.hs
@@ -118,7 +118,7 @@ instance DSIGNAlgorithm MockDSIGN where
       = Nothing
 
     rawDeserialiseSigDSIGN bs
-      | [hb, kb] <- splitsAt [sizeHash (Proxy :: Proxy ShortHash), 8] bs
+      | [hb, kb] <- splitsAt [fromIntegral $ sizeHash (Proxy :: Proxy ShortHash), 8] bs
       , Just h   <- hashFromBytes hb
       , let k = readBinaryWord64 kb
       = Just $! SigMockDSIGN h k

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Mock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Mock.hs
@@ -118,7 +118,7 @@ instance DSIGNAlgorithm MockDSIGN where
       = Nothing
 
     rawDeserialiseSigDSIGN bs
-      | [hb, kb] <- splitsAt [4, 8] bs
+      | [hb, kb] <- splitsAt [8] bs
       , Just h   <- hashFromBytes hb
       , let k = readBinaryWord64 kb
       = Just $! SigMockDSIGN h k

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Mock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Mock.hs
@@ -118,7 +118,7 @@ instance DSIGNAlgorithm MockDSIGN where
       = Nothing
 
     rawDeserialiseSigDSIGN bs
-      | [hb, kb] <- splitsAt [8] bs
+      | [hb, kb] <- splitsAt [sizeHash (Proxy :: Proxy ShortHash), 8] bs
       , Just h   <- hashFromBytes hb
       , let k = readBinaryWord64 kb
       = Just $! SigMockDSIGN h k

--- a/cardano-crypto-class/src/Cardano/Crypto/Hash/Short.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Hash/Short.hs
@@ -17,7 +17,7 @@ data ShortHash
 
 instance HashAlgorithm ShortHash where
   hashAlgorithmName _ = "md5_short"
-  sizeHash _ = 4
+  sizeHash _ = 8
   digest p =
     B.take (fromIntegral (sizeHash p)) .
       BA.convert .


### PR DESCRIPTION
Having `ShortHash` only have 4 bytes leads to the occasional property test failure resulting from a hash conflict.  I would like to increase it to 8 bytes, hopefully striking a middle ground between conveniently short but not too prone to conflicts.