### PR TITLE
Prevent accidental reintroduction of Ord instances for keys

### DIFF
--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Class.hs
@@ -5,8 +5,9 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 -- | Abstract digital signatures.
 module Cardano.Crypto.DSIGN.Class
@@ -49,7 +50,7 @@ import Data.Typeable (Typeable)
 import GHC.Exts (Constraint)
 import GHC.Generics (Generic)
 import GHC.Stack
-import GHC.TypeLits (KnownNat, Nat, natVal)
+import GHC.TypeLits (KnownNat, Nat, natVal, TypeError, ErrorMessage (..))
 import NoThunks.Class (NoThunks)
 
 import Cardano.Binary (Decoder, decodeBytes, Encoding, encodeBytes, Size, withWordSize)
@@ -149,6 +150,21 @@ class ( Typeable v
   rawDeserialiseSignKeyDSIGN :: ByteString -> Maybe (SignKeyDSIGN v)
   rawDeserialiseSigDSIGN     :: ByteString -> Maybe (SigDSIGN     v)
 
+--
+-- Do not provide Ord instances for keys, see #38
+--
+
+instance ( TypeError ('Text "Ord not supported for signing keys, use the hash instead")
+         , Eq (SignKeyDSIGN v)
+         )
+      => Ord (SignKeyDSIGN v) where
+    compare = error "unsupported"
+
+instance ( TypeError ('Text "Ord not supported for verification keys, use the hash instead")
+         , Eq (VerKeyDSIGN v)
+         )
+      => Ord (VerKeyDSIGN v) where
+    compare = error "unsupported"
 
 -- | The upper bound on the 'Seed' size needed by 'genKeyDSIGN'
 seedSizeDSIGN :: forall v proxy. DSIGNAlgorithm v => proxy v -> Word

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Mock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Mock.hs
@@ -49,11 +49,11 @@ instance DSIGNAlgorithm MockDSIGN where
     --
 
     newtype VerKeyDSIGN MockDSIGN = VerKeyMockDSIGN Word64
-        deriving stock   (Show, Eq, Ord, Generic)
+        deriving stock   (Show, Eq, Generic)
         deriving newtype (Num, NoThunks)
 
     newtype SignKeyDSIGN MockDSIGN = SignKeyMockDSIGN Word64
-        deriving stock   (Show, Eq, Ord, Generic)
+        deriving stock   (Show, Eq, Generic)
         deriving newtype (Num, NoThunks)
 
     data SigDSIGN MockDSIGN = SigMockDSIGN !(Hash ShortHash ()) !Word64

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/NeverUsed.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/NeverUsed.hs
@@ -31,13 +31,13 @@ instance DSIGNAlgorithm NeverDSIGN where
   type SizeSigDSIGN     NeverDSIGN = 0
 
   data VerKeyDSIGN  NeverDSIGN = NeverUsedVerKeyDSIGN
-     deriving (Show, Eq, Ord, Generic, NoThunks)
+     deriving (Show, Eq, Generic, NoThunks)
 
   data SignKeyDSIGN NeverDSIGN = NeverUsedSignKeyDSIGN
-     deriving (Show, Eq, Ord, Generic, NoThunks)
+     deriving (Show, Eq, Generic, NoThunks)
 
   data SigDSIGN     NeverDSIGN = NeverUsedSigDSIGN
-     deriving (Show, Eq, Ord, Generic, NoThunks)
+     deriving (Show, Eq, Generic, NoThunks)
 
   algorithmNameDSIGN _ = "never"
 

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Class.hs
@@ -7,6 +7,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 -- | Abstract key evolving signatures.
 module Cardano.Crypto.KES.Class
@@ -45,7 +46,7 @@ import Data.Typeable (Typeable)
 import GHC.Exts (Constraint)
 import GHC.Generics (Generic)
 import GHC.Stack
-import GHC.TypeLits (Nat, KnownNat, natVal)
+import GHC.TypeLits (Nat, KnownNat, natVal, TypeError, ErrorMessage (..))
 import NoThunks.Class (NoThunks)
 
 import Cardano.Binary (Decoder, decodeBytes, Encoding, encodeBytes, Size, withWordSize)
@@ -195,6 +196,21 @@ class ( Typeable v
   rawDeserialiseSignKeyKES :: ByteString -> Maybe (SignKeyKES v)
   rawDeserialiseSigKES     :: ByteString -> Maybe (SigKES v)
 
+--
+-- Do not provide Ord instances for keys, see #38
+--
+
+instance ( TypeError ('Text "Ord not supported for signing keys, use the hash instead")
+         , Eq (SignKeyKES v)
+         )
+      => Ord (SignKeyKES v) where
+    compare = error "unsupported"
+
+instance ( TypeError ('Text "Ord not supported for verification keys, use the hash instead")
+         , KESAlgorithm v
+         )
+      => Ord (VerKeyKES v) where
+    compare = error "unsupported"
 
 --
 -- Convenient CBOR encoding/decoding

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Mock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Mock.hs
@@ -54,12 +54,12 @@ instance KnownNat t => KESAlgorithm (MockKES t) where
     --
 
     newtype VerKeyKES (MockKES t) = VerKeyMockKES Word64
-        deriving stock   (Show, Eq, Ord, Generic)
+        deriving stock   (Show, Eq, Generic)
         deriving newtype (NoThunks)
 
     data SignKeyKES (MockKES t) =
            SignKeyMockKES !(VerKeyKES (MockKES t)) !Period
-        deriving stock    (Show, Eq, Ord, Generic)
+        deriving stock    (Show, Eq, Generic)
         deriving anyclass (NoThunks)
 
     data SigKES (MockKES t) =

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/NeverUsed.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/NeverUsed.hs
@@ -27,13 +27,13 @@ instance KESAlgorithm NeverKES where
   type SeedSizeKES NeverKES = 0
 
   data VerKeyKES  NeverKES = NeverUsedVerKeyKES
-      deriving (Show, Eq, Ord, Generic, NoThunks)
+      deriving (Show, Eq, Generic, NoThunks)
 
   data SignKeyKES NeverKES = NeverUsedSignKeyKES
-      deriving (Show, Eq, Ord, Generic, NoThunks)
+      deriving (Show, Eq, Generic, NoThunks)
 
   data SigKES     NeverKES = NeverUsedSigKES
-      deriving (Show, Eq, Ord, Generic, NoThunks)
+      deriving (Show, Eq, Generic, NoThunks)
 
   algorithmNameKES _ = "never"
 

--- a/cardano-crypto-class/src/Cardano/Crypto/VRF/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/VRF/Class.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -8,6 +9,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 -- | Abstract Verifiable Random Functions.
 module Cardano.Crypto.VRF.Class
@@ -42,15 +44,17 @@ module Cardano.Crypto.VRF.Class
 where
 
 import Data.ByteString (ByteString)
-import qualified Data.ByteString as BS
 import Data.Kind (Type)
 import Data.Proxy (Proxy(..))
 import Data.Typeable (Typeable)
-import Numeric.Natural (Natural)
 import GHC.Exts (Constraint)
 import GHC.Generics (Generic)
 import GHC.Stack
+import GHC.TypeLits (TypeError, ErrorMessage (..))
 import NoThunks.Class (NoThunks)
+import Numeric.Natural (Natural)
+
+import qualified Data.ByteString as BS
 
 import Cardano.Binary
          (Decoder, Encoding, FromCBOR (..), ToCBOR (..), Size,
@@ -176,6 +180,22 @@ class ( Typeable v
       , sizeCertVRF
       , sizeOutputVRF
     #-}
+
+--
+-- Do not provide Ord instances for keys, see #38
+--
+
+instance ( TypeError ('Text "Ord not supported for signing keys, use the hash instead")
+         , Eq (SignKeyVRF v)
+         )
+      => Ord (SignKeyVRF v) where
+    compare = error "unsupported"
+
+instance ( TypeError ('Text "Ord not supported for verification keys, use the hash instead")
+         , Eq (VerKeyVRF v)
+         )
+      => Ord (VerKeyVRF v) where
+    compare = error "unsupported"
 
 -- | The output bytes of the VRF.
 --

--- a/cardano-crypto-class/src/Cardano/Crypto/VRF/NeverUsed.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/VRF/NeverUsed.hs
@@ -25,10 +25,10 @@ data NeverVRF
 instance VRFAlgorithm NeverVRF where
 
   data VerKeyVRF NeverVRF = NeverUsedVerKeyVRF
-    deriving (Show, Eq, Ord, Generic, NoThunks)
+    deriving (Show, Eq, Generic, NoThunks)
 
   data SignKeyVRF NeverVRF = NeverUsedSignKeyVRF
-    deriving (Show, Eq, Ord, Generic, NoThunks)
+    deriving (Show, Eq, Generic, NoThunks)
 
   data CertVRF NeverVRF = NeverUsedCertVRF
     deriving (Show, Eq, Ord, Generic, NoThunks)


### PR DESCRIPTION
This is a rebase of https://github.com/input-output-hk/cardano-base/pull/158
