### PR TITLE
build: Enable build with recursion-schemes 5.2

### DIFF
--- a/binary/cardano-binary.cabal
+++ b/binary/cardano-binary.cabal
@@ -41,11 +41,12 @@ library
                      , cardano-prelude
                      , cborg              >= 0.2.2 && < 0.3
                      , containers
+                     , data-fix
                      , digest
                      , formatting
                      , nothunks
                      , primitive
-                     , recursion-schemes  >= 5.1   && < 5.2
+                     , recursion-schemes  >= 5.1
                      , safe-exceptions
                      , tagged
                      , text

--- a/binary/src/Cardano/Binary/ToCBOR.hs
+++ b/binary/src/Cardano/Binary/ToCBOR.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                       #-}
 {-# LANGUAGE ConstrainedClassMethods   #-}
 {-# LANGUAGE DeriveFunctor             #-}
 {-# LANGUAGE ExistentialQuantification #-}
@@ -44,7 +45,12 @@ import qualified Data.ByteString.Short as SBS
 import qualified Data.ByteString.Short.Internal as SBS
 import qualified Data.Primitive.ByteArray as Prim
 import Data.Fixed (E12, Fixed(..), Nano, Pico, resolution)
-import Data.Functor.Foldable (Fix(..), cata, unfix)
+#if MIN_VERSION_recursion_schemes(5,2,0)
+import Data.Fix ( Fix(..) )
+#else
+import Data.Functor.Foldable (Fix(..))
+#endif
+import Data.Functor.Foldable (cata, project)
 import qualified Data.Map as M
 import qualified Data.Set as S
 import Data.Tagged (Tagged(..))
@@ -166,7 +172,7 @@ instance B.Buildable t => B.Buildable (SizeF t) where
           TodoF _ x -> bprint ("(_ :: " . shown . ")") (typeRep x)
 
 instance B.Buildable (Fix SizeF) where
-  build x = bprint build (unfix x)
+  build x = bprint build (project @(Fix _) x)
 
 -- | Create a case expression from individual cases.
 szCases :: [Case Size] -> Size


### PR DESCRIPTION
This PR obsoletes https://github.com/input-output-hk/cardano-base/pull/162, it enables `cardano-binary` to be build with `recursion-schemes >= 5.2` and removes the constraint `recursion-schemes =< 5.2`.