### PR TITLE
Export `decodeMapSkel`.

### DIFF
--- a/binary/src/Cardano/Binary/FromCBOR.hs
+++ b/binary/src/Cardano/Binary/FromCBOR.hs
@@ -15,6 +15,8 @@ module Cardano.Binary.FromCBOR
   , module D
   , fromCBORMaybe
   , decodeListWith
+    -- * Helper tools to build instances
+  , decodeMapSkel
   )
 where
 


### PR DESCRIPTION
This will be useful to define an efficient decoder for `Bimap`.