### PR TITLE
Upgrade to cabal-3.4.0.0 rc5 on Windows

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["8.6.5", "8.10.2"]
+        ghc: ["8.6.5", "8.10.3"]
         os: [ubuntu-latest, macos-latest, windows-latest]
         exclude:
           - os: windows-latest
@@ -64,20 +64,18 @@ jobs:
         echo "LIBSODIUM_PATH=$LIBSODIUM_PATH"
         echo "$LIBSODIUM_PATH" >> $GITHUB_PATH
 
-    - uses: actions/setup-haskell@v1
+    - name: Select optimal cabal version
+      run: |
+        case "$OS" in
+          Windows_NT)   echo "CABAL_VERSION=3.4.0.0-rc5"  >> $GITHUB_ENV;;
+          *)            echo "CABAL_VERSION=3.4.0.0-rc4"  >> $GITHUB_ENV;;
+        esac
+
+    - uses: haskell/actions/setup@v1
       id: setup-haskell
       with:
         ghc-version: ${{ matrix.ghc }}
-        cabal-version: '3.2.0.0'
-
-    - name: Patch GHC 8.10.2 linker
-      if: matrix.os == 'windows-latest'
-      run: |
-        if [ -f /c/ProgramData/chocolatey/lib/ghc.8.10.2/tools/ghc-8.10.2/lib/settings ]; then
-          sed -i \
-            's|C:/GitLabRunner/builds/2WeHDSFP/0/ghc/ghc/inplace/mingw/bin/ld.exe|C:/ProgramData/chocolatey/lib/ghc.8.10.2/tools/ghc-8.10.2/mingw/bin/ld.exe|g' \
-            /c/ProgramData/chocolatey/lib/ghc.8.10.2/tools/ghc-8.10.2/lib/settings
-        fi
+        cabal-version: ${{ env.CABAL_VERSION }}
 
     - name: Configure to use libsodium
       run: |
@@ -92,14 +90,21 @@ jobs:
     - name: Cabal Configure
       run: cabal configure --builddir="$CABAL_BUILDDIR" --enable-tests --enable-benchmarks --write-ghc-environment-files=always
 
+    - name: Record dependencies
+      run: |
+        cat ${{ env.PLAN_JSON }} | jq -r '."install-plan"[].id' | sort | uniq > dependencies.txt
+
+    - name: Set cache version
+      run: echo "CACHE_VERSION=9w76Z3Q" >> $GITHUB_ENV
+
     - uses: actions/cache@v2
       name: Cache cabal store
       with:
         path: ${{ steps.setup-haskell.outputs.cabal-store }}
-        key: cache-5e43c04-${{ runner.os }}-${{ matrix.ghc }}-v1-${{ hashFiles(env.PLAN_JSON) }}-${{ github.sha }}
+        key: cache-${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('dependencies.txt') }}
         restore-keys: |
-          cache-5e43c04-${{ runner.os }}-${{ matrix.ghc }}-v1-${{ hashFiles(env.PLAN_JSON) }}-
-          cache-5e43c04-${{ runner.os }}-${{ matrix.ghc }}-v1-
+          cache-${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-${{ hashFiles('dependencies.txt') }}
+          cache-${{ env.CACHE_VERSION }}-${{ runner.os }}-${{ matrix.ghc }}-
 
     - name: Install dependencies
       run: cabal build all --builddir="$CABAL_BUILDDIR" --only-dependencies

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
-Copyright 2019 Input Output (Hong Kong) Ltd.
+Copyright 2019-2021 Input Output (Hong Kong) Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/binary/NOTICE
+++ b/binary/NOTICE
@@ -1,4 +1,4 @@
-Copyright 2019 Input Output (Hong Kong) Ltd.
+Copyright 2019-2021 Input Output (Hong Kong) Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/binary/cardano-binary.cabal
+++ b/binary/cardano-binary.cabal
@@ -46,7 +46,7 @@ library
                      , formatting
                      , nothunks
                      , primitive
-                     , recursion-schemes  >= 5.1
+                     , recursion-schemes  >= 5.1   && < 5.3
                      , safe-exceptions
                      , tagged
                      , text

--- a/binary/cardano-binary.cabal
+++ b/binary/cardano-binary.cabal
@@ -41,11 +41,12 @@ library
                      , cardano-prelude
                      , cborg              >= 0.2.2 && < 0.3
                      , containers
+                     , data-fix
                      , digest
                      , formatting
                      , nothunks
                      , primitive
-                     , recursion-schemes  >= 5.1   && < 5.2
+                     , recursion-schemes  >= 5.1
                      , safe-exceptions
                      , tagged
                      , text

--- a/binary/cardano-binary.cabal
+++ b/binary/cardano-binary.cabal
@@ -8,7 +8,7 @@ license-files:
   NOTICE
 author:              IOHK
 maintainer:          operations@iohk.io
-copyright:           2019 IOHK
+copyright:           2019-2021 IOHK
 category:            Currency
 build-type:          Simple
 extra-source-files:  README.md

--- a/binary/src/Cardano/Binary/ToCBOR.hs
+++ b/binary/src/Cardano/Binary/ToCBOR.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                       #-}
 {-# LANGUAGE ConstrainedClassMethods   #-}
 {-# LANGUAGE DeriveFunctor             #-}
 {-# LANGUAGE ExistentialQuantification #-}
@@ -44,7 +45,12 @@ import qualified Data.ByteString.Short as SBS
 import qualified Data.ByteString.Short.Internal as SBS
 import qualified Data.Primitive.ByteArray as Prim
 import Data.Fixed (E12, Fixed(..), Nano, Pico, resolution)
-import Data.Functor.Foldable (Fix(..), cata, unfix)
+#if MIN_VERSION_recursion_schemes(5,2,0)
+import Data.Fix ( Fix(..) )
+#else
+import Data.Functor.Foldable (Fix(..))
+#endif
+import Data.Functor.Foldable (cata, project)
 import qualified Data.Map as M
 import qualified Data.Set as S
 import Data.Tagged (Tagged(..))
@@ -166,7 +172,7 @@ instance B.Buildable t => B.Buildable (SizeF t) where
           TodoF _ x -> bprint ("(_ :: " . shown . ")") (typeRep x)
 
 instance B.Buildable (Fix SizeF) where
-  build x = bprint build (unfix x)
+  build x = bprint build (project @(Fix _) x)
 
 -- | Create a case expression from individual cases.
 szCases :: [Case Size] -> Size

--- a/binary/test/LICENSE
+++ b/binary/test/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2019 IOHK
+Copyright (c) 2019-2021 IOHK
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/binary/test/cardano-binary-test.cabal
+++ b/binary/test/cardano-binary-test.cabal
@@ -6,7 +6,7 @@ license:             MIT
 license-file:        LICENSE
 author:              IOHK
 maintainer:          operations@iohk.io
-copyright:           2019 IOHK
+copyright:           2019-2021 IOHK
 category:            Currency
 build-type:          Simple
 cabal-version:       >=1.10

--- a/cabal.project
+++ b/cabal.project
@@ -15,8 +15,8 @@ package cardano-crypto
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: 742e8525b96bf4b66fb61a00c8298d75d7931d5e
-  --sha256: 1132r58bjgdcf7yz3n77nlrkanqcmpn5b5km4nw151yar2dgifsv
+  tag: 116087dbcebb88aafdc7d3d0577477ba36129b41
+  --sha256: 0kxk5vcywsl19qc65y8mkc0npv5qz9fm23avs247xnb0zq17wcrd
   subdir:
     cardano-prelude
     cardano-prelude-test

--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,4 @@
-index-state: 2020-11-15T00:00:00Z
+index-state: 2021-01-01T00:00:00Z
 
 packages:
   binary

--- a/cardano-crypto-class/NOTICE
+++ b/cardano-crypto-class/NOTICE
@@ -1,4 +1,4 @@
-Copyright 2019 Input Output (Hong Kong) Ltd.
+Copyright 2019-2021 Input Output (Hong Kong) Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/cardano-crypto-class/cardano-crypto-class.cabal
+++ b/cardano-crypto-class/cardano-crypto-class.cabal
@@ -8,7 +8,7 @@ license-files:
   NOTICE
 author:              IOHK
 maintainer:          operations@iohk.io
-copyright:           2019 IOHK
+copyright:           2019-2021 IOHK
 category:            Currency
 build-type:          Simple
 extra-source-files:  README.md

--- a/cardano-crypto-praos/NOTICE
+++ b/cardano-crypto-praos/NOTICE
@@ -1,4 +1,4 @@
-Copyright 2019 Input Output (Hong Kong) Ltd.
+Copyright 2019-2021 Input Output (Hong Kong) Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/cardano-crypto-praos/cardano-crypto-praos.cabal
+++ b/cardano-crypto-praos/cardano-crypto-praos.cabal
@@ -8,7 +8,7 @@ license-files:
   NOTICE
 author:              IOHK
 maintainer:          operations@iohk.io
-copyright:           2019 IOHK
+copyright:           2019-2021 IOHK
 category:            Currency
 build-type:          Simple
 extra-source-files:  README.md

--- a/cardano-crypto-tests/NOTICE
+++ b/cardano-crypto-tests/NOTICE
@@ -1,4 +1,4 @@
-Copyright 2019 Input Output (Hong Kong) Ltd.
+Copyright 2019-2021 Input Output (Hong Kong) Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/cardano-crypto-tests/cardano-crypto-tests.cabal
+++ b/cardano-crypto-tests/cardano-crypto-tests.cabal
@@ -8,7 +8,7 @@ license-files:
   NOTICE
 author:              IOHK
 maintainer:          operations@iohk.io
-copyright:           2020 IOHK
+copyright:           2020-2021 IOHK
 category:            Currency
 build-type:          Simple
 extra-source-files:  README.md

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "271d1ebae0062704d74ca9c166cbb428fbce7761",
-        "sha256": "165pg37vxhr3xl82hwg9zcakczf6qfcj6kw9ci6gb7wki8yfhn0b",
+        "rev": "f848b47dde85297a11dc84d32687bf0b165db309",
+        "sha256": "0a585wa2crsk5jb5kc02gnshjv7n5i08kzd1r31m3wzpx15krd1s",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/271d1ebae0062704d74ca9c166cbb428fbce7761.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/f848b47dde85297a11dc84d32687bf0b165db309.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "iohk-nix": {
@@ -17,10 +17,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "3230d3a0547c734b4dcea856aaec89b9adc373bf",
-        "sha256": "1p35gkp7icx3shkh4kgzghjgj4wg646bqbkns104nqzqcnqx68sz",
+        "rev": "65d5b5eabf5252c7ece10efdc507f0a5c9b2aa8a",
+        "sha256": "1b2n1c3cygrczhgffq6px42hln0344l88cf0hgq78l7m5w7lysal",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/iohk-nix/archive/3230d3a0547c734b4dcea856aaec89b9adc373bf.tar.gz",
+        "url": "https://github.com/input-output-hk/iohk-nix/archive/65d5b5eabf5252c7ece10efdc507f0a5c9b2aa8a.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {
@@ -29,10 +29,10 @@
         "homepage": null,
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "99f8282a65821f148df596ba389606e732eaf99d",
-        "sha256": "1mm4j1vjs875yzv03plng43ivny0qm09hxpn0if8g9vc849rwc2g",
+        "rev": "d04a7a30979db2ba6ac001e4c24907e5594dc07d",
+        "sha256": "1vhd56z706lmjb8pq3ky72gn6j3naacwxwks52wd2fr2bwwb73z2",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/99f8282a65821f148df596ba389606e732eaf99d.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/d04a7a30979db2ba6ac001e4c24907e5594dc07d.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/slotting/NOTICE
+++ b/slotting/NOTICE
@@ -1,4 +1,4 @@
-Copyright 2019 Input Output (Hong Kong) Ltd.
+Copyright 2019-2021 Input Output (Hong Kong) Ltd.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -11,4 +11,3 @@ Copyright 2019 Input Output (Hong Kong) Ltd.
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-


### PR DESCRIPTION
This for better caching of cabal cache.  Introduce `CACHE_VERSION` to make it possible to "invalidate" cache.  Introduce `dependencies.txt` which will cause new cache to be generated when dependencies changed.  Upgrade to `ghc-8.10.3` in Github Actions.  Update copyright.  Relax upper bound on `recursion-schemes` with associated fixes from https://github.com/input-output-hk/cardano-base/pull/196.