### PR TITLE
Rollback KES changes

### DIFF
--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Class.hs
@@ -51,10 +51,10 @@ import NoThunks.Class (NoThunks)
 
 import Cardano.Binary (Decoder, decodeBytes, Encoding, encodeBytes, Size, withWordSize)
 
+import Cardano.Crypto.Seed
 import Cardano.Crypto.Util (Empty)
 import Cardano.Crypto.Hash.Class (HashAlgorithm, Hash, hashWith)
 
-import qualified Cardano.Crypto.Libsodium as NaCl
 
 class ( Typeable v
       , Show (VerKeyKES v)
@@ -161,7 +161,7 @@ class ( Typeable v
   -- Key generation
   --
 
-  genKeyKES :: NaCl.MLockedSizedBytes (SeedSizeKES v) -> SignKeyKES v
+  genKeyKES :: Seed -> SignKeyKES v
 
   -- | The upper bound on the 'Seed' size needed by 'genKeyKES'
   seedSizeKES :: proxy v -> Word

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Mock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Mock.hs
@@ -31,7 +31,7 @@ import Cardano.Crypto.Hash
 import Cardano.Crypto.Seed
 import Cardano.Crypto.KES.Class
 import Cardano.Crypto.Util
-import Cardano.Crypto.Libsodium (mlsbToByteString)
+
 
 data MockKES (t :: Nat)
 
@@ -116,7 +116,7 @@ instance KnownNat t => KESAlgorithm (MockKES t) where
     --
 
     genKeyKES seed =
-        let vk = VerKeyMockKES (runMonadRandomWithSeed (mkSeedFromBytes $ mlsbToByteString seed) getRandomWord64)
+        let vk = VerKeyMockKES (runMonadRandomWithSeed seed getRandomWord64)
          in SignKeyMockKES vk 0
 
 

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Simple.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Simple.hs
@@ -38,7 +38,6 @@ import qualified Cardano.Crypto.DSIGN as DSIGN
 import           Cardano.Crypto.KES.Class
 import           Cardano.Crypto.Seed
 import           Cardano.Crypto.Util
-import           Cardano.Crypto.Libsodium (mlsbToByteString)
 
 
 data SimpleKES d (t :: Nat)
@@ -129,9 +128,8 @@ instance (DSIGNAlgorithm d, Typeable d, KnownNat t, KnownNat (SeedSizeDSIGN d * 
             duration = fromIntegral (natVal (Proxy @ t))
          in duration * seedSize
 
-    genKeyKES mlsb =
-        let seed     = mkSeedFromBytes $ mlsbToByteString mlsb
-            seedSize = seedSizeDSIGN (Proxy :: Proxy d)
+    genKeyKES seed =
+        let seedSize = seedSizeDSIGN (Proxy :: Proxy d)
             duration = fromIntegral (natVal (Proxy @ t))
             seeds    = take duration
                      . map mkSeedFromBytes

--- a/cardano-crypto-tests/src/Bench/Crypto/KES.hs
+++ b/cardano-crypto-tests/src/Bench/Crypto/KES.hs
@@ -15,14 +15,14 @@ import Cardano.Crypto.DSIGN.Ed25519
 import Cardano.Crypto.Hash.Blake2b
 import Cardano.Crypto.KES.Class
 import Cardano.Crypto.KES.Sum
-import Cardano.Crypto.Libsodium
+import Cardano.Crypto.Seed
 import qualified Data.ByteString as BS (pack)
 import Data.Maybe (fromJust)
 
 {- HLINT ignore "Use camelCase" -}
 
-testSeed :: forall (n :: Nat). KnownNat n => MLockedSizedBytes n
-testSeed = mlsbFromByteString (BS.pack testBytes)
+testSeed :: Seed
+testSeed = mkSeedFromBytes (BS.pack testBytes)
 
 testBytes :: [Word8]
 testBytes = [

--- a/cardano-crypto-tests/src/Test/Crypto/KES.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/KES.hs
@@ -22,7 +22,6 @@ import Cardano.Crypto.DSIGN hiding (Signable)
 import Cardano.Crypto.Hash
 import Cardano.Crypto.KES
 import Cardano.Crypto.Util (SignableRepresentation(..))
-import qualified Cardano.Crypto.Libsodium as NaCl
 
 import Test.QuickCheck
 import Test.Tasty (TestTree, testGroup, adjustOption)
@@ -50,9 +49,9 @@ tests =
 -- instance here.
 deriving instance Eq (SignKeyDSIGN d) => Eq (SignKeyKES (SimpleKES d t))
 
-deriving instance Eq (NaCl.SodiumSignKeyDSIGN d)
+deriving instance Eq (SignKeyDSIGN d)
                => Eq (SignKeyKES (SingleKES d))
-deriving instance (KESAlgorithm d, NaCl.SodiumHashAlgorithm h, Eq (SignKeyKES d))
+deriving instance (KESAlgorithm d, Eq (SignKeyKES d))
                => Eq (SignKeyKES (SumKES h d))
 
 testKESAlgorithm
@@ -363,7 +362,9 @@ instance KESAlgorithm v => Arbitrary (VerKeyKES v) where
   shrink = const []
 
 instance KESAlgorithm v => Arbitrary (SignKeyKES v) where
-  arbitrary = genKeyKES <$> arbitrary
+  arbitrary = genKeyKES <$> arbitrarySeedOfSize seedSize
+    where
+      seedSize = seedSizeKES (Proxy :: Proxy v)
   shrink = const []
 
 instance (KESAlgorithm v, ContextKES v ~ (), Signable v ~ SignableRepresentation)


### PR DESCRIPTION
The KES changes to use libsodium currently cause a segfault when running the node. This commit reverts them until we can do more extensive testing to work out where this problem is.