### PR TITLE
Avoid using broken api function base16.decode

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -15,14 +15,14 @@ package cardano-crypto
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: a5519e09958ad1605ed438d26dd7aad39167d0f9
+  tag: 0115bc2b0b245af2aea8d4e229c8f5e9ce90b767
   --sha256: 03v46yn5bnkmwcm1zwihjhqvma4ssh3s1s1bfdizvq18y1janwf1
   subdir: cardano-prelude
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: a5519e09958ad1605ed438d26dd7aad39167d0f9
+  tag: 0115bc2b0b245af2aea8d4e229c8f5e9ce90b767
   --sha256: 03v46yn5bnkmwcm1zwihjhqvma4ssh3s1s1bfdizvq18y1janwf1
   subdir: cardano-prelude-test
 


### PR DESCRIPTION
Broken as in broken API compatibility.  This change allows the code to compile against any version of `base16-bytestring`.  It is currently set to `0.1.1.7`.  In future this will be bumped to `1.0.0.0` requiring no code change.