### PR TITLE
Include size summary in error string

### DIFF
--- a/cardano-crypto-praos/src/Cardano/Crypto/VRF/Praos.hs
+++ b/cardano-crypto-praos/src/Cardano/Crypto/VRF/Praos.hs
@@ -332,10 +332,13 @@ proofFromBytes bs
         copyFromByteString ptr bs certSizeVRF
       return proof
 
+sizeSummary :: String
+sizeSummary = show (certSizeVRF, signKeySizeVRF, verKeySizeVRF, vrfKeySizeVRF)
+
 skFromBytes :: ByteString -> SignKey
 skFromBytes bs
   | bsLen /= signKeySizeVRF
-  = error ("Invalid sk length " <> show @Int bsLen <> ", expecting " <> show @Int signKeySizeVRF)
+  = error ("Invalid sk length " <> show @Int bsLen <> ", expecting " <> show @Int signKeySizeVRF <> ", size summary is " <> sizeSummary)
   | otherwise
   = unsafePerformIO $ do
       sk <- mkSignKey
@@ -348,7 +351,7 @@ skFromBytes bs
 vkFromBytes :: ByteString -> VerKey
 vkFromBytes bs
   | BS.length bs /= verKeySizeVRF
-  = error ("Invalid pk length " <> show @Int bsLen <> ", expecting " <> show @Int verKeySizeVRF)
+  = error ("Invalid pk length " <> show @Int bsLen <> ", expecting " <> show @Int verKeySizeVRF <> ", size summary is " <> sizeSummary)
   | otherwise
   = unsafePerformIO $ do
       pk <- mkVerKey


### PR DESCRIPTION
To investigate mysterious constant not-so-constant issue.

The issue being investigated is that `signKeySizeVRF ` is supposed to return `64` always, but very rarely it returns something else like `58104768`.  This change is to see how many similar constants are affected.