### PR TITLE
Prevent accidental reintroduction of Ord instances for keys

### DIFF
--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Class.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -5,6 +6,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 -- | Abstract digital signatures.
 module Cardano.Crypto.DSIGN.Class
@@ -43,6 +45,7 @@ import Data.Typeable (Typeable)
 import GHC.Exts (Constraint)
 import GHC.Generics (Generic)
 import GHC.Stack
+import GHC.TypeLits (TypeError, ErrorMessage (..))
 
 import Cardano.Prelude (NoUnexpectedThunks)
 import Cardano.Binary (Decoder, decodeBytes, Encoding, encodeBytes, Size, withWordSize)
@@ -142,6 +145,21 @@ class ( Typeable v
   rawDeserialiseSignKeyDSIGN :: ByteString -> Maybe (SignKeyDSIGN v)
   rawDeserialiseSigDSIGN     :: ByteString -> Maybe (SigDSIGN     v)
 
+--
+-- Do not provide Ord instances for keys, see #38
+--
+
+instance ( TypeError ('Text "Ord not supported for signing keys, use the hash instead")
+         , Eq (SignKeyDSIGN v)
+         )
+      => Ord (SignKeyDSIGN v) where
+    compare = error "unsupported"
+
+instance ( TypeError ('Text "Ord not supported for verification keys, use the hash instead")
+         , Eq (VerKeyDSIGN v)
+         )
+      => Ord (VerKeyDSIGN v) where
+    compare = error "unsupported"
 
 --
 -- Convenient CBOR encoding/decoding

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Mock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Mock.hs
@@ -40,11 +40,11 @@ instance DSIGNAlgorithm MockDSIGN where
     --
 
     newtype VerKeyDSIGN MockDSIGN = VerKeyMockDSIGN Word64
-        deriving stock   (Show, Eq, Ord, Generic)
+        deriving stock   (Show, Eq, Generic)
         deriving newtype (Num, NoUnexpectedThunks)
 
     newtype SignKeyDSIGN MockDSIGN = SignKeyMockDSIGN Word64
-        deriving stock   (Show, Eq, Ord, Generic)
+        deriving stock   (Show, Eq, Generic)
         deriving newtype (Num, NoUnexpectedThunks)
 
     data SigDSIGN MockDSIGN = SigMockDSIGN !(Hash ShortHash ()) !Word64

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/NeverUsed.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/NeverUsed.hs
@@ -26,10 +26,10 @@ data NeverDSIGN
 instance DSIGNAlgorithm NeverDSIGN where
 
   data VerKeyDSIGN  NeverDSIGN = NeverUsedVerKeyDSIGN
-     deriving (Show, Eq, Ord, Generic, NoUnexpectedThunks)
+     deriving (Show, Eq, Generic, NoUnexpectedThunks)
 
   data SignKeyDSIGN NeverDSIGN = NeverUsedSignKeyDSIGN
-     deriving (Show, Eq, Ord, Generic, NoUnexpectedThunks)
+     deriving (Show, Eq, Generic, NoUnexpectedThunks)
 
   data SigDSIGN     NeverDSIGN = NeverUsedSigDSIGN
      deriving (Show, Eq, Ord, Generic, NoUnexpectedThunks)

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Class.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -5,6 +6,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 -- | Abstract key evolving signatures.
 module Cardano.Crypto.KES.Class
@@ -43,6 +45,7 @@ import Data.Typeable (Typeable)
 import GHC.Exts (Constraint)
 import GHC.Generics (Generic)
 import GHC.Stack
+import GHC.TypeLits (TypeError, ErrorMessage (..))
 
 import Cardano.Prelude (NoUnexpectedThunks)
 import Cardano.Binary (Decoder, decodeBytes, Encoding, encodeBytes, Size, withWordSize)
@@ -189,6 +192,21 @@ class ( Typeable v
   rawDeserialiseSignKeyKES :: ByteString -> Maybe (SignKeyKES v)
   rawDeserialiseSigKES     :: ByteString -> Maybe (SigKES v)
 
+--
+-- Do not provide Ord instances for keys, see #38
+--
+
+instance ( TypeError ('Text "Ord not supported for signing keys, use the hash instead")
+         , Eq (SignKeyKES v)
+         )
+      => Ord (SignKeyKES v) where
+    compare = error "unsupported"
+
+instance ( TypeError ('Text "Ord not supported for verification keys, use the hash instead")
+         , KESAlgorithm v
+         )
+      => Ord (VerKeyKES v) where
+    compare = error "unsupported"
 
 --
 -- Convenient CBOR encoding/decoding

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Mock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Mock.hs
@@ -53,12 +53,12 @@ instance KnownNat t => KESAlgorithm (MockKES t) where
     --
 
     newtype VerKeyKES (MockKES t) = VerKeyMockKES Word64
-        deriving stock   (Show, Eq, Ord, Generic)
+        deriving stock   (Show, Eq, Generic)
         deriving newtype (NoUnexpectedThunks)
 
     data SignKeyKES (MockKES t) =
            SignKeyMockKES !(VerKeyKES (MockKES t)) !Period
-        deriving stock    (Show, Eq, Ord, Generic)
+        deriving stock    (Show, Eq, Generic)
         deriving anyclass (NoUnexpectedThunks)
 
     data SigKES (MockKES t) =

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/NeverUsed.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/NeverUsed.hs
@@ -25,13 +25,13 @@ data NeverKES
 instance KESAlgorithm NeverKES where
 
   data VerKeyKES  NeverKES = NeverUsedVerKeyKES
-      deriving (Show, Eq, Ord, Generic, NoUnexpectedThunks)
+      deriving (Show, Eq, Generic, NoUnexpectedThunks)
 
   data SignKeyKES NeverKES = NeverUsedSignKeyKES
-      deriving (Show, Eq, Ord, Generic, NoUnexpectedThunks)
+      deriving (Show, Eq, Generic, NoUnexpectedThunks)
 
   data SigKES     NeverKES = NeverUsedSigKES
-      deriving (Show, Eq, Ord, Generic, NoUnexpectedThunks)
+      deriving (Show, Eq, Generic, NoUnexpectedThunks)
 
   algorithmNameKES _ = "never"
 

--- a/cardano-crypto-class/src/Cardano/Crypto/VRF/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/VRF/Class.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -8,6 +9,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 -- | Abstract Verifiable Random Functions.
 module Cardano.Crypto.VRF.Class
@@ -50,6 +52,7 @@ import Numeric.Natural (Natural)
 import GHC.Exts (Constraint)
 import GHC.Generics (Generic)
 import GHC.Stack
+import GHC.TypeLits (TypeError, ErrorMessage (..))
 
 import Cardano.Prelude (NoUnexpectedThunks)
 import Cardano.Binary
@@ -176,6 +179,22 @@ class ( Typeable v
       , sizeCertVRF
       , sizeOutputVRF
     #-}
+
+--
+-- Do not provide Ord instances for keys, see #38
+--
+
+instance ( TypeError ('Text "Ord not supported for signing keys, use the hash instead")
+         , Eq (SignKeyVRF v)
+         )
+      => Ord (SignKeyVRF v) where
+    compare = error "unsupported"
+
+instance ( TypeError ('Text "Ord not supported for verification keys, use the hash instead")
+         , Eq (VerKeyVRF v)
+         )
+      => Ord (VerKeyVRF v) where
+    compare = error "unsupported"
 
 -- | The output bytes of the VRF.
 --

--- a/cardano-crypto-class/src/Cardano/Crypto/VRF/NeverUsed.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/VRF/NeverUsed.hs
@@ -26,10 +26,10 @@ data NeverVRF
 instance VRFAlgorithm NeverVRF where
 
   data VerKeyVRF NeverVRF = NeverUsedVerKeyVRF
-    deriving (Show, Eq, Ord, Generic, NoUnexpectedThunks)
+    deriving (Show, Eq, Generic, NoUnexpectedThunks)
 
   data SignKeyVRF NeverVRF = NeverUsedSignKeyVRF
-    deriving (Show, Eq, Ord, Generic, NoUnexpectedThunks)
+    deriving (Show, Eq, Generic, NoUnexpectedThunks)
 
   data CertVRF NeverVRF = NeverUsedCertVRF
     deriving (Show, Eq, Ord, Generic, NoUnexpectedThunks)


### PR DESCRIPTION
The auditors have recommended in the past to remove `Ord` instances for signing
and verification keys. Instead, the comparison should be done on the hashes of
the keys.

See:
* https://github.com/input-output-hk/cardano-ledger/pull/587
* https://github.com/input-output-hk/cardano-base/pull/38
* https://github.com/input-output-hk/cardano-base/pull/60

After having been removed, these instances have been accidentally reintroduced
and people have wondered a few times why the instances were missing.

Using `TypeError` as a superclass constraint for a blanket `Ord` instance, it is
no longer possible to *accidentally* reintroduce an `Ord` instance because of
the overlap. Not even as orphans.

When `Ord` is needed for testing purposes, one should use `Ord` on the hashes or
use a newtype.