### PR TITLE
DSIGN key forgetting

### DIFF
--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Single.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Single.hs
@@ -123,10 +123,8 @@ instance ( NaCl.SodiumDSIGNAlgorithm d -- needed for secure forgetting
     --
     -- forgetting
     --
-
-    -- TODO: to implement this, we
-    -- should know how to forget DSIGN keys.
-    forgetSignKeyKES = const $ return ()
+    forgetSignKeyKES (SignKeySingleKES sk) =
+      NaCl.naclForgetSignKeyDSIGN (Proxy @d) sk
 
     --
     -- raw serialise/deserialise

--- a/cardano-crypto-class/src/Cardano/Crypto/Libsodium.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Libsodium.hs
@@ -23,6 +23,7 @@ module Cardano.Crypto.Libsodium (
   SodiumDSIGNAlgorithm (..),
   naclSignDSIGN,
   naclVerifyDSIGN,
+  naclForgetSignKeyDSIGN,
   SodiumSignKeyDSIGN,
   SodiumVerKeyDSIGN,
   SodiumSigDSIGN,

--- a/cardano-crypto-class/src/Cardano/Crypto/Libsodium/DSIGN.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Libsodium/DSIGN.hs
@@ -10,6 +10,7 @@ module Cardano.Crypto.Libsodium.DSIGN (
     SodiumDSIGNAlgorithm (..),
     naclSignDSIGN,
     naclVerifyDSIGN,
+    naclForgetSignKeyDSIGN,
     SodiumSignKeyDSIGN,
     SodiumVerKeyDSIGN,
     SodiumSigDSIGN,
@@ -62,6 +63,13 @@ class (DSIGNAlgorithm v, ContextDSIGN v ~ (), Signable v ~ SignableRepresentatio
         :: Proxy v
         -> SodiumSignKeyDSIGN v
         -> SodiumVerKeyDSIGN v
+
+naclForgetSignKeyDSIGN
+    :: Proxy v
+    -> SodiumSignKeyDSIGN v
+    -> IO ()
+naclForgetSignKeyDSIGN _ (MLSB mfp) =
+  finalizeMLockedForeignPtr mfp
 
 naclSignDSIGN
     :: (SodiumDSIGNAlgorithm v, SignableRepresentation a)


### PR DESCRIPTION
Expose secure forgetting for the DSIGN implementation, and use it to securely forget the DSIGN part of the SignKeyKES of the SumKES and SingleKES implementations.

Should only be merged after #138.