### PR TITLE
Eliminate Signable constraint and use raw bytes for signing

### DIFF
--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed25519.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed25519.hs
@@ -15,18 +15,18 @@ module Cardano.Crypto.DSIGN.Ed25519
   )
 where
 
-import Data.ByteString.Lazy (toStrict)
 import Data.ByteArray as BA (ByteArrayAccess, convert)
 import GHC.Generics (Generic)
 
 import Cardano.Prelude (NFData, NoUnexpectedThunks, UseIsNormalForm(..))
-import Cardano.Binary (FromCBOR (..), ToCBOR (..), serialize)
+import Cardano.Binary (FromCBOR (..), ToCBOR (..))
 
 import Crypto.Error (CryptoFailable (..))
 import Crypto.PubKey.Ed25519 as Ed25519
 
 import Cardano.Crypto.DSIGN.Class
 import Cardano.Crypto.Seed
+import Cardano.Crypto.Util (SignableRepresentation(..))
 
 
 data Ed25519DSIGN
@@ -64,15 +64,15 @@ instance DSIGNAlgorithm Ed25519DSIGN where
     -- Core algorithm operations
     --
 
-    type Signable Ed25519DSIGN = ToCBOR
+    type Signable Ed25519DSIGN = SignableRepresentation
 
     signDSIGN () a (SignKeyEd25519DSIGN sk) =
         let vk = toPublic sk
-            bs = toStrict $ serialize a
+            bs = getSignableRepresentation a
          in SigEd25519DSIGN $ sign sk vk bs
 
     verifyDSIGN () (VerKeyEd25519DSIGN vk) a (SigEd25519DSIGN sig) =
-        if verify vk (toStrict $ serialize a) sig
+        if verify vk (getSignableRepresentation a) sig
           then Right ()
           else Left "Verification failed"
 

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed448.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed448.hs
@@ -15,18 +15,18 @@ module Cardano.Crypto.DSIGN.Ed448
   )
 where
 
-import Data.ByteString.Lazy (toStrict)
 import Data.ByteArray as BA (ByteArrayAccess, convert)
 import GHC.Generics (Generic)
 
 import Cardano.Prelude (NFData, NoUnexpectedThunks, UseIsNormalForm(..))
-import Cardano.Binary (FromCBOR (..), ToCBOR (..), serialize)
+import Cardano.Binary (FromCBOR (..), ToCBOR (..))
 
 import Crypto.Error (CryptoFailable (..))
 import Crypto.PubKey.Ed448 as Ed448
 
 import Cardano.Crypto.DSIGN.Class
 import Cardano.Crypto.Seed
+import Cardano.Crypto.Util (SignableRepresentation(..))
 
 
 data Ed448DSIGN
@@ -64,15 +64,15 @@ instance DSIGNAlgorithm Ed448DSIGN where
     -- Core algorithm operations
     --
 
-    type Signable Ed448DSIGN = ToCBOR
+    type Signable Ed448DSIGN = SignableRepresentation
 
     signDSIGN () a (SignKeyEd448DSIGN sk) =
         let vk = toPublic sk
-            bs = toStrict $ serialize a
+            bs = getSignableRepresentation a
          in SigEd448DSIGN $ sign sk vk bs
 
     verifyDSIGN () (VerKeyEd448DSIGN vk) a (SigEd448DSIGN sig) =
-        if verify vk (toStrict $ serialize a) sig
+        if verify vk (getSignableRepresentation a) sig
           then Right ()
           else Left "Verification failed"
 

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Mock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Mock.hs
@@ -65,7 +65,7 @@ instance DSIGNAlgorithm MockDSIGN where
     -- Core algorithm operations
     --
 
-    type Signable MockDSIGN = ToCBOR
+    type Signable MockDSIGN = SignableRepresentation
 
     signDSIGN () a sk = mockSign a sk
 
@@ -161,10 +161,13 @@ data VerificationFailure
       }
   deriving Show
 
-mockSign :: ToCBOR a => a -> SignKeyDSIGN MockDSIGN -> SigDSIGN MockDSIGN
-mockSign a (SignKeyMockDSIGN n) = SigMockDSIGN (castHash (hash a)) n
+mockSign :: SignableRepresentation a
+         => a -> SignKeyDSIGN MockDSIGN -> SigDSIGN MockDSIGN
+mockSign a (SignKeyMockDSIGN n) =
+  SigMockDSIGN (castHash (hashRaw getSignableRepresentation a)) n
 
-mockSigned :: ToCBOR a => a -> SignKeyDSIGN MockDSIGN -> SignedDSIGN MockDSIGN a
+mockSigned :: SignableRepresentation a
+           => a -> SignKeyDSIGN MockDSIGN -> SignedDSIGN MockDSIGN a
 mockSigned a k = SignedDSIGN (mockSign a k)
 
 -- | Get the id of the signer from a signature. Used for testing.

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Mock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Mock.hs
@@ -83,7 +83,7 @@ instance KnownNat t => KESAlgorithm (MockKES t) where
     -- Core algorithm operations
     --
 
-    type Signable (MockKES t) = ToCBOR
+    type Signable (MockKES t) = SignableRepresentation
 
     updateKES () (SignKeyMockKES vk t') t =
         assert (t == t') $
@@ -95,12 +95,13 @@ instance KnownNat t => KESAlgorithm (MockKES t) where
     -- allowed KES period.
     signKES () t a (SignKeyMockKES vk t') =
         assert (t == t') $
-        SigMockKES (castHash (hash a)) (SignKeyMockKES vk t)
+        SigMockKES (castHash (hashRaw getSignableRepresentation a))
+                   (SignKeyMockKES vk t)
 
     verifyKES () vk t a (SigMockKES h (SignKeyMockKES vk' t'))
       | t' == t
       , vk == vk'
-      , castHash (hash a) == h
+      , castHash (hashRaw getSignableRepresentation a) == h
       = Right ()
 
       | otherwise

--- a/cardano-crypto-class/src/Cardano/Crypto/Util.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Util.hs
@@ -4,6 +4,7 @@
 
 module Cardano.Crypto.Util
   ( Empty
+  , SignableRepresentation(..)
   , getRandomWord64
 
     -- * Simple serialisation used in mock instances
@@ -37,6 +38,21 @@ import           Crypto.Random (MonadRandom (..))
 
 class Empty a
 instance Empty a
+
+
+
+--
+-- Signable
+--
+
+-- | A class of types that have a representation in bytes that can be used
+-- for signing and verifying.
+--
+class SignableRepresentation a where
+    getSignableRepresentation :: a -> ByteString
+
+instance SignableRepresentation ByteString where
+    getSignableRepresentation = id
 
 
 --

--- a/cardano-crypto-class/src/Cardano/Crypto/VRF/Mock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/VRF/Mock.hs
@@ -54,7 +54,7 @@ instance VRFAlgorithm MockVRF where
   -- Core algorithm operations
   --
 
-  type Signable MockVRF = ToCBOR
+  type Signable MockVRF = SignableRepresentation
 
   evalVRF () a sk = evalVRF' a sk
 
@@ -131,10 +131,11 @@ instance FromCBOR (CertVRF MockVRF) where
   fromCBOR = decodeCertVRF
 
 
-evalVRF' :: ToCBOR a
+evalVRF' :: SignableRepresentation a
          => a
          -> SignKeyVRF MockVRF
          -> (OutputVRF MockVRF, CertVRF MockVRF)
 evalVRF' a sk@(SignKeyMockVRF n) =
-  let y = getHash $ hashWithSerialiser @MD5 id $ toCBOR a <> toCBOR sk
+  let y = getHash $ hashWithSerialiser @MD5 id $
+            toCBOR (getSignableRepresentation a) <> toCBOR sk
   in (OutputVRF y, CertMockVRF n)

--- a/cardano-crypto-class/src/Cardano/Crypto/VRF/Simple.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/VRF/Simple.hs
@@ -135,10 +135,11 @@ instance VRFAlgorithm SimpleVRF where
   -- Core algorithm operations
   --
 
-  type Signable SimpleVRF = ToCBOR
+  type Signable SimpleVRF = SignableRepresentation
 
-  evalVRF () a sk@(SignKeySimpleVRF k) =
-    let u = h' (toCBOR a) k
+  evalVRF () a' sk@(SignKeySimpleVRF k) =
+    let a = getSignableRepresentation a'
+        u = h' (toCBOR a) k
         y = h $ toCBOR a <> toCBOR u
         VerKeySimpleVRF v = deriveVerKeyVRF sk
 
@@ -147,8 +148,9 @@ instance VRFAlgorithm SimpleVRF where
         s = mod (r + k * fromIntegral (bytesToNatural c)) q
     in (OutputVRF y, CertSimpleVRF u (bytesToNatural c) s)
 
-  verifyVRF () (VerKeySimpleVRF v) a (OutputVRF y, cert) =
-    let u = certU cert
+  verifyVRF () (VerKeySimpleVRF v) a' (OutputVRF y, cert) =
+    let a = getSignableRepresentation a'
+        u = certU cert
         c = certC cert
         c' = -fromIntegral c
         s = certS cert

--- a/cardano-crypto-tests/src/Test/Crypto/Util.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/Util.hs
@@ -29,9 +29,11 @@ module Test.Crypto.Util
 
     -- * Seeds
   , arbitrarySeedOfSize
+
+   -- * test messages for signings
+  , Message(..)
   )
 where
-
 
 import Cardano.Binary (FromCBOR (..), ToCBOR (..),
                        Encoding, Decoder, Range (..),
@@ -40,13 +42,14 @@ import Cardano.Prelude (NoUnexpectedThunks, unsafeNoUnexpectedThunks)
 import Codec.CBOR.FlatTerm
 import Codec.CBOR.Write
 import Cardano.Crypto.Seed (Seed, mkSeedFromBytes)
+import Cardano.Crypto.Util (SignableRepresentation(..))
 import Crypto.Random
   ( ChaChaDRG
   , MonadPseudoRandom
   , drgNewTest
   , withDRG
   )
-import Data.ByteString as BS (ByteString, pack, length)
+import Data.ByteString as BS (ByteString, pack, unpack, length)
 import Data.Proxy (Proxy (..))
 import Data.Word (Word64)
 import Numeric.Natural (Natural)
@@ -99,6 +102,18 @@ instance Arbitrary TestSeed where
 arbitrarySeedOfSize :: Word -> Gen Seed
 arbitrarySeedOfSize sz =
   (mkSeedFromBytes . BS.pack) <$> vector (fromIntegral sz)
+
+--------------------------------------------------------------------------------
+-- Messages to sign
+--------------------------------------------------------------------------------
+
+newtype Message = Message { messageBytes :: ByteString }
+  deriving (Eq, Show, SignableRepresentation)
+
+instance Arbitrary Message where
+  arbitrary = Message . BS.pack <$> arbitrary
+  shrink    = map (Message . BS.pack) . shrink . BS.unpack . messageBytes
+
 
 --------------------------------------------------------------------------------
 -- Serialisation properties


### PR DESCRIPTION
Change Signable constraint to use SignableRepresentation

The approach of having the Signable constraint set to ToCBOR leads to
the mistake of signing and verifying the serialisation of a bytestring
rather than the bytestring itself. For example it leads to accidentally
signing the CBOR serialisation a txbody hash, rather than simply the
txbody hash.

So switch from ToCBOR to a new

class SignableRepresentation a where
    getSignableRepresentation :: a -> ByteString

Which just returns the representation as bytes for the purpose of
signing or verifying.