### PR TITLE
Upgrade cardano-prelude

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -15,16 +15,11 @@ package cardano-crypto
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: 0115bc2b0b245af2aea8d4e229c8f5e9ce90b767
-  --sha256: 03v46yn5bnkmwcm1zwihjhqvma4ssh3s1s1bfdizvq18y1janwf1
-  subdir: cardano-prelude
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/cardano-prelude
-  tag: 0115bc2b0b245af2aea8d4e229c8f5e9ce90b767
-  --sha256: 03v46yn5bnkmwcm1zwihjhqvma4ssh3s1s1bfdizvq18y1janwf1
-  subdir: cardano-prelude-test
+  tag: 742e8525b96bf4b66fb61a00c8298d75d7931d5e
+  --sha256: 1132r58bjgdcf7yz3n77nlrkanqcmpn5b5km4nw151yar2dgifsv
+  subdir:
+    cardano-prelude
+    cardano-prelude-test
 
 source-repository-package
   type: git


### PR DESCRIPTION
This is to fix rts.h inclusion warning.

See https://github.com/input-output-hk/cardano-prelude/pull/140