### PR TITLE
Various hashing api tweaks and improvements

### DIFF
--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Class.hs
@@ -49,7 +49,7 @@ import Cardano.Binary (Decoder, decodeBytes, Encoding, encodeBytes, Size, withWo
 
 import Cardano.Crypto.Util (Empty)
 import Cardano.Crypto.Seed
-import Cardano.Crypto.Hash.Class (HashAlgorithm, Hash, hashRaw)
+import Cardano.Crypto.Hash.Class (HashAlgorithm, Hash, hashWith)
 
 
 
@@ -84,7 +84,7 @@ class ( Typeable v
   deriveVerKeyDSIGN :: SignKeyDSIGN v -> VerKeyDSIGN v
 
   hashVerKeyDSIGN :: HashAlgorithm h => VerKeyDSIGN v -> Hash h (VerKeyDSIGN v)
-  hashVerKeyDSIGN = hashRaw rawSerialiseVerKeyDSIGN
+  hashVerKeyDSIGN = hashWith rawSerialiseVerKeyDSIGN
 
 
   --

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Mock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Mock.hs
@@ -162,4 +162,4 @@ data VerificationFailure
 mockSign :: SignableRepresentation a
          => a -> SignKeyDSIGN MockDSIGN -> SigDSIGN MockDSIGN
 mockSign a (SignKeyMockDSIGN n) =
-  SigMockDSIGN (castHash (hashRaw getSignableRepresentation a)) n
+  SigMockDSIGN (castHash (hashWith getSignableRepresentation a)) n

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Mock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Mock.hs
@@ -14,9 +14,7 @@ module Cardano.Crypto.DSIGN.Mock
   , SignKeyDSIGN (..)
   , VerKeyDSIGN (..)
   , SigDSIGN (..)
-  , verKeyIdFromSigned
   , mockSign
-  , mockSigned
   )
 where
 
@@ -165,11 +163,3 @@ mockSign :: SignableRepresentation a
          => a -> SignKeyDSIGN MockDSIGN -> SigDSIGN MockDSIGN
 mockSign a (SignKeyMockDSIGN n) =
   SigMockDSIGN (castHash (hashRaw getSignableRepresentation a)) n
-
-mockSigned :: SignableRepresentation a
-           => a -> SignKeyDSIGN MockDSIGN -> SignedDSIGN MockDSIGN a
-mockSigned a k = SignedDSIGN (mockSign a k)
-
--- | Get the id of the signer from a signature. Used for testing.
-verKeyIdFromSigned :: SignedDSIGN MockDSIGN a -> Word64
-verKeyIdFromSigned (SignedDSIGN (SigMockDSIGN _ i)) = i

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Mock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Mock.hs
@@ -96,7 +96,7 @@ instance DSIGNAlgorithm MockDSIGN where
 
     rawSerialiseVerKeyDSIGN  (VerKeyMockDSIGN  k) = writeBinaryWord64 k
     rawSerialiseSignKeyDSIGN (SignKeyMockDSIGN k) = writeBinaryWord64 k
-    rawSerialiseSigDSIGN     (SigMockDSIGN   h k) = getHash h
+    rawSerialiseSigDSIGN     (SigMockDSIGN   h k) = hashToBytes h
                                                  <> writeBinaryWord64 k
 
     rawDeserialiseVerKeyDSIGN bs

--- a/cardano-crypto-class/src/Cardano/Crypto/Hash/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Hash/Class.hs
@@ -28,6 +28,7 @@ module Cardano.Crypto.Hash.Class
   , hash
   , fromHash
   , hashRaw
+  , getHash
   , getHashBytesAsHex
   )
 where
@@ -72,7 +73,7 @@ class Typeable h => HashAlgorithm h where
   digest :: proxy h -> ByteString -> ByteString
 
 
-newtype Hash h a = UnsafeHash {getHash :: ByteString}
+newtype Hash h a = UnsafeHash ByteString
   deriving (Eq, Ord, Generic, NFData, NoUnexpectedThunks)
 
 
@@ -233,6 +234,10 @@ fromHash = foldl' f 0 . SB.unpack . getHash
 
 hashRaw :: forall h a. HashAlgorithm h => (a -> ByteString) -> a -> Hash h a
 hashRaw = hashWith
+
+{-# DEPRECATED getHash "Use hashToBytes" #-}
+getHash :: Hash h a -> ByteString
+getHash = hashToBytes
 
 {-# DEPRECATED getHashBytesAsHex "Use hashToBytesAsHex" #-}
 getHashBytesAsHex :: Hash h a -> ByteString

--- a/cardano-crypto-class/src/Cardano/Crypto/Hash/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Hash/Class.hs
@@ -16,6 +16,8 @@ module Cardano.Crypto.Hash.Class
   , castHash
   , hashToBytes
   , hashFromBytes
+  , hashToBytesShort
+  , hashFromBytesShort
 
     -- * Rendering and parsing
   , hashToBytesAsHex
@@ -130,6 +132,26 @@ hashFromBytes :: forall h a. HashAlgorithm h => ByteString -> Maybe (Hash h a)
 hashFromBytes bytes
   | BS.length bytes == fromIntegral (sizeHash (Proxy :: Proxy h))
   = Just (UnsafeHash (SBS.toShort bytes))
+
+  | otherwise
+  = Nothing
+
+
+-- | The representation of the hash as bytes, as a 'ShortByteString'.
+--
+hashToBytesShort :: Hash h a -> ShortByteString
+hashToBytesShort (UnsafeHash h) = h
+
+
+-- | Make a hash from it bytes representation, as a 'ShortByteString'.
+--
+-- It must be a a bytestring of the correct length, as given by 'sizeHash'.
+--
+hashFromBytesShort :: forall h a. HashAlgorithm h
+                   => ShortByteString -> Maybe (Hash h a)
+hashFromBytesShort bytes
+  | SBS.length bytes == fromIntegral (sizeHash (Proxy :: Proxy h))
+  = Just (UnsafeHash bytes)
 
   | otherwise
   = Nothing

--- a/cardano-crypto-class/src/Cardano/Crypto/Hash/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Hash/Class.hs
@@ -233,7 +233,7 @@ instance (HashAlgorithm h, Typeable a) => FromCBOR (Hash h a) where
 -- Deprecated
 --
 
-{-# DEPRECATED hash "Use hashRaw or hashWithSerialiser" #-}
+{-# DEPRECATED hash "Use hashWith or hashWithSerialiser" #-}
 hash :: forall h a. (HashAlgorithm h, ToCBOR a) => a -> Hash h a
 hash = hashWithSerialiser toCBOR
 
@@ -244,6 +244,7 @@ fromHash = foldl' f 0 . BS.unpack . hashToBytes
     f :: Natural -> Word8 -> Natural
     f n b = n * 256 + fromIntegral b
 
+{-# DEPRECATED hashRaw "Use hashWith" #-}
 hashRaw :: forall h a. HashAlgorithm h => (a -> ByteString) -> a -> Hash h a
 hashRaw = hashWith
 

--- a/cardano-crypto-class/src/Cardano/Crypto/Hash/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Hash/Class.hs
@@ -10,7 +10,6 @@ module Cardano.Crypto.Hash.Class
   , castHash
   , hashRaw
   , hashWithSerialiser
-  , fromHash
   , hashFromBytes
   , getHashBytesAsHex
   , hashFromBytesAsHex
@@ -18,6 +17,7 @@ module Cardano.Crypto.Hash.Class
 
   -- * Deprecated
   , hash
+  , fromHash
   )
 where
 
@@ -133,13 +133,6 @@ hashWithSerialiser toEnc
 hashRaw :: forall h a. HashAlgorithm h => (a -> ByteString) -> a -> Hash h a
 hashRaw serialise = UnsafeHash . digest (Proxy :: Proxy h) . serialise
 
-fromHash :: Hash h a -> Natural
-fromHash = foldl' f 0 . SB.unpack . getHash
-  where
-    f :: Natural -> Word8 -> Natural
-    f n b = n * 256 + fromIntegral b
---TODO: make this efficient ^^
-
 
 -- | Convert the hash to hex encoding, as a ByteString.
 --
@@ -177,3 +170,11 @@ xor (UnsafeHash x) (UnsafeHash y) = UnsafeHash $ SB.pack $ SB.zipWith Bits.xor x
 {-# DEPRECATED hash "Use hashRaw or hashWithSerialiser" #-}
 hash :: forall h a. (HashAlgorithm h, ToCBOR a) => a -> Hash h a
 hash = hashWithSerialiser toCBOR
+
+{-# DEPRECATED fromHash "Use bytesToNatural . hashToBytes" #-}
+fromHash :: Hash h a -> Natural
+fromHash = foldl' f 0 . SB.unpack . getHash
+  where
+    f :: Natural -> Word8 -> Natural
+    f n b = n * 256 + fromIntegral b
+

--- a/cardano-crypto-class/src/Cardano/Crypto/Hash/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Hash/Class.hs
@@ -57,12 +57,8 @@ class Typeable h => HashAlgorithm h where
   -- | The size in bytes of the output of 'digest'
   sizeHash :: proxy h -> Word
 
-  byteCount :: proxy h -> Natural
-  byteCount = fromIntegral . sizeHash
-
   digest :: HasCallStack => proxy h -> ByteString -> ByteString
 
-{-# DEPRECATED byteCount "Use sizeHash" #-}
 
 newtype Hash h a = UnsafeHash {getHash :: ByteString}
   deriving (Eq, Ord, Generic, NFData, NoUnexpectedThunks)
@@ -94,7 +90,7 @@ instance (HashAlgorithm h, Typeable a) => FromCBOR (Hash h a) where
     bs <- decodeBytes
     let la = SB.length bs
         le :: Int
-        le = fromIntegral $ byteCount (Proxy :: Proxy h)
+        le = fromIntegral $ sizeHash (Proxy :: Proxy h)
     if la == le
     then return $ UnsafeHash bs
     else fail $ "expected " ++ show le ++ " byte(s), but got " ++ show la
@@ -162,7 +158,7 @@ hashFromBytesAsHex hexrep
 
 hashFromBytes :: forall h a. HashAlgorithm h => ByteString -> Maybe (Hash h a)
 hashFromBytes bytes
-  | SB.length bytes == fromIntegral (byteCount (Proxy :: Proxy h))
+  | SB.length bytes == fromIntegral (sizeHash (Proxy :: Proxy h))
   = Just (UnsafeHash bytes)
 
   | otherwise

--- a/cardano-crypto-class/src/Cardano/Crypto/Hash/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Hash/Class.hs
@@ -47,7 +47,6 @@ import qualified Data.Text.Encoding as Text
 import Data.Typeable (Typeable)
 import Data.Word (Word8)
 import GHC.Generics (Generic)
-import GHC.Stack
 import Numeric.Natural
 
 import Cardano.Prelude (Base16ParseError, NoUnexpectedThunks, parseBase16)
@@ -59,7 +58,7 @@ class Typeable h => HashAlgorithm h where
   -- | The size in bytes of the output of 'digest'
   sizeHash :: proxy h -> Word
 
-  digest :: HasCallStack => proxy h -> ByteString -> ByteString
+  digest :: proxy h -> ByteString -> ByteString
 
 
 newtype Hash h a = UnsafeHash {getHash :: ByteString}

--- a/cardano-crypto-class/src/Cardano/Crypto/Hash/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Hash/Class.hs
@@ -10,7 +10,6 @@ module Cardano.Crypto.Hash.Class
   , castHash
   , hash
   , hashRaw
-  , hashPair
   , hashWithSerialiser
   , fromHash
   , hashFromBytes
@@ -175,6 +174,3 @@ hashFromBytes bytes
 xor :: Hash h a -> Hash h a -> Hash h a
 xor (UnsafeHash x) (UnsafeHash y) = UnsafeHash $ SB.pack $ SB.zipWith Bits.xor x y
 --TODO: make this efficient ^^
-
-hashPair :: forall h a b c. HashAlgorithm h => Hash h a -> Hash h b -> Hash h c
-hashPair (UnsafeHash a) (UnsafeHash b) = UnsafeHash $ digest (Proxy :: Proxy h) $ a <> b

--- a/cardano-crypto-class/src/Cardano/Crypto/Hash/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Hash/Class.hs
@@ -220,13 +220,6 @@ instance (HashAlgorithm h, Typeable a) => FromCBOR (Hash h a) where
           actual   = SB.length bs
 
 
--- | XOR two hashes together
---
---   This functionality is required for VRF calculation.
-xor :: Hash h a -> Hash h a -> Hash h a
-xor (UnsafeHash x) (UnsafeHash y) = UnsafeHash $ SB.pack $ SB.zipWith Bits.xor x y
---TODO: make this efficient ^^
-
 --
 -- Deprecated
 --
@@ -253,3 +246,7 @@ getHash = hashToBytes
 getHashBytesAsHex :: Hash h a -> ByteString
 getHashBytesAsHex = hashToBytesAsHex
 
+-- | XOR two hashes together
+--TODO: fully deprecate this, or rename it and make it efficient.
+xor :: Hash h a -> Hash h a -> Hash h a
+xor (UnsafeHash x) (UnsafeHash y) = UnsafeHash $ SB.pack $ SB.zipWith Bits.xor x y

--- a/cardano-crypto-class/src/Cardano/Crypto/Hash/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Hash/Class.hs
@@ -14,6 +14,7 @@ module Cardano.Crypto.Hash.Class
 
     -- * Conversions
   , castHash
+  , hashToBytes
   , hashFromBytes
   , getHashBytesAsHex
   , hashFromBytesAsHex
@@ -102,6 +103,25 @@ castHash :: Hash h a -> Hash h b
 castHash (UnsafeHash h) = UnsafeHash h
 
 
+-- | The representation of the hash as bytes.
+--
+hashToBytes :: Hash h a -> ByteString
+hashToBytes (UnsafeHash h) = h
+
+
+-- | Make a hash from it bytes representation.
+--
+-- It must be a a bytestring of the correct length, as given by 'sizeHash'.
+--
+hashFromBytes :: forall h a. HashAlgorithm h => ByteString -> Maybe (Hash h a)
+hashFromBytes bytes
+  | SB.length bytes == fromIntegral (sizeHash (Proxy :: Proxy h))
+  = Just (UnsafeHash bytes)
+
+  | otherwise
+  = Nothing
+
+
 instance Show (Hash h a) where
   show = SB8.unpack . getHashBytesAsHex
 
@@ -175,13 +195,6 @@ hashFromBytesAsHex hexrep
   | otherwise
   = Nothing
 
-hashFromBytes :: forall h a. HashAlgorithm h => ByteString -> Maybe (Hash h a)
-hashFromBytes bytes
-  | SB.length bytes == fromIntegral (sizeHash (Proxy :: Proxy h))
-  = Just (UnsafeHash bytes)
-
-  | otherwise
-  = Nothing
 
 -- | XOR two hashes together
 --

--- a/cardano-crypto-class/src/Cardano/Crypto/Hash/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Hash/Class.hs
@@ -65,7 +65,10 @@ import Numeric.Natural
 
 import Cardano.Prelude (NoUnexpectedThunks)
 
+
 class Typeable h => HashAlgorithm h where
+      --TODO: eliminate this Typeable constraint needed only for the ToCBOR
+      -- the ToCBOR should not need it either
 
   hashAlgorithmName :: proxy h -> String
 

--- a/cardano-crypto-class/src/Cardano/Crypto/Hash/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Hash/Class.hs
@@ -76,6 +76,20 @@ hashWith :: forall h a. HashAlgorithm h => (a -> ByteString) -> a -> Hash h a
 hashWith serialise = UnsafeHash . digest (Proxy :: Proxy h) . serialise
 
 
+--
+-- Conversions
+--
+
+-- | Cast the type of the hashed data.
+--
+-- The 'Hash' type has a phantom type parameter to indicate what type the
+-- hash is of. It is sometimes necessary to fake this and hash a value of one
+-- type and use it where as hash of a different type is expected.
+--
+castHash :: Hash h a -> Hash h b
+castHash (UnsafeHash h) = UnsafeHash h
+
+
 instance Show (Hash h a) where
   show = SB8.unpack . getHashBytesAsHex
 
@@ -133,9 +147,6 @@ parseHash t = do
 
     badSize :: Aeson.Parser (Hash crypto a)
     badSize  = fail "Hash is the wrong length"
-
-castHash :: Hash h a -> Hash h b
-castHash (UnsafeHash h) = UnsafeHash h
 
 hashWithSerialiser :: forall h a. HashAlgorithm h => (a -> Encoding) -> a -> Hash h a
 hashWithSerialiser toEnc = hashWith (serializeEncoding' . toEnc)

--- a/cardano-crypto-class/src/Cardano/Crypto/Hash/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Hash/Class.hs
@@ -8,7 +8,6 @@ module Cardano.Crypto.Hash.Class
   , ByteString
   , Hash(..)
   , castHash
-  , hash
   , hashRaw
   , hashWithSerialiser
   , fromHash
@@ -16,6 +15,9 @@ module Cardano.Crypto.Hash.Class
   , getHashBytesAsHex
   , hashFromBytesAsHex
   , xor
+
+  -- * Deprecated
+  , hash
   )
 where
 
@@ -124,9 +126,6 @@ parseHash t = do
 castHash :: Hash h a -> Hash h b
 castHash (UnsafeHash h) = UnsafeHash h
 
-hash :: forall h a. (HashAlgorithm h, ToCBOR a) => a -> Hash h a
-hash = hashWithSerialiser toCBOR
-
 hashWithSerialiser :: forall h a. HashAlgorithm h => (a -> Encoding) -> a -> Hash h a
 hashWithSerialiser toEnc
   = UnsafeHash . digest (Proxy :: Proxy h) . serializeEncoding' . toEnc
@@ -170,3 +169,11 @@ hashFromBytes bytes
 xor :: Hash h a -> Hash h a -> Hash h a
 xor (UnsafeHash x) (UnsafeHash y) = UnsafeHash $ SB.pack $ SB.zipWith Bits.xor x y
 --TODO: make this efficient ^^
+
+--
+-- Deprecated
+--
+
+{-# DEPRECATED hash "Use hashRaw or hashWithSerialiser" #-}
+hash :: forall h a. (HashAlgorithm h, ToCBOR a) => a -> Hash h a
+hash = hashWithSerialiser toCBOR

--- a/cardano-crypto-class/src/Cardano/Crypto/Hash/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Hash/Class.hs
@@ -7,15 +7,21 @@ module Cardano.Crypto.Hash.Class
   ( HashAlgorithm (..)
   , ByteString
   , Hash(..)
+
+    -- * Core operations
   , hashWith
-  , castHash
   , hashWithSerialiser
+
+    -- * Conversions
+  , castHash
   , hashFromBytes
   , getHashBytesAsHex
   , hashFromBytesAsHex
+
+    -- * Other operations
   , xor
 
-  -- * Deprecated
+    -- * Deprecated
   , hash
   , fromHash
   , hashRaw
@@ -74,6 +80,12 @@ newtype Hash h a = UnsafeHash {getHash :: ByteString}
 --
 hashWith :: forall h a. HashAlgorithm h => (a -> ByteString) -> a -> Hash h a
 hashWith serialise = UnsafeHash . digest (Proxy :: Proxy h) . serialise
+
+
+-- | A variation on 'hashWith', but specially for CBOR encodings.
+--
+hashWithSerialiser :: forall h a. HashAlgorithm h => (a -> Encoding) -> a -> Hash h a
+hashWithSerialiser toEnc = hashWith (serializeEncoding' . toEnc)
 
 
 --
@@ -147,9 +159,6 @@ parseHash t = do
 
     badSize :: Aeson.Parser (Hash crypto a)
     badSize  = fail "Hash is the wrong length"
-
-hashWithSerialiser :: forall h a. HashAlgorithm h => (a -> Encoding) -> a -> Hash h a
-hashWithSerialiser toEnc = hashWith (serializeEncoding' . toEnc)
 
 
 -- | Convert the hash to hex encoding, as a ByteString.

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Class.hs
@@ -49,7 +49,7 @@ import Cardano.Binary (Decoder, decodeBytes, Encoding, encodeBytes, Size, withWo
 
 import Cardano.Crypto.Seed
 import Cardano.Crypto.Util (Empty)
-import Cardano.Crypto.Hash.Class (HashAlgorithm, Hash, hashRaw)
+import Cardano.Crypto.Hash.Class (HashAlgorithm, Hash, hashWith)
 
 
 class ( Typeable v
@@ -83,7 +83,7 @@ class ( Typeable v
   deriveVerKeyKES :: SignKeyKES v -> VerKeyKES v
 
   hashVerKeyKES :: HashAlgorithm h => VerKeyKES v -> Hash h (VerKeyKES v)
-  hashVerKeyKES = hashRaw rawSerialiseVerKeyKES
+  hashVerKeyKES = hashWith rawSerialiseVerKeyKES
 
 
   --

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Mock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Mock.hs
@@ -95,13 +95,13 @@ instance KnownNat t => KESAlgorithm (MockKES t) where
     -- allowed KES period.
     signKES () t a (SignKeyMockKES vk t') =
         assert (t == t') $
-        SigMockKES (castHash (hashRaw getSignableRepresentation a))
+        SigMockKES (castHash (hashWith getSignableRepresentation a))
                    (SignKeyMockKES vk t)
 
     verifyKES () vk t a (SigMockKES h (SignKeyMockKES vk' t'))
       | t' == t
       , vk == vk'
-      , castHash (hashRaw getSignableRepresentation a) == h
+      , castHash (hashWith getSignableRepresentation a) == h
       = Right ()
 
       | otherwise
@@ -132,7 +132,7 @@ instance KnownNat t => KESAlgorithm (MockKES t) where
      <> writeBinaryWord64 (fromIntegral t)
 
     rawSerialiseSigKES (SigMockKES h sk) =
-        getHash h
+        hashToBytes h
      <> rawSerialiseSignKeyKES sk
 
     rawDeserialiseVerKeyKES bs

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Sum.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Sum.hs
@@ -272,7 +272,7 @@ hashPairOfVKeys :: (KESAlgorithm d, HashAlgorithm h)
                 => (VerKeyKES d, VerKeyKES d)
                 -> Hash h (VerKeyKES d, VerKeyKES d)
 hashPairOfVKeys =
-    hashRaw $ \(a,b) ->
+    hashWith $ \(a,b) ->
       rawSerialiseVerKeyKES a <> rawSerialiseVerKeyKES b
 
 slice :: Word -> Word -> ByteString -> ByteString

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Sum.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Sum.hs
@@ -139,7 +139,7 @@ instance (KESAlgorithm d, HashAlgorithm h, Typeable d)
     -- the hash, not the implementation. So that's why we have to hash
     -- the hash here. We could alternatively provide a "key identifier"
     -- function and let the implementation choose what that is.
-    hashVerKeyKES (VerKeySumKES vk) = castHash (hashRaw getHash vk)
+    hashVerKeyKES (VerKeySumKES vk) = castHash (hashWith hashToBytes vk)
 
 
     --
@@ -206,7 +206,7 @@ instance (KESAlgorithm d, HashAlgorithm h, Typeable d)
     sizeSigKES     _ = sizeSigKES     (Proxy :: Proxy d)
                      + sizeVerKeyKES  (Proxy :: Proxy d) * 2
 
-    rawSerialiseVerKeyKES  (VerKeySumKES  vk) = getHash vk
+    rawSerialiseVerKeyKES  (VerKeySumKES  vk) = hashToBytes vk
 
     rawSerialiseSignKeyKES (SignKeySumKES sk r_1 vk_0 vk_1) =
       mconcat

--- a/cardano-crypto-class/src/Cardano/Crypto/VRF/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/VRF/Class.hs
@@ -59,7 +59,7 @@ import Cardano.Binary
 
 import Cardano.Crypto.Util (Empty, bytesToNatural, naturalToBytes)
 import Cardano.Crypto.Seed (Seed)
-import Cardano.Crypto.Hash.Class (HashAlgorithm, Hash, hashRaw)
+import Cardano.Crypto.Hash.Class (HashAlgorithm, Hash, hashWith)
 
 
 class ( Typeable v
@@ -93,7 +93,7 @@ class ( Typeable v
   deriveVerKeyVRF :: SignKeyVRF v -> VerKeyVRF v
 
   hashVerKeyVRF :: HashAlgorithm h => VerKeyVRF v -> Hash h (VerKeyVRF v)
-  hashVerKeyVRF = hashRaw rawSerialiseVerKeyVRF
+  hashVerKeyVRF = hashWith rawSerialiseVerKeyVRF
 
   --
   -- Core algorithm operations

--- a/cardano-crypto-class/src/Cardano/Crypto/VRF/Mock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/VRF/Mock.hs
@@ -136,6 +136,6 @@ evalVRF' :: SignableRepresentation a
          -> SignKeyVRF MockVRF
          -> (OutputVRF MockVRF, CertVRF MockVRF)
 evalVRF' a sk@(SignKeyMockVRF n) =
-  let y = getHash $ hashWithSerialiser @MD5 id $
+  let y = hashToBytes $ hashWithSerialiser @MD5 id $
             toCBOR (getSignableRepresentation a) <> toCBOR sk
   in (OutputVRF y, CertMockVRF n)

--- a/cardano-crypto-class/src/Cardano/Crypto/VRF/Simple.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/VRF/Simple.hs
@@ -89,7 +89,7 @@ pow' :: Point -> Integer -> Point
 pow' (Point p) n = Point $ C.pointMul curve n p
 
 h :: Encoding -> ByteString
-h = getHash . hashWithSerialiser @H id
+h = hashToBytes . hashWithSerialiser @H id
 
 h' :: Encoding -> Integer -> Point
 h' enc l = pow $ mod (l * (fromIntegral . bytesToNatural $ h enc)) q

--- a/cardano-crypto-tests/src/Test/Crypto/Hash.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/Hash.hs
@@ -66,5 +66,5 @@ prop_hash_show_fromString h = h === fromString (show h)
 --
 
 instance HashAlgorithm h => Arbitrary (Hash h a) where
-  arbitrary = castHash . hashRaw SB.pack <$> vector 16
+  arbitrary = castHash . hashWith SB.pack <$> vector 16
   shrink = const []

--- a/cardano-crypto-tests/src/Test/Crypto/Hash.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/Hash.hs
@@ -55,7 +55,7 @@ prop_hash_correct_sizeHash
   => Hash h a
   -> Property
 prop_hash_correct_sizeHash h =
-  SB.length (getHash h) === fromIntegral (sizeHash (Proxy :: Proxy h))
+  SB.length (hashToBytes h) === fromIntegral (sizeHash (Proxy :: Proxy h))
 
 prop_hash_show_fromString :: HashAlgorithm h => Hash h a -> Property
 prop_hash_show_fromString h = h === fromString (show h)

--- a/cardano-crypto-tests/src/Test/Crypto/Hash.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/Hash.hs
@@ -57,7 +57,7 @@ prop_hash_correct_sizeHash
 prop_hash_correct_sizeHash h =
   SB.length (getHash h) === fromIntegral (sizeHash (Proxy :: Proxy h))
 
-prop_hash_show_fromString :: Hash h a -> Property
+prop_hash_show_fromString :: HashAlgorithm h => Hash h a -> Property
 prop_hash_show_fromString h = h === fromString (show h)
 
 

--- a/cardano-crypto-tests/src/Test/Crypto/Hash.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/Hash.hs
@@ -8,7 +8,6 @@ module Test.Crypto.Hash
   )
 where
 
-import Cardano.Binary (ToCBOR(..))
 import Cardano.Crypto.Hash
 import qualified Data.ByteString as SB
 import Data.Proxy (Proxy (..))
@@ -66,6 +65,6 @@ prop_hash_show_fromString h = h === fromString (show h)
 -- Arbitrary instances
 --
 
-instance (ToCBOR a, Arbitrary a, HashAlgorithm h) => Arbitrary (Hash h a) where
-  arbitrary = hash <$> arbitrary
+instance HashAlgorithm h => Arbitrary (Hash h a) where
+  arbitrary = castHash . hashRaw SB.pack <$> vector 16
   shrink = const []


### PR DESCRIPTION
Add a number of functions with more sensible names, and deprecate the old ones.

Change the representation of Hash to use ShortByteString, cutting the size from 13 words to 8.