### PR TITLE
Proposed forget-logging mockup KES wrapper (RFC)

### DIFF
--- a/cardano-crypto-class/cardano-crypto-class.cabal
+++ b/cardano-crypto-class/cardano-crypto-class.cabal
@@ -43,6 +43,7 @@ library
 
                        Cardano.Crypto.KES.Class
                        Cardano.Crypto.KES.Mock
+                       Cardano.Crypto.KES.ForgetMock
                        Cardano.Crypto.KES.NeverUsed
                        Cardano.Crypto.KES.Simple
                        Cardano.Crypto.KES.Single
@@ -84,6 +85,7 @@ library
                      , memory
                      , nothunks
                      , primitive
+                     , stm
                      , text
                      , transformers
                      , vector

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Class.hs
@@ -47,6 +47,7 @@ import GHC.Generics (Generic)
 import GHC.Stack
 import GHC.TypeLits (Nat, KnownNat, natVal)
 import NoThunks.Class (NoThunks)
+>>>>>>> Cardano.Crypto.KES using libsodium bindings
 
 import Cardano.Binary (Decoder, decodeBytes, Encoding, encodeBytes, Size, withWordSize)
 

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/ForgetMock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/ForgetMock.hs
@@ -1,0 +1,125 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE LambdaCase #-}
+
+-- | Mock key evolving signatures.
+module Cardano.Crypto.KES.ForgetMock
+  ( ForgetMockKES
+  , VerKeyKES (..)
+  , SignKeyKES (..)
+  , SigKES (..)
+  )
+where
+
+import Data.Proxy (Proxy(..))
+import GHC.Generics (Generic)
+
+import Cardano.Prelude (lift, MonadIO, liftIO, ReaderT (..), ask)
+
+import Cardano.Crypto.KES.Class
+import Debug.Trace (traceEvent)
+import NoThunks.Class (NoThunks)
+import System.IO.Unsafe
+
+-- | A wrapper for a KES implementation that adds logging functionality, for
+-- the purpose of verifying that invocations of 'genKeyKES' and
+-- 'forgetSignKeyKES' pair up properly in a given host application.
+--
+-- The wrapped KES behaves exactly like its unwrapped payload, except that
+-- invocations of 'genKeyKES', 'updateKES' and 'forgetSignKeyKES' are logged
+-- to the eventlog (via 'traceEvent'), prefixed with @"PRE: "@, @"UPD: "@,
+-- or @"DEL: "@, respectively.
+data ForgetMockKES k
+
+type Logger = String -> IO ()
+
+instance
+  ( KESAlgorithm k
+  , MonadIO (ForgetKES k)
+  )
+  => KESAlgorithm (ForgetMockKES k) where
+    type SeedSizeKES (ForgetMockKES k) = SeedSizeKES k
+    type Signable (ForgetMockKES k) = Signable k
+
+    newtype VerKeyKES (ForgetMockKES k) = VerKeyForgetMockKES (VerKeyKES k)
+      deriving (Generic)
+    newtype SignKeyKES (ForgetMockKES k) = SignKeyForgetMockKES (SignKeyKES k)
+      deriving (Generic)
+    newtype SigKES (ForgetMockKES k) = SigForgetMockKES (SigKES k)
+      deriving (Generic)
+
+    type ContextKES (ForgetMockKES k) = ContextKES k
+
+    type GenerateKES (ForgetMockKES k) = ReaderT Logger (GenerateKES k)
+    type ForgetKES (ForgetMockKES k) = ReaderT Logger (ForgetKES k)
+
+    genKeyKES seed = do
+      sk <- lift $ genKeyKES seed
+      (writeLog :: Logger) <- ask
+      let a = unsafePerformIO $ writeLog ("GEN: " ++ show sk)
+      a `seq` return (SignKeyForgetMockKES sk)
+
+    forgetSignKeyKES (SignKeyForgetMockKES sk) = do
+      writeLog <- ask
+      liftIO $ writeLog ("DEL: " ++ show sk)
+      return ()
+
+    algorithmNameKES _ = algorithmNameKES (Proxy @k)
+
+    deriveVerKeyKES (SignKeyForgetMockKES k) = VerKeyForgetMockKES $ deriveVerKeyKES k
+
+    signKES ctx p msg (SignKeyForgetMockKES sk) =
+        SigForgetMockKES $ signKES ctx p msg sk
+
+    verifyKES ctx (VerKeyForgetMockKES vk) p msg (SigForgetMockKES sig) =
+        verifyKES ctx vk p msg sig
+
+    updateKES ctx (SignKeyForgetMockKES sk) p = do
+      writeLog <- ask
+      lift (updateKES ctx sk p) >>= \case
+        Just sk' -> do
+          let a = unsafePerformIO $ writeLog ("UPD: " ++ show sk')
+          a `seq` (return $ Just $ SignKeyForgetMockKES sk')
+        Nothing -> do
+          let a = unsafePerformIO $ writeLog ("UPD: ---")
+          a `seq` return Nothing
+
+    totalPeriodsKES _ = totalPeriodsKES (Proxy @k)
+
+    sizeVerKeyKES _ = sizeVerKeyKES (Proxy @k)
+    sizeSignKeyKES _ = sizeSignKeyKES (Proxy @k)
+    sizeSigKES _ = sizeSigKES (Proxy @k)
+
+    rawSerialiseVerKeyKES (VerKeyForgetMockKES k) = rawSerialiseVerKeyKES k
+    rawSerialiseSignKeyKES (SignKeyForgetMockKES k) = rawSerialiseSignKeyKES k
+    rawSerialiseSigKES (SigForgetMockKES k) = rawSerialiseSigKES k
+
+    rawDeserialiseVerKeyKES = fmap VerKeyForgetMockKES . rawDeserialiseVerKeyKES
+    rawDeserialiseSignKeyKES = fmap SignKeyForgetMockKES . rawDeserialiseSignKeyKES
+    rawDeserialiseSigKES = fmap SigForgetMockKES . rawDeserialiseSigKES
+
+
+
+deriving instance Show (VerKeyKES k) => Show (VerKeyKES (ForgetMockKES k))
+deriving instance Eq (VerKeyKES k) => Eq (VerKeyKES (ForgetMockKES k))
+deriving instance Ord (VerKeyKES k) => Ord (VerKeyKES (ForgetMockKES k))
+deriving instance NoThunks (VerKeyKES k) => NoThunks (VerKeyKES (ForgetMockKES k))
+
+deriving instance Show (SignKeyKES k) => Show (SignKeyKES (ForgetMockKES k))
+deriving instance Eq (SignKeyKES k) => Eq (SignKeyKES (ForgetMockKES k))
+deriving instance Ord (SignKeyKES k) => Ord (SignKeyKES (ForgetMockKES k))
+deriving instance NoThunks (SignKeyKES k) => NoThunks (SignKeyKES (ForgetMockKES k))
+
+deriving instance Show (SigKES k) => Show (SigKES (ForgetMockKES k))
+deriving instance Eq (SigKES k) => Eq (SigKES (ForgetMockKES k))
+deriving instance Ord (SigKES k) => Ord (SigKES (ForgetMockKES k))
+deriving instance NoThunks (SigKES k) => NoThunks (SigKES (ForgetMockKES k))

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Mock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Mock.hs
@@ -89,8 +89,8 @@ instance KnownNat t => KESAlgorithm (MockKES t) where
     updateKES () (SignKeyMockKES vk t') t =
         assert (t == t') $
          if t+1 < totalPeriodsKES (Proxy @ (MockKES t))
-           then Just (SignKeyMockKES vk (t+1))
-           else Nothing
+           then return $ Just (SignKeyMockKES vk (t+1))
+           else return Nothing
 
     -- | Produce valid signature only with correct key, i.e., same iteration and
     -- allowed KES period.
@@ -115,9 +115,9 @@ instance KnownNat t => KESAlgorithm (MockKES t) where
     -- Key generation
     --
 
-    genKeyKES seed =
+    genKeyKES seed = do
         let vk = VerKeyMockKES (runMonadRandomWithSeed (mkSeedFromBytes $ mlsbToByteString seed) getRandomWord64)
-         in SignKeyMockKES vk 0
+        return $ SignKeyMockKES vk 0
 
 
     --

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/NeverUsed.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/NeverUsed.hs
@@ -45,7 +45,7 @@ instance KESAlgorithm NeverKES where
 
   totalPeriodsKES _ = 0
 
-  genKeyKES       _ = NeverUsedSignKeyKES
+  genKeyKES       _ = return NeverUsedSignKeyKES
 
   sizeVerKeyKES  _ = 0
   sizeSignKeyKES _ = 0

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Simple.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Simple.hs
@@ -40,6 +40,8 @@ import           Cardano.Crypto.Seed
 import           Cardano.Crypto.Util
 import           Cardano.Crypto.Libsodium (mlsbToByteString)
 
+import qualified GHC.TypeLits
+
 
 data SimpleKES d (t :: Nat)
 
@@ -64,10 +66,10 @@ pattern SignKeySimpleKES v <- ThunkySignKeySimpleKES v
 
 {-# COMPLETE SignKeySimpleKES #-}
 
-instance (DSIGNAlgorithm d, Typeable d, KnownNat t, KnownNat (SeedSizeDSIGN d * t)) =>
+instance (DSIGNAlgorithm d, Typeable d, KnownNat t, KnownNat (SeedSizeDSIGN d GHC.TypeLits.* t)) =>
          KESAlgorithm (SimpleKES d t) where
 
-    type SeedSizeKES (SimpleKES d t) = SeedSizeDSIGN d * t
+    type SeedSizeKES (SimpleKES d t) = SeedSizeDSIGN d GHC.TypeLits.* t
 
     --
     -- Key and signature types
@@ -199,31 +201,31 @@ instance DSIGNAlgorithm d => NoThunks (SigKES     (SimpleKES d t))
 instance DSIGNAlgorithm d => NoThunks (SignKeyKES (SimpleKES d t))
 instance DSIGNAlgorithm d => NoThunks (VerKeyKES  (SimpleKES d t))
 
-instance (DSIGNAlgorithm d, Typeable d, KnownNat t, KnownNat (SeedSizeDSIGN d * t))
+instance (DSIGNAlgorithm d, Typeable d, KnownNat t, KnownNat (SeedSizeDSIGN d GHC.TypeLits.* t))
       => ToCBOR (VerKeyKES (SimpleKES d t)) where
   toCBOR = encodeVerKeyKES
   encodedSizeExpr _size = encodedVerKeyKESSizeExpr
 
-instance (DSIGNAlgorithm d, Typeable d, KnownNat t, KnownNat (SeedSizeDSIGN d * t))
+instance (DSIGNAlgorithm d, Typeable d, KnownNat t, KnownNat (SeedSizeDSIGN d GHC.TypeLits.* t))
       => FromCBOR (VerKeyKES (SimpleKES d t)) where
   fromCBOR = decodeVerKeyKES
 
 
-instance (DSIGNAlgorithm d, Typeable d, KnownNat t, KnownNat (SeedSizeDSIGN d * t))
+instance (DSIGNAlgorithm d, Typeable d, KnownNat t, KnownNat (SeedSizeDSIGN d GHC.TypeLits.* t))
       => ToCBOR (SignKeyKES (SimpleKES d t)) where
   toCBOR = encodeSignKeyKES
   encodedSizeExpr _size = encodedSignKeyKESSizeExpr
 
-instance (DSIGNAlgorithm d, Typeable d, KnownNat t, KnownNat (SeedSizeDSIGN d * t))
+instance (DSIGNAlgorithm d, Typeable d, KnownNat t, KnownNat (SeedSizeDSIGN d GHC.TypeLits.* t))
       => FromCBOR (SignKeyKES (SimpleKES d t)) where
   fromCBOR = decodeSignKeyKES
 
-instance (DSIGNAlgorithm d, Typeable d, KnownNat t, KnownNat (SeedSizeDSIGN d * t))
+instance (DSIGNAlgorithm d, Typeable d, KnownNat t, KnownNat (SeedSizeDSIGN d GHC.TypeLits.* t))
       => ToCBOR (SigKES (SimpleKES d t)) where
   toCBOR = encodeSigKES
   encodedSizeExpr _size = encodedSigKESSizeExpr
 
-instance (DSIGNAlgorithm d, Typeable d, KnownNat t, KnownNat (SeedSizeDSIGN d * t))
+instance (DSIGNAlgorithm d, Typeable d, KnownNat t, KnownNat (SeedSizeDSIGN d GHC.TypeLits.* t))
       => FromCBOR (SigKES (SimpleKES d t)) where
   fromCBOR = decodeSigKES
 

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Simple.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Simple.hs
@@ -114,8 +114,8 @@ instance (DSIGNAlgorithm d, Typeable d, KnownNat t, KnownNat (SeedSizeDSIGN d * 
           Just vk -> verifyDSIGN ctxt vk a sig
 
     updateKES _ sk t
-      | t+1 < fromIntegral (natVal (Proxy @ t)) = Just sk
-      | otherwise                               = Nothing
+      | t+1 < fromIntegral (natVal (Proxy @ t)) = return $ Just sk
+      | otherwise                               = return Nothing
 
     totalPeriodsKES  _ = fromIntegral (natVal (Proxy @ t))
 
@@ -137,7 +137,7 @@ instance (DSIGNAlgorithm d, Typeable d, KnownNat t, KnownNat (SeedSizeDSIGN d * 
                      . map mkSeedFromBytes
                      $ unfoldr (getBytesFromSeed seedSize) seed
             sks      = map genKeyDSIGN seeds
-         in SignKeySimpleKES (Vec.fromList sks)
+         in return $ SignKeySimpleKES (Vec.fromList sks)
 
 
     --

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Simple.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Simple.hs
@@ -40,8 +40,6 @@ import           Cardano.Crypto.Seed
 import           Cardano.Crypto.Util
 import           Cardano.Crypto.Libsodium (mlsbToByteString)
 
-import qualified GHC.TypeLits
-
 
 data SimpleKES d (t :: Nat)
 
@@ -66,10 +64,10 @@ pattern SignKeySimpleKES v <- ThunkySignKeySimpleKES v
 
 {-# COMPLETE SignKeySimpleKES #-}
 
-instance (DSIGNAlgorithm d, Typeable d, KnownNat t, KnownNat (SeedSizeDSIGN d GHC.TypeLits.* t)) =>
+instance (DSIGNAlgorithm d, Typeable d, KnownNat t, KnownNat (SeedSizeDSIGN d * t)) =>
          KESAlgorithm (SimpleKES d t) where
 
-    type SeedSizeKES (SimpleKES d t) = SeedSizeDSIGN d GHC.TypeLits.* t
+    type SeedSizeKES (SimpleKES d t) = SeedSizeDSIGN d * t
 
     --
     -- Key and signature types
@@ -201,31 +199,31 @@ instance DSIGNAlgorithm d => NoThunks (SigKES     (SimpleKES d t))
 instance DSIGNAlgorithm d => NoThunks (SignKeyKES (SimpleKES d t))
 instance DSIGNAlgorithm d => NoThunks (VerKeyKES  (SimpleKES d t))
 
-instance (DSIGNAlgorithm d, Typeable d, KnownNat t, KnownNat (SeedSizeDSIGN d GHC.TypeLits.* t))
+instance (DSIGNAlgorithm d, Typeable d, KnownNat t, KnownNat (SeedSizeDSIGN d * t))
       => ToCBOR (VerKeyKES (SimpleKES d t)) where
   toCBOR = encodeVerKeyKES
   encodedSizeExpr _size = encodedVerKeyKESSizeExpr
 
-instance (DSIGNAlgorithm d, Typeable d, KnownNat t, KnownNat (SeedSizeDSIGN d GHC.TypeLits.* t))
+instance (DSIGNAlgorithm d, Typeable d, KnownNat t, KnownNat (SeedSizeDSIGN d * t))
       => FromCBOR (VerKeyKES (SimpleKES d t)) where
   fromCBOR = decodeVerKeyKES
 
 
-instance (DSIGNAlgorithm d, Typeable d, KnownNat t, KnownNat (SeedSizeDSIGN d GHC.TypeLits.* t))
+instance (DSIGNAlgorithm d, Typeable d, KnownNat t, KnownNat (SeedSizeDSIGN d * t))
       => ToCBOR (SignKeyKES (SimpleKES d t)) where
   toCBOR = encodeSignKeyKES
   encodedSizeExpr _size = encodedSignKeyKESSizeExpr
 
-instance (DSIGNAlgorithm d, Typeable d, KnownNat t, KnownNat (SeedSizeDSIGN d GHC.TypeLits.* t))
+instance (DSIGNAlgorithm d, Typeable d, KnownNat t, KnownNat (SeedSizeDSIGN d * t))
       => FromCBOR (SignKeyKES (SimpleKES d t)) where
   fromCBOR = decodeSignKeyKES
 
-instance (DSIGNAlgorithm d, Typeable d, KnownNat t, KnownNat (SeedSizeDSIGN d GHC.TypeLits.* t))
+instance (DSIGNAlgorithm d, Typeable d, KnownNat t, KnownNat (SeedSizeDSIGN d * t))
       => ToCBOR (SigKES (SimpleKES d t)) where
   toCBOR = encodeSigKES
   encodedSizeExpr _size = encodedSigKESSizeExpr
 
-instance (DSIGNAlgorithm d, Typeable d, KnownNat t, KnownNat (SeedSizeDSIGN d GHC.TypeLits.* t))
+instance (DSIGNAlgorithm d, Typeable d, KnownNat t, KnownNat (SeedSizeDSIGN d * t))
       => FromCBOR (SigKES (SimpleKES d t)) where
   fromCBOR = decodeSigKES
 

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Single.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Single.hs
@@ -104,7 +104,7 @@ instance ( NaCl.SodiumDSIGNAlgorithm d -- needed for secure forgetting
         assert (t == 0) $
         NaCl.naclVerifyDSIGN (Proxy @d) vk a sig
 
-    updateKES _ctx (SignKeySingleKES _sk) _to = Nothing
+    updateKES _ctx (SignKeySingleKES _sk) _to = return Nothing
 
     totalPeriodsKES  _ = 1
 
@@ -112,7 +112,8 @@ instance ( NaCl.SodiumDSIGNAlgorithm d -- needed for secure forgetting
     -- Key generation
     --
 
-    genKeyKES seed = SignKeySingleKES (NaCl.naclGenKeyDSIGN (Proxy @d) seed)
+    genKeyKES seed =
+      return $ SignKeySingleKES (NaCl.naclGenKeyDSIGN (Proxy @d) seed)
 
     --
     -- forgetting

--- a/cardano-crypto-class/src/Cardano/Crypto/Libsodium/Memory/Internal.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Libsodium/Memory/Internal.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE CPP #-}
 module Cardano.Crypto.Libsodium.Memory.Internal (
   -- * High-level memory management
   MLockedForeignPtr (..),
@@ -14,8 +15,12 @@ module Cardano.Crypto.Libsodium.Memory.Internal (
   mlockedAllocaSized,
   sodiumMalloc,
   sodiumFree,
+  -- * Debugging / testing instrumentation
+  popAllocLogEvent
 ) where
 
+import Control.Concurrent.STM (atomically)
+import Control.Concurrent.STM.TChan (newTChanIO, TChan, tryReadTChan, writeTChan)
 import Control.Exception (bracket)
 import Control.Monad (when)
 import Data.Coerce (coerce)
@@ -23,14 +28,29 @@ import Data.Proxy (Proxy (..))
 import Foreign.C.Error (errnoToIOError, getErrno)
 import Foreign.C.Types (CSize (..))
 import Foreign.ForeignPtr (ForeignPtr, newForeignPtr, withForeignPtr, finalizeForeignPtr)
-import Foreign.Ptr (Ptr, nullPtr)
+import Foreign.Ptr (Ptr, nullPtr, WordPtr, ptrToWordPtr)
 import Foreign.Storable (Storable (alignment, sizeOf, peek))
 import GHC.TypeLits (KnownNat, natVal)
 import GHC.IO.Exception (ioException)
 import NoThunks.Class (NoThunks, OnlyCheckWhnfNamed (..))
+import System.IO.Unsafe (unsafePerformIO)
 
 import Cardano.Foreign
 import Cardano.Crypto.Libsodium.C
+
+data AllocEvent
+  = AllocEv !WordPtr
+  | FreeEv !WordPtr
+
+{-#NOINLINE allocLog #-}
+allocLog :: TChan AllocEvent
+allocLog = unsafePerformIO newTChanIO
+
+popAllocLogEvent :: IO (Maybe AllocEvent)
+popAllocLogEvent = atomically $ tryReadTChan allocLog
+
+pushAllocLogEvent :: AllocEvent -> IO ()
+pushAllocLogEvent = atomically . writeTChan allocLog
 
 -- | Foreign pointer to securely allocated memory.
 newtype MLockedForeignPtr a = SFP { _unwrapMLockedForeignPtr :: ForeignPtr a }
@@ -83,10 +103,15 @@ sodiumMalloc size = do
     when (ptr == nullPtr) $ do
         errno <- getErrno
         ioException $ errnoToIOError "c_sodium_malloc" errno Nothing Nothing
+    -- putStrLn $ "sodiumMalloc " <> show ptr
+    pushAllocLogEvent $ AllocEv (ptrToWordPtr ptr)
     return ptr
 
 sodiumFree :: Ptr a -> IO ()
-sodiumFree = c_sodium_free
+sodiumFree ptr = do
+  -- putStrLn $ "sodiumFree " <> show ptr
+  pushAllocLogEvent $ FreeEv (ptrToWordPtr ptr)
+  c_sodium_free ptr
 
 mlockedAlloca :: forall a b. CSize -> (Ptr a -> IO b) -> IO b
 mlockedAlloca size = bracket (sodiumMalloc size) sodiumFree

--- a/cardano-crypto-tests/cardano-crypto-tests.cabal
+++ b/cardano-crypto-tests/cardano-crypto-tests.cabal
@@ -31,6 +31,7 @@ library
 
   build-depends:       base
                      , bytestring
+                     , cardano-prelude
                      , cardano-binary
                      , cardano-crypto-class
                      , cardano-crypto-praos
@@ -42,6 +43,8 @@ library
                      , quickcheck-instances
                      , tasty
                      , tasty-quickcheck
+                     , tasty-hunit
+                     , HUnit
 
   default-language:    Haskell2010
 

--- a/cardano-crypto-tests/src/Test/Crypto/Hash.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/Hash.hs
@@ -67,16 +67,6 @@ testSodiumHashAlgorithm p =
     ]
     where n = hashAlgorithmName p
 
-testSodiumHashAlgorithm
-  :: forall proxy h. NaCl.SodiumHashAlgorithm h
-  => proxy h
-  -> TestTree 
-testSodiumHashAlgorithm p =
-  testGroup n
-    [ testProperty "sodium and cryptonite work the same" $ prop_libsodium_model @h Proxy
-    ]
-    where n = hashAlgorithmName p
-
 prop_hash_cbor :: HashAlgorithm h => Hash h Int -> Property
 prop_hash_cbor = prop_cbor
 

--- a/cardano-crypto-tests/src/Test/Crypto/Hash.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/Hash.hs
@@ -67,6 +67,16 @@ testSodiumHashAlgorithm p =
     ]
     where n = hashAlgorithmName p
 
+testSodiumHashAlgorithm
+  :: forall proxy h. NaCl.SodiumHashAlgorithm h
+  => proxy h
+  -> TestTree 
+testSodiumHashAlgorithm p =
+  testGroup n
+    [ testProperty "sodium and cryptonite work the same" $ prop_libsodium_model @h Proxy
+    ]
+    where n = hashAlgorithmName p
+
 prop_hash_cbor :: HashAlgorithm h => Hash h Int -> Property
 prop_hash_cbor = prop_cbor
 


### PR DESCRIPTION
In order to improve testability of the forgetfulness feature of the `KESAlgorithm` typeclass, we provide a wrapper type, `ForgetMockKES`, which wraps around any other KES implementation, and adds two logging actions, one in the `genKeyKES` method, and one in the `forgetSignKeyKES` method. Both emit a log message to stdout, consisting of a rendering of the key in question (as per `Show`), prefixed with `GEN:` or `DEL:` to indicate key generation and deletion, respectively.

The intended use case for this is to run KES-consuming code against this wrapped KES instance, capturing stdout over the lifecycle of the code; and then, by analyzing the output, pairing up `GEN` and `DEL` lines per unique key, we can check whether the code behaves as intended. Specifically, we can verify that for each generated key, the `forgetSignKeyKES` method is invoked exactly once.