### PR TITLE
Comment out incorrect test to unblock other PRs

### DIFF
--- a/cardano-crypto-tests/src/Test/Crypto/Hash.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/Hash.hs
@@ -11,7 +11,6 @@ where
 import Cardano.Crypto.Hash
 import qualified Data.ByteString as SB
 import Data.Proxy (Proxy (..))
-import Data.String (IsString (..))
 import Test.Crypto.Util (prop_cbor, prop_cbor_size, prop_no_unexpected_thunks)
 import Test.QuickCheck
 import Test.Tasty (TestTree, testGroup)
@@ -40,7 +39,11 @@ testHashAlgorithm _ n =
     [ testProperty "hash size" $ prop_hash_correct_sizeHash @h @[Int]
     , testProperty "serialise" $ prop_hash_cbor @h
     , testProperty "ToCBOR size" $ prop_hash_cbor_size @h
-    , testProperty "show/fromString" $ prop_hash_show_fromString @h @Float
+
+    -- TODO The following property is wrong because show and fromString are not inverses of each other
+    -- Commenting the following out to fix CI and unblock other unrelated PRs to this project.
+
+    -- , testProperty "show/fromString" $ prop_hash_show_fromString @h @Float
     , testProperty "NoUnexpectedThunks" $ prop_no_unexpected_thunks @(Hash h Int)
     ]
 
@@ -57,8 +60,8 @@ prop_hash_correct_sizeHash
 prop_hash_correct_sizeHash h =
   SB.length (hashToBytes h) === fromIntegral (sizeHash (Proxy :: Proxy h))
 
-prop_hash_show_fromString :: HashAlgorithm h => Hash h a -> Property
-prop_hash_show_fromString h = h === fromString (show h)
+-- prop_hash_show_fromString :: HashAlgorithm h => Hash h a -> Property
+-- prop_hash_show_fromString h = h === fromString (show h)
 
 
 --


### PR DESCRIPTION
The problem property:

```haskell
testProperty "show/fromString" $ prop_hash_show_fromString @h @Float

prop_hash_show_fromString :: HashAlgorithm h => Hash h a -> Property
prop_hash_show_fromString h = h === fromString (show h)
```

This property does not hold true for `ByteString`:

```haskell
λ> let bs = "abc" :: BS.ByteString
bs :: BS.ByteString
λ> bs == fromString (show bs)
False
it :: Bool
```

`fromString` is not the inverse of `show`.  Rather `read` is the inverse of `show`:

```haskell
λ> let bs = "abc" :: BS.ByteString
bs :: BS.ByteString
λ> bs == read (show bs)
True
```

This PR is necessary because `master` is currently broken in CI and unrelated PRs are unable to merge.

We will separately and fairly urgently need a proper fix including to introduce replacement property tests.