### PR TITLE
Add a strict-containers package

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -7,6 +7,7 @@ packages:
   cardano-crypto-praos
   cardano-crypto-tests
   slotting
+  strict-containers
 
 -- Disable tests in a dependency (which are currently broken)
 package cardano-crypto

--- a/hie-cabal.yaml
+++ b/hie-cabal.yaml
@@ -23,3 +23,6 @@ cradle:
 
     - path: "slotting/src"
       component: "lib:cardano-slotting"
+
+    - path: "strict-containers"
+      component: "lib:strict-containers"

--- a/strict-containers/LICENSE
+++ b/strict-containers/LICENSE
@@ -1,0 +1,53 @@
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+You must give any other recipients of the Work or Derivative Works a copy of this License; and
+You must cause any modified files to carry prominent notices stating that You changed the files; and
+You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License. 
+
+You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/strict-containers/NOTICE
+++ b/strict-containers/NOTICE
@@ -1,0 +1,13 @@
+Copyright 2021 Input Output (Hong Kong) Ltd.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/strict-containers/Setup.hs
+++ b/strict-containers/Setup.hs
@@ -1,0 +1,2 @@
+import Distribution.Simple
+main = defaultMain

--- a/strict-containers/src/Data/FingerTree/Strict.hs
+++ b/strict-containers/src/Data/FingerTree/Strict.hs
@@ -1,0 +1,290 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE StandaloneDeriving #-}
+
+-- | Strict variants of 'FingerTree' operations.
+module Data.FingerTree.Strict
+  ( StrictFingerTree,
+    fromStrict,
+    forceToStrict,
+
+    -- * Construction
+    empty,
+    singleton,
+    (<|),
+    (|>),
+    (><),
+    fromList,
+
+    -- * Deconstruction
+    null,
+
+    -- ** Examining the ends
+    viewl,
+    viewr,
+
+    -- ** Search
+    SearchResult (..),
+    search,
+
+    -- ** Splitting
+
+    -- | These functions are special cases of 'search'.
+    split,
+    takeUntil,
+    dropUntil,
+
+    -- * Transformation
+    reverse,
+
+    -- ** Maps
+    fmap',
+    unsafeFmap,
+    -- Re-export from "Data.FingerTree"
+    Measured (..),
+    ViewL (..),
+    ViewR (..),
+  )
+where
+
+import Data.FingerTree (Measured (..), ViewL (..), ViewR (..))
+import qualified Data.FingerTree as FT
+import Data.Foldable (foldl', toList)
+import Data.Unit.Strict (forceElemsToWHNF)
+import GHC.Generics (Generic)
+import NoThunks.Class (NoThunks (..), noThunksInValues)
+import Prelude hiding (null, reverse)
+
+infixr 5 ><
+
+infixr 5 <|
+
+infixl 5 |>
+
+-- | A @newtype@ wrapper around a 'FT.FingerTree', representing a finger tree
+-- that is strict in its values.
+--
+-- This strictness is not enforced at the type level, but rather by the
+-- construction functions in this module. These functions essentially just
+-- wrap the original "Data.FingerTree" functions while forcing the provided
+-- value to WHNF.
+newtype StrictFingerTree v a = SFT {fromStrict :: FT.FingerTree v a}
+  deriving (Eq, Ord, Show)
+
+deriving newtype instance Foldable (StrictFingerTree v)
+
+deriving newtype instance (Measured v a) => Measured v (StrictFingerTree v a)
+
+instance NoThunks a => NoThunks (StrictFingerTree v a) where
+  showTypeOf _ = "StrictFingerTree"
+  wNoThunks ctxt = noThunksInValues ctxt . toList
+
+{-------------------------------------------------------------------------------
+  Construction
+-------------------------------------------------------------------------------}
+
+-- | /O(1)/. The empty sequence.
+empty :: Measured v a => StrictFingerTree v a
+empty = SFT FT.empty
+
+-- | /O(1)/. A singleton sequence.
+singleton :: Measured v a => a -> StrictFingerTree v a
+singleton !a = SFT (FT.singleton a)
+
+-- | /O(n)/. Create a sequence from a finite list of elements.
+-- The opposite operation 'toList' is supplied by the 'Foldable' instance.
+fromList :: (Measured v a) => [a] -> StrictFingerTree v a
+fromList !xs = foldl' (|>) (SFT FT.empty) xs
+
+-- | /O(1)/. Add an element to the left end of a sequence.
+-- Mnemonic: a triangle with the single element at the pointy end.
+(<|) :: (Measured v a) => a -> StrictFingerTree v a -> StrictFingerTree v a
+(!a) <| SFT ft = SFT (a FT.<| ft)
+
+-- | /O(1)/. Add an element to the right end of a sequence.
+-- Mnemonic: a triangle with the single element at the pointy end.
+(|>) :: (Measured v a) => StrictFingerTree v a -> a -> StrictFingerTree v a
+SFT ft |> (!a) = SFT (ft FT.|> a)
+
+-- | /O(log(min(n1,n2)))/. Concatenate two sequences.
+(><) ::
+  (Measured v a) =>
+  StrictFingerTree v a ->
+  StrictFingerTree v a ->
+  StrictFingerTree v a
+SFT ft >< SFT ft' = SFT (ft FT.>< ft')
+
+-- | Convert a 'FT.FingerTree' into a 'StrictFingerTree' by forcing each element
+-- to WHNF.
+forceToStrict :: FT.FingerTree v a -> StrictFingerTree v a
+forceToStrict xs = SFT (forceElemsToWHNF xs)
+
+{-------------------------------------------------------------------------------
+  Deconstruction
+-------------------------------------------------------------------------------}
+
+-- | /O(1)/. Is this the empty sequence?
+null :: StrictFingerTree v a -> Bool
+null (SFT ft) = FT.null ft
+
+{-------------------------------------------------------------------------------
+  Examining the ends
+-------------------------------------------------------------------------------}
+
+-- | /O(1)/. Analyse the left end of a sequence.
+viewl ::
+  (Measured v a) =>
+  StrictFingerTree v a ->
+  ViewL (StrictFingerTree v) a
+viewl (SFT ft) = case FT.viewl ft of
+  EmptyL -> EmptyL
+  a :< ft' -> a :< SFT ft'
+
+-- | /O(1)/. Analyse the right end of a sequence.
+viewr ::
+  (Measured v a) =>
+  StrictFingerTree v a ->
+  ViewR (StrictFingerTree v) a
+viewr (SFT ft) = case FT.viewr ft of
+  EmptyR -> EmptyR
+  ft' :> a -> SFT ft' :> a
+
+{-------------------------------------------------------------------------------
+  Search
+-------------------------------------------------------------------------------}
+
+-- | A result of 'search', attempting to find a point where a predicate
+-- on splits of the sequence changes from 'False' to 'True'.
+--
+-- @since 0.1.2.0
+data SearchResult v a
+  = -- | A tree opened at a particular element: the prefix to the
+    -- left, the element, and the suffix to the right.
+    Position !(StrictFingerTree v a) !a !(StrictFingerTree v a)
+  | -- | A position to the left of the sequence, indicating that the
+    -- predicate is 'True' at both ends.
+    OnLeft
+  | -- | A position to the right of the sequence, indicating that the
+    -- predicate is 'False' at both ends.
+    OnRight
+  | -- | No position in the tree, returned if the predicate is 'True'
+    -- at the left end and 'False' at the right end.  This will not
+    -- occur if the predicate in monotonic on the tree.
+    Nowhere
+  deriving (Eq, Ord, Show, Generic)
+
+-- | Convert from an 'FT.SearchResult' (the data type from "Data.FingerTree")
+-- to a 'SearchResult' (the data type from this module).
+fromOriginalSearchResult :: FT.SearchResult v a -> SearchResult v a
+fromOriginalSearchResult (FT.Position left a right) =
+  Position (SFT left) a (SFT right)
+fromOriginalSearchResult FT.OnLeft = OnLeft
+fromOriginalSearchResult FT.OnRight = OnRight
+fromOriginalSearchResult FT.Nowhere = Nowhere
+
+-- | /O(log(min(i,n-i)))/. Search a sequence for a point where a predicate
+-- on splits of the sequence changes from 'False' to 'True'.
+--
+-- The argument @p@ is a relation between the measures of the two
+-- sequences that could be appended together to form the sequence @t@.
+-- If the relation is 'False' at the leftmost split and 'True' at the
+-- rightmost split, i.e.
+--
+-- @not (p 'mempty' ('measure' t)) && p ('measure' t) 'mempty'@
+--
+-- then there must exist an element @x@ in the sequence such that @p@
+-- is 'False' for the split immediately before @x@ and 'True' for the
+-- split just after it:
+--
+-- <<images/search.svg>>
+--
+-- In this situation, @'search' p t@ returns such an element @x@ and the
+-- pieces @l@ and @r@ of the sequence to its left and right respectively.
+-- That is, it returns @'Position' l x r@ such that
+--
+-- * @l >< (x <| r) = t@
+--
+-- * @not (p (measure l) (measure (x <| r))@
+--
+-- * @p (measure (l |> x)) (measure r)@
+--
+-- For predictable results, one should ensure that there is only one such
+-- point, i.e. that the predicate is /monotonic/ on @t@.
+--
+-- @since 0.1.2.0
+search ::
+  (Measured v a) =>
+  (v -> v -> Bool) ->
+  StrictFingerTree v a ->
+  SearchResult v a
+search p (SFT ft) = fromOriginalSearchResult (FT.search p ft)
+
+{-------------------------------------------------------------------------------
+  Splitting
+-------------------------------------------------------------------------------}
+
+-- | /O(log(min(i,n-i)))/. Split a sequence at a point where the predicate
+-- on the accumulated measure of the prefix changes from 'False' to 'True'.
+--
+-- For predictable results, one should ensure that there is only one such
+-- point, i.e. that the predicate is /monotonic/.
+split ::
+  (Measured v a) =>
+  (v -> Bool) ->
+  StrictFingerTree v a ->
+  (StrictFingerTree v a, StrictFingerTree v a)
+split p (SFT ft) = (SFT left, SFT right)
+  where
+    (left, right) = FT.split p ft
+
+-- | /O(log(min(i,n-i)))/.
+-- Given a monotonic predicate @p@, @'takeUntil' p t@ is the largest
+-- prefix of @t@ whose measure does not satisfy @p@.
+--
+-- *  @'takeUntil' p t = 'fst' ('split' p t)@
+takeUntil ::
+  (Measured v a) =>
+  (v -> Bool) ->
+  StrictFingerTree v a ->
+  StrictFingerTree v a
+takeUntil p (SFT ft) = SFT (FT.takeUntil p ft)
+
+-- | /O(log(min(i,n-i)))/.
+-- Given a monotonic predicate @p@, @'dropUntil' p t@ is the rest of @t@
+-- after removing the largest prefix whose measure does not satisfy @p@.
+--
+-- * @'dropUntil' p t = 'snd' ('split' p t)@
+dropUntil ::
+  (Measured v a) =>
+  (v -> Bool) ->
+  StrictFingerTree v a ->
+  StrictFingerTree v a
+dropUntil p (SFT ft) = SFT (FT.dropUntil p ft)
+
+{-------------------------------------------------------------------------------
+  Transformation
+-------------------------------------------------------------------------------}
+
+-- | /O(n)/. The reverse of a sequence.
+reverse :: (Measured v a) => StrictFingerTree v a -> StrictFingerTree v a
+reverse (SFT ft) = SFT (FT.reverse ft)
+
+{-------------------------------------------------------------------------------
+  Maps
+-------------------------------------------------------------------------------}
+
+-- | Like 'fmap', but with constraints on the element types.
+fmap' ::
+  (Measured v1 a1, Measured v2 a2) =>
+  (a1 -> a2) ->
+  StrictFingerTree v1 a1 ->
+  StrictFingerTree v2 a2
+fmap' f (SFT ft) = forceToStrict (FT.fmap' f ft)
+
+-- | Like 'fmap', but safe only if the function preserves the measure.
+unsafeFmap :: (a -> b) -> StrictFingerTree v a -> StrictFingerTree v b
+unsafeFmap f (SFT ft) = forceToStrict (FT.unsafeFmap f ft)

--- a/strict-containers/src/Data/Maybe/Strict.hs
+++ b/strict-containers/src/Data/Maybe/Strict.hs
@@ -1,0 +1,107 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveTraversable #-}
+
+-- | Strict version of the 'Maybe' type.
+module Data.Maybe.Strict
+  ( StrictMaybe (SNothing, SJust),
+
+    -- * Conversion: StrictMaybe <--> Maybe
+    strictMaybeToMaybe,
+    maybeToStrictMaybe,
+
+    -- * accessing the optional component
+    fromSMaybe,
+  )
+where
+
+import Cardano.Binary
+  ( FromCBOR (fromCBOR),
+    ToCBOR (toCBOR),
+    decodeBreakOr,
+    decodeListLenOrIndef,
+    encodeListLen,
+  )
+import Control.DeepSeq (NFData)
+import Data.Aeson (FromJSON (..), ToJSON (..))
+import Data.Default.Class (Default (..))
+import GHC.Generics (Generic)
+import NoThunks.Class (NoThunks (..))
+
+data StrictMaybe a
+  = SNothing
+  | SJust !a
+  deriving
+    ( Eq,
+      Ord,
+      Show,
+      Generic,
+      Functor,
+      Foldable,
+      Traversable,
+      NoThunks,
+      NFData
+    )
+
+instance Applicative StrictMaybe where
+  pure = SJust
+
+  SJust f <*> m = fmap f m
+  SNothing <*> _m = SNothing
+
+  SJust _m1 *> m2 = m2
+  SNothing *> _m2 = SNothing
+
+instance Monad StrictMaybe where
+  SJust x >>= k = k x
+  SNothing >>= _ = SNothing
+
+  (>>) = (*>)
+
+  return = SJust
+
+instance MonadFail StrictMaybe where
+  fail _ = SNothing
+
+instance ToCBOR a => ToCBOR (StrictMaybe a) where
+  toCBOR SNothing = encodeListLen 0
+  toCBOR (SJust x) = encodeListLen 1 <> toCBOR x
+
+instance FromCBOR a => FromCBOR (StrictMaybe a) where
+  fromCBOR = do
+    maybeN <- decodeListLenOrIndef
+    case maybeN of
+      Just 0 -> pure SNothing
+      Just 1 -> SJust <$> fromCBOR
+      Just _ -> fail "too many elements in length-style decoding of StrictMaybe."
+      Nothing -> do
+        isBreak <- decodeBreakOr
+        if isBreak
+          then pure SNothing
+          else do
+            x <- fromCBOR
+            isBreak2 <- decodeBreakOr
+            if isBreak2
+              then pure (SJust x)
+              else fail "too many elements in break-style decoding of StrictMaybe."
+
+instance ToJSON a => ToJSON (StrictMaybe a) where
+  toJSON = toJSON . strictMaybeToMaybe
+
+instance FromJSON a => FromJSON (StrictMaybe a) where
+  parseJSON v = maybeToStrictMaybe <$> parseJSON v
+
+strictMaybeToMaybe :: StrictMaybe a -> Maybe a
+strictMaybeToMaybe SNothing = Nothing
+strictMaybeToMaybe (SJust x) = Just x
+
+maybeToStrictMaybe :: Maybe a -> StrictMaybe a
+maybeToStrictMaybe Nothing = SNothing
+maybeToStrictMaybe (Just x) = SJust x
+
+fromSMaybe :: a -> StrictMaybe a -> a
+fromSMaybe d SNothing = d
+fromSMaybe _ (SJust x) = x
+
+instance Default (StrictMaybe t) where
+  def = SNothing

--- a/strict-containers/src/Data/Sequence/Strict.hs
+++ b/strict-containers/src/Data/Sequence/Strict.hs
@@ -1,0 +1,357 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ViewPatterns #-}
+
+-- | Strict variants of 'Seq' operations.
+module Data.Sequence.Strict
+  ( StrictSeq (Empty, (:<|), (:|>)),
+    fromStrict,
+    forceToStrict,
+
+    -- * Construction
+    empty,
+    singleton,
+    (<|),
+    (|>),
+    (><),
+    fromList,
+
+    -- * Deconstruction
+
+    -- | Additional functions for deconstructing sequences are available
+    -- via the 'Foldable' instance of 'Seq'.
+
+    -- ** Queries
+    null,
+    length,
+
+    -- * Scans
+    scanl,
+
+    -- * Sublists
+
+    -- ** Sequential searches
+    dropWhileL,
+    dropWhileR,
+    spanl,
+    spanr,
+
+    -- * Indexing
+    lookup,
+    (!?),
+    take,
+    takeLast,
+    drop,
+    dropLast,
+    splitAt,
+    splitAtEnd,
+
+    -- * Indexing with predicates
+    findIndexL,
+    findIndicesL,
+    findIndexR,
+    findIndicesR,
+
+    -- * Zips and unzips
+    zip,
+    zipWith,
+    unzip,
+    unzipWith,
+  )
+where
+
+import Codec.Serialise (Serialise)
+import Control.Arrow ((***))
+import Data.Foldable (foldl', toList)
+import Data.Sequence (Seq)
+import qualified Data.Sequence as Seq
+import Data.Unit.Strict (forceElemsToWHNF)
+import NoThunks.Class (NoThunks (..), noThunksInValues)
+import Prelude hiding
+  ( drop,
+    length,
+    lookup,
+    null,
+    scanl,
+    splitAt,
+    take,
+    unzip,
+    zip,
+    zipWith,
+  )
+
+infixr 5 ><
+
+infixr 5 <|
+
+infixl 5 |>
+
+infixr 5 :<|
+
+infixl 5 :|>
+
+{-# COMPLETE Empty, (:<|) #-}
+
+{-# COMPLETE Empty, (:|>) #-}
+
+-- | A @newtype@ wrapper around a 'Seq', representing a general-purpose finite
+-- sequence that is strict in its values.
+--
+-- This strictness is not enforced at the type level, but rather by the
+-- construction functions in this module. These functions essentially just
+-- wrap the original "Data.Sequence" functions while forcing the provided
+-- value to WHNF.
+newtype StrictSeq a = StrictSeq {fromStrict :: Seq a}
+  deriving stock (Eq, Ord, Show)
+  deriving newtype (Foldable, Monoid, Semigroup, Serialise)
+
+instance Functor StrictSeq where
+  fmap f (StrictSeq s) = StrictSeq . forceElemsToWHNF $ fmap f s
+
+instance Traversable StrictSeq where
+  sequenceA (StrictSeq xs) = forceToStrict <$> sequenceA xs
+
+-- | Instance for 'StrictSeq' checks elements only
+--
+-- The internal fingertree in 'Seq' might have thunks, which is essential for
+-- its asymptotic complexity.
+instance NoThunks a => NoThunks (StrictSeq a) where
+  showTypeOf _ = "StrictSeq"
+  wNoThunks ctxt = noThunksInValues ctxt . toList
+
+-- | A helper function for the ':<|' pattern.
+viewFront :: StrictSeq a -> Maybe (a, StrictSeq a)
+viewFront (StrictSeq xs) = case Seq.viewl xs of
+  Seq.EmptyL -> Nothing
+  x Seq.:< xs' -> Just (x, StrictSeq xs')
+
+-- | A helper function for the ':|>' pattern.
+viewBack :: StrictSeq a -> Maybe (StrictSeq a, a)
+viewBack (StrictSeq xs) = case Seq.viewr xs of
+  Seq.EmptyR -> Nothing
+  xs' Seq.:> x -> Just (StrictSeq xs', x)
+
+-- | A bidirectional pattern synonym matching an empty sequence.
+pattern Empty :: StrictSeq a
+pattern Empty = StrictSeq Seq.Empty
+
+-- | A bidirectional pattern synonym viewing the front of a non-empty
+-- sequence.
+pattern (:<|) :: a -> StrictSeq a -> StrictSeq a
+pattern x :<| xs <-
+  (viewFront -> Just (x, xs))
+  where
+    x :<| xs = x <| xs
+
+-- | A bidirectional pattern synonym viewing the rear of a non-empty
+-- sequence.
+pattern (:|>) :: StrictSeq a -> a -> StrictSeq a
+pattern xs :|> x <-
+  (viewBack -> Just (xs, x))
+  where
+    xs :|> x = xs |> x
+
+{-------------------------------------------------------------------------------
+  Construction
+-------------------------------------------------------------------------------}
+
+-- | \( O(1) \). The empty sequence.
+empty :: StrictSeq a
+empty = Empty
+
+-- | \( O(1) \). A singleton sequence.
+singleton :: a -> StrictSeq a
+singleton !x = StrictSeq (Seq.singleton x)
+
+-- | \( O(1) \). Add an element to the left end of a sequence.
+-- Mnemonic: a triangle with the single element at the pointy end.
+(<|) :: a -> StrictSeq a -> StrictSeq a
+(!x) <| StrictSeq s = StrictSeq (x Seq.<| s)
+
+-- | \( O(1) \). Add an element to the right end of a sequence.
+-- Mnemonic: a triangle with the single element at the pointy end.
+(|>) :: StrictSeq a -> a -> StrictSeq a
+StrictSeq s |> (!x) = StrictSeq (s Seq.|> x)
+
+-- | \( O(\log(\min(n_1,n_2))) \). Concatenate two sequences.
+(><) :: StrictSeq a -> StrictSeq a -> StrictSeq a
+StrictSeq xs >< StrictSeq ys = StrictSeq (xs Seq.>< ys)
+
+fromList :: [a] -> StrictSeq a
+fromList !xs = foldl' (|>) empty xs
+
+-- | Convert a 'Seq' into a 'StrictSeq' by forcing each element to WHNF.
+forceToStrict :: Seq a -> StrictSeq a
+forceToStrict xs = StrictSeq (forceElemsToWHNF xs)
+
+{-------------------------------------------------------------------------------
+  Deconstruction
+-------------------------------------------------------------------------------}
+
+-- | \( O(1) \). Is this the empty sequence?
+null :: StrictSeq a -> Bool
+null (StrictSeq xs) = Seq.null xs
+
+-- | \( O(1) \). The number of elements in the sequence.
+length :: StrictSeq a -> Int
+length (StrictSeq xs) = Seq.length xs
+
+{-------------------------------------------------------------------------------
+  Scans
+-------------------------------------------------------------------------------}
+
+-- | 'scanl' is similar to 'foldl', but returns a sequence of reduced
+-- values from the left:
+--
+-- > scanl f z (fromList [x1, x2, ...]) = fromList [z, z `f` x1, (z `f` x1) `f` x2, ...]
+scanl :: (a -> b -> a) -> a -> StrictSeq b -> StrictSeq a
+scanl f !z0 (StrictSeq xs) = StrictSeq $ forceElemsToWHNF (Seq.scanl f z0 xs)
+
+{-------------------------------------------------------------------------------
+  Sublists
+-------------------------------------------------------------------------------}
+
+-- | \( O(i) \) where \( i \) is the prefix length.  @'dropWhileL' p xs@ returns
+-- the suffix remaining after @'takeWhileL' p xs@.
+dropWhileL :: (a -> Bool) -> StrictSeq a -> StrictSeq a
+dropWhileL p (StrictSeq xs) = StrictSeq (Seq.dropWhileL p xs)
+
+-- | \( O(i) \) where \( i \) is the suffix length.  @'dropWhileR' p xs@ returns
+-- the prefix remaining after @'takeWhileR' p xs@.
+--
+-- @'dropWhileR' p xs@ is equivalent to @'reverse' ('dropWhileL' p ('reverse' xs))@.
+dropWhileR :: (a -> Bool) -> StrictSeq a -> StrictSeq a
+dropWhileR p (StrictSeq xs) = StrictSeq (Seq.dropWhileR p xs)
+
+-- | \( O(i) \) where \( i \) is the prefix length.  'spanl', applied to
+-- a predicate @p@ and a sequence @xs@, returns a pair whose first
+-- element is the longest prefix (possibly empty) of @xs@ of elements that
+-- satisfy @p@ and the second element is the remainder of the sequence.
+spanl :: (a -> Bool) -> StrictSeq a -> (StrictSeq a, StrictSeq a)
+spanl p (StrictSeq xs) = toStrictSeqTuple (Seq.spanl p xs)
+
+-- | \( O(i) \) where \( i \) is the suffix length.  'spanr', applied to a
+-- predicate @p@ and a sequence @xs@, returns a pair whose /first/ element
+-- is the longest /suffix/ (possibly empty) of @xs@ of elements that
+-- satisfy @p@ and the second element is the remainder of the sequence.
+spanr :: (a -> Bool) -> StrictSeq a -> (StrictSeq a, StrictSeq a)
+spanr p (StrictSeq xs) = toStrictSeqTuple (Seq.spanr p xs)
+
+{-------------------------------------------------------------------------------
+  Indexing
+-------------------------------------------------------------------------------}
+
+-- | \( O(\log(\min(i,n-i))) \). The element at the specified position,
+-- counting from 0. If the specified position is negative or at
+-- least the length of the sequence, 'lookup' returns 'Nothing'.
+--
+-- prop> 0 <= i < length xs ==> lookup i xs == Just (toList xs !! i)
+-- prop> i < 0 || i >= length xs ==> lookup i xs = Nothing
+--
+-- Unlike 'index', this can be used to retrieve an element without
+-- forcing it. For example, to insert the fifth element of a sequence
+-- @xs@ into a 'Data.Map.Lazy.Map' @m@ at key @k@, you could use
+--
+-- @
+-- case lookup 5 xs of
+--   Nothing -> m
+--   Just x -> 'Data.Map.Lazy.insert' k x m
+-- @
+lookup :: Int -> StrictSeq a -> Maybe a
+lookup i (StrictSeq xs) = Seq.lookup i xs
+
+-- | \( O(\log(\min(i,n-i))) \). A flipped, infix version of 'lookup'.
+(!?) :: StrictSeq a -> Int -> Maybe a
+(!?) = flip lookup
+
+-- | \( O(\log(\min(i,n-i))) \). The first @i@ elements of a sequence.
+-- If @i@ is negative, @'take' i s@ yields the empty sequence.
+-- If the sequence contains fewer than @i@ elements, the whole sequence
+-- is returned.
+take :: Int -> StrictSeq a -> StrictSeq a
+take i (StrictSeq xs) = StrictSeq (Seq.take i xs)
+
+-- | Take the last @n@ elements
+--
+-- Returns the entire sequence if it has fewer than @n@ elements.
+--
+-- Inherits asymptotic complexity from @drop@.
+takeLast :: Int -> StrictSeq a -> StrictSeq a
+takeLast i xs
+  | length xs >= i = drop (length xs - i) xs
+  | otherwise = xs
+
+-- | \( O(\log(\min(i,n-i))) \). Elements of a sequence after the first @i@.
+-- If @i@ is negative, @'drop' i s@ yields the whole sequence.
+-- If the sequence contains fewer than @i@ elements, the empty sequence
+-- is returned.
+drop :: Int -> StrictSeq a -> StrictSeq a
+drop i (StrictSeq xs) = StrictSeq (Seq.drop i xs)
+
+-- | Drop the last @n@ elements
+--
+-- Returns the @Empty@ sequence if it has fewer than @n@ elements.
+--
+-- Inherits asymptotic complexity from @take@.
+dropLast :: Int -> StrictSeq a -> StrictSeq a
+dropLast i xs
+  | length xs >= i = take (length xs - i) xs
+  | otherwise = Empty
+
+-- | \( O(\log(\min(i,n-i))) \). Split a sequence at a given position.
+-- @'splitAt' i s = ('take' i s, 'drop' i s)@.
+splitAt :: Int -> StrictSeq a -> (StrictSeq a, StrictSeq a)
+splitAt i (StrictSeq xs) = toStrictSeqTuple (Seq.splitAt i xs)
+
+-- | Split at the given position counting from the end of the sequence.
+--
+-- Inherits asymptotic complexity from 'splitAt'.
+splitAtEnd :: Int -> StrictSeq a -> (StrictSeq a, StrictSeq a)
+splitAtEnd i xs
+  | length xs >= i = splitAt (length xs - i) xs
+  | otherwise = (Empty, xs)
+
+-- | @'findIndexL' p xs@ finds the index of the leftmost element that
+-- satisfies @p@, if any exist.
+findIndexL :: (a -> Bool) -> StrictSeq a -> Maybe Int
+findIndexL p (StrictSeq xs) = Seq.findIndexL p xs
+
+-- | @'findIndexR' p xs@ finds the index of the rightmost element that
+-- satisfies @p@, if any exist.
+findIndexR :: (a -> Bool) -> StrictSeq a -> Maybe Int
+findIndexR p (StrictSeq xs) = Seq.findIndexR p xs
+
+-- | @'findIndicesL' p@ finds all indices of elements that satisfy @p@, in
+-- ascending order.
+findIndicesL :: (a -> Bool) -> StrictSeq a -> [Int]
+findIndicesL p (StrictSeq xs) = Seq.findIndicesL p xs
+
+-- | @'findIndicesR' p@ finds all indices of elements that satisfy @p@, in
+-- descending order.
+findIndicesR :: (a -> Bool) -> StrictSeq a -> [Int]
+findIndicesR p (StrictSeq xs) = Seq.findIndicesR p xs
+
+{-------------------------------------------------------------------------------
+  Zips and Unzips
+-------------------------------------------------------------------------------}
+
+zip :: StrictSeq a -> StrictSeq b -> StrictSeq (a, b)
+zip = zipWith (,)
+
+zipWith :: (a -> b -> c) -> StrictSeq a -> StrictSeq b -> StrictSeq c
+zipWith f (StrictSeq x) (StrictSeq y) = forceToStrict $ Seq.zipWith f x y
+
+unzip :: StrictSeq (a, b) -> (StrictSeq a, StrictSeq b)
+unzip = unzipWith id
+
+unzipWith :: (a -> (b, c)) -> StrictSeq a -> (StrictSeq b, StrictSeq c)
+unzipWith f (StrictSeq xs) = StrictSeq *** StrictSeq $ Seq.unzipWith f xs
+
+{-------------------------------------------------------------------------------
+  Helpers
+-------------------------------------------------------------------------------}
+
+toStrictSeqTuple :: (Seq a, Seq a) -> (StrictSeq a, StrictSeq a)
+toStrictSeqTuple (a, b) = (StrictSeq a, StrictSeq b)

--- a/strict-containers/src/Data/Unit/Strict.hs
+++ b/strict-containers/src/Data/Unit/Strict.hs
@@ -1,0 +1,27 @@
+-- | Helper functions for enforcing strictness.
+module Data.Unit.Strict
+  ( StrictUnit (),
+    forceElemsToWHNF,
+  )
+where
+
+-- | Force all of the elements of a 'Foldable' to weak head normal form.
+--
+-- In order to ensure that all of the elements of a 'Foldable' are strict, we
+-- can simply 'foldMap' over it and 'seq' each value with '()'. However,
+-- '()''s 'mappend' implementation is actually completely lazy: @_ <> _ = ()@
+-- So, in order to work around this, we instead utilize this newly defined
+-- 'StrictUnit' whose 'mappend' implementation is specifically strict.
+forceElemsToWHNF :: Foldable t => t a -> t a
+forceElemsToWHNF x = foldMap (`seq` StrictUnit) x `seq` x
+
+-- | The equivalent of '()', but with a strict 'mappend' implementation.
+--
+-- For more information, see the documentation for 'forceElemsToWHNF'.
+data StrictUnit = StrictUnit
+
+instance Semigroup StrictUnit where
+  StrictUnit <> StrictUnit = StrictUnit
+
+instance Monoid StrictUnit where
+  mempty = StrictUnit

--- a/strict-containers/strict-containers.cabal
+++ b/strict-containers/strict-containers.cabal
@@ -1,0 +1,45 @@
+cabal-version:       >=1.10
+
+name:                strict-containers
+version:             0.1.0.0
+synopsis:            Various strict container types
+license:             Apache-2.0
+license-files:
+  LICENSE
+  NOTICE
+author:              IOHK
+maintainer:          operations@iohk.io
+copyright:           IOHK
+build-type:          Simple
+
+flag development
+    description: Disable `-Werror`
+    default: False
+    manual: True
+
+library
+  default-language:     Haskell2010
+  hs-source-dirs:       src
+  ghc-options:
+    -Wall
+    -Wcompat
+    -Wincomplete-record-updates
+    -Wincomplete-uni-patterns
+    -Wredundant-constraints
+  if (!flag(development))
+    ghc-options:
+      -Werror
+  exposed-modules:      Data.FingerTree.Strict
+                        Data.Maybe.Strict
+                        Data.Sequence.Strict
+                        Data.Unit.Strict
+  build-depends:        aeson
+                      , base >= 4.14
+                      , cardano-binary
+                      , cborg
+                      , containers
+                      , data-default-class
+                      , deepseq
+                      , fingertree
+                      , nothunks
+                      , serialise


### PR DESCRIPTION
This package collects together various strict variants of types which have been defined in different places around the cardano ecosystem.

- StrictMaybe comes from the ledger code
- Fingertree and Seq are currently defined in the prelude

