### PR TITLE
Drop support for ghc-8.6.5

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -13,11 +13,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["8.6.5", "8.10.3"]
+        ghc: ["8.10.3"]
         os: [ubuntu-latest, macos-latest, windows-latest]
-        exclude:
-          - os: windows-latest
-            ghc: 8.6.5
 
     steps:
     - uses: actions/checkout@v1

--- a/binary/cardano-binary.cabal
+++ b/binary/cardano-binary.cabal
@@ -20,7 +20,7 @@ flag development
     default: False
     manual: True
 
-common base                         { build-depends: base                             >= 4.12       && < 4.15     }
+common base                         { build-depends: base                             >= 4.14       && < 4.15     }
 
 common project-config
   default-language:     Haskell2010
@@ -32,9 +32,7 @@ common project-config
                         -Wincomplete-uni-patterns
                         -Wpartial-fields
                         -Wredundant-constraints
-
-  if impl(ghc >= 8.10)
-    ghc-options:        -Wunused-packages
+                        -Wunused-packages
 
   if (!flag(development))
     ghc-options:        -Werror

--- a/binary/test/cardano-binary-test.cabal
+++ b/binary/test/cardano-binary-test.cabal
@@ -17,7 +17,7 @@ flag development
     default: False
     manual: True
 
-common base                         { build-depends: base                             >= 4.12       && < 4.15     }
+common base                         { build-depends: base                             >= 4.14       && < 4.15     }
 
 common project-config
   default-language:     Haskell2010
@@ -29,9 +29,7 @@ common project-config
                         -Wincomplete-uni-patterns
                         -Wpartial-fields
                         -Wredundant-constraints
-
-  if impl(ghc >= 8.10)
-    ghc-options:        -Wunused-packages
+                        -Wunused-packages
 
   if (!flag(development))
     ghc-options:         -Werror

--- a/cardano-crypto-class/cardano-crypto-class.cabal
+++ b/cardano-crypto-class/cardano-crypto-class.cabal
@@ -20,7 +20,7 @@ flag development
     default: False
     manual: True
 
-common base                         { build-depends: base                             >= 4.12       && < 4.15     }
+common base                         { build-depends: base                             >= 4.14       && < 4.15     }
 
 common project-config
   default-language:     Haskell2010
@@ -31,9 +31,7 @@ common project-config
                         -Wincomplete-uni-patterns
                         -Wpartial-fields
                         -Wredundant-constraints
-
-  if impl(ghc >= 8.10)
-    ghc-options:        -Wunused-packages
+                        -Wunused-packages
 
   if (!flag(development))
     ghc-options:        -Werror

--- a/cardano-crypto-praos/cardano-crypto-praos.cabal
+++ b/cardano-crypto-praos/cardano-crypto-praos.cabal
@@ -46,7 +46,7 @@ flag external-libsodium-vrf
     default: True
     manual: True
 
-common base                         { build-depends: base                             >= 4.12       && < 4.15     }
+common base                         { build-depends: base                             >= 4.14       && < 4.15     }
 
 common project-config
   default-language:     Haskell2010
@@ -57,9 +57,7 @@ common project-config
                         -Wincomplete-uni-patterns
                         -Wpartial-fields
                         -Wredundant-constraints
-
-  if impl(ghc >= 8.10)
-    ghc-options:        -Wunused-packages
+                        -Wunused-packages
 
   if (!flag(development))
     ghc-options:        -Werror

--- a/cardano-crypto-tests/cardano-crypto-tests.cabal
+++ b/cardano-crypto-tests/cardano-crypto-tests.cabal
@@ -20,7 +20,7 @@ flag development
     default: False
     manual: True
 
-common base                         { build-depends: base                             >= 4.12       && < 4.15     }
+common base                         { build-depends: base                             >= 4.14       && < 4.15     }
 
 common project-config
   default-language:     Haskell2010
@@ -31,9 +31,7 @@ common project-config
                         -Wincomplete-uni-patterns
                         -Wpartial-fields
                         -Wredundant-constraints
-
-  if impl(ghc >= 8.10)
-    ghc-options:        -Wunused-packages
+                        -Wunused-packages
 
   if (!flag(development))
     ghc-options:        -Werror

--- a/slotting/cardano-slotting.cabal
+++ b/slotting/cardano-slotting.cabal
@@ -20,7 +20,7 @@ flag development
     default: False
     manual: True
 
-common base                         { build-depends: base                             >= 4.12       && < 4.15     }
+common base                         { build-depends: base                             >= 4.14       && < 4.15     }
 
 common project-config
   default-language:     Haskell2010
@@ -30,9 +30,7 @@ common project-config
                         -Wincomplete-record-updates
                         -Wincomplete-uni-patterns
                         -Wredundant-constraints
-
-  if impl(ghc >= 8.10)
-    ghc-options:        -Wunused-packages
+                        -Wunused-packages
 
   if (!flag(development))
     ghc-options:        -Werror


### PR DESCRIPTION
* Add lower-bounds to `base`.
* Remove redundant `if` conditionals from cabal files.
