### PR TITLE
Defunctionalize EpochInfo and add To/FromCBOR instances

### DIFF
--- a/slotting/cardano-slotting.cabal
+++ b/slotting/cardano-slotting.cabal
@@ -51,7 +51,6 @@ library
                       , cardano-binary
                       , cborg
                       , deepseq
-                      , mmorph
                       , nothunks
                       , quiet
                       , serialise

--- a/slotting/src/Cardano/Slotting/EpochInfo/API.hs
+++ b/slotting/src/Cardano/Slotting/EpochInfo/API.hs
@@ -1,121 +1,90 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 
 module Cardano.Slotting.EpochInfo.API
   ( EpochInfo (..),
-    epochInfoSize,
     epochInfoFirst,
     epochInfoEpoch,
     epochInfoRange,
     epochInfoSlotToRelativeTime,
     epochInfoSlotToUTCTime,
-
-    -- * Utility
-    hoistEpochInfo,
-    generalizeEpochInfo,
   )
 where
 
+import Cardano.Binary
+import Cardano.Slotting.EpochInfo.Impl
 import Cardano.Slotting.Slot (EpochNo (..), EpochSize (..), SlotNo (..))
-import Cardano.Slotting.Time (RelativeTime, SystemStart, fromRelativeTime)
-import Control.Monad.Morph (generalize)
-import Data.Functor.Identity
+import Cardano.Slotting.Time
 import Data.Time.Clock (UTCTime)
-import GHC.Stack (HasCallStack)
-import NoThunks.Class (NoThunks, OnlyCheckWhnfNamed (..))
+import GHC.Generics
+import NoThunks.Class (NoThunks)
 
--- | Information about epochs
---
--- Different epochs may have different sizes and different slot lengths. This
--- information is encapsulated by 'EpochInfo'. It is parameterized over a monad
--- @m@ because the information about how long each epoch is may depend on
--- information derived from the blockchain itself. It ultimately requires acess
--- to state, and so either uses the monad for that or uses the monad to reify
--- failure due to cached state information being too stale for the current
--- query.
-data EpochInfo m
+-- | Information about epochs. This assumes the epoch size and slot length are
+-- fixed.
+data EpochInfo
   = EpochInfo
-      { -- | Return the size of the given epoch as a number of slots
-        --
-        -- Note that the number of slots does /not/ bound the number of blocks,
-        -- since the EBB and a regular block share a slot number.
-        epochInfoSize_ :: HasCallStack => EpochNo -> m EpochSize,
-        -- | First slot in the specified epoch
-        --
-        -- See also 'epochInfoRange'
-        epochInfoFirst_ :: HasCallStack => EpochNo -> m SlotNo,
-        -- | Epoch containing the given slot
-        --
-        -- We should have the property that
-        --
-        -- > s `inRange` epochInfoRange (epochInfoEpoch s)
-        epochInfoEpoch_ :: HasCallStack => SlotNo -> m EpochNo,
-        -- | The 'RelativeTime' of the start of the given slot
-        --
-        -- This calculation depends on the varying slot lengths of the relevant
-        -- epochs.
-        --
-        -- See also 'epochInfoSlotToUTCTime'.
-        epochInfoSlotToRelativeTime_ ::
-          HasCallStack => SlotNo -> m RelativeTime
+      { -- | The size of an epoch as a number of slots.
+        epochInfoSize       :: EpochSize
+        -- | The slot length.
+      , epochInfoSlotLength :: SlotLength
       }
-  deriving NoThunks via OnlyCheckWhnfNamed "EpochInfo" (EpochInfo m)
+  deriving (Generic, Show, NoThunks)
 
--- | Unhelpful instance, but this type occurs in records (eg @Shelley.Globals@)
--- that we want to be able to 'show'
-instance Show (EpochInfo f) where
-  showsPrec _ _ = showString "EpochInfoHasNoUsefulShowInstance"
+instance ToCBOR EpochInfo where
+  toCBOR (EpochInfo epochSize slotLength) = mconcat
+    [ encodeListLen 2
+    , toCBOR epochSize
+    , toCBOR slotLength
+    ]
 
-epochInfoRange :: Monad m => EpochInfo m -> EpochNo -> m (SlotNo, SlotNo)
+instance FromCBOR EpochInfo where
+  fromCBOR = do
+    enforceSize "EpochInfo" 2
+    EpochInfo <$> fromCBOR <*> fromCBOR
+
+-- | First slot in the specified epoch
+--
+-- See also 'epochInfoRange'
+epochInfoFirst :: EpochInfo -> EpochNo -> SlotNo
+epochInfoFirst (EpochInfo epochSize _) e = fixedEpochInfoFirst epochSize e
+
+-- | Epoch containing the given slot
+--
+-- We have the property that
+--
+-- > s `inRange` epochInfoRange (epochInfoEpoch s)
+epochInfoEpoch :: EpochInfo -> SlotNo -> EpochNo
+epochInfoEpoch (EpochInfo epochSize _) sl = fixedEpochInfoEpoch epochSize sl
+
+-- | The 'RelativeTime' of the start of the given slot
+--
+-- This calculation depends on the varying slot lengths of the relevant
+-- epochs.
+--
+-- See also 'epochInfoSlotToUTCTime'.
+epochInfoSlotToRelativeTime :: EpochInfo -> SlotNo -> RelativeTime
+epochInfoSlotToRelativeTime (EpochInfo _ slotLength) (SlotNo slot)
+  = RelativeTime (fromIntegral slot * getSlotLength slotLength)
+
+epochInfoRange :: EpochInfo -> EpochNo -> (SlotNo, SlotNo)
 epochInfoRange epochInfo epochNo =
-  aux <$> epochInfoFirst epochInfo epochNo
-    <*> epochInfoSize epochInfo epochNo
+  aux
+    (epochInfoFirst epochInfo epochNo)
+    (epochInfoSize epochInfo)
   where
     aux :: SlotNo -> EpochSize -> (SlotNo, SlotNo)
     aux (SlotNo s) (EpochSize sz) = (SlotNo s, SlotNo (s + sz - 1))
 
 -- | The start of the given slot
 epochInfoSlotToUTCTime ::
-     (HasCallStack, Monad m)
-  => EpochInfo m
+     EpochInfo
   -> SystemStart
   -> SlotNo
-  -> m UTCTime
+  -> UTCTime
 epochInfoSlotToUTCTime ei start sl =
-  fromRelativeTime start <$> epochInfoSlotToRelativeTime ei sl
-
-{-------------------------------------------------------------------------------
-  Extraction functions that preserve the HasCallStack constraint
-
-  (Ideally, ghc would just do this..)
--------------------------------------------------------------------------------}
-
-epochInfoSize :: HasCallStack => EpochInfo m -> EpochNo -> m EpochSize
-epochInfoSize = epochInfoSize_
-
-epochInfoFirst :: HasCallStack => EpochInfo m -> EpochNo -> m SlotNo
-epochInfoFirst = epochInfoFirst_
-
-epochInfoEpoch :: HasCallStack => EpochInfo m -> SlotNo -> m EpochNo
-epochInfoEpoch = epochInfoEpoch_
-
-epochInfoSlotToRelativeTime ::
-  HasCallStack => EpochInfo m -> SlotNo -> m RelativeTime
-epochInfoSlotToRelativeTime = epochInfoSlotToRelativeTime_
-
-{-------------------------------------------------------------------------------
-  Utility
--------------------------------------------------------------------------------}
-
-hoistEpochInfo :: (forall a. m a -> n a) -> EpochInfo m -> EpochInfo n
-hoistEpochInfo f ei = EpochInfo
-  { epochInfoSize_ = f . epochInfoSize ei,
-    epochInfoFirst_ = f . epochInfoFirst ei,
-    epochInfoEpoch_ = f . epochInfoEpoch ei,
-    epochInfoSlotToRelativeTime_ = f . epochInfoSlotToRelativeTime ei
-  }
-
-generalizeEpochInfo :: Monad m => EpochInfo Identity -> EpochInfo m
-generalizeEpochInfo = hoistEpochInfo generalize
+  fromRelativeTime start (epochInfoSlotToRelativeTime ei sl)

--- a/slotting/src/Cardano/Slotting/EpochInfo/Impl.hs
+++ b/slotting/src/Cardano/Slotting/EpochInfo/Impl.hs
@@ -1,27 +1,11 @@
 -- | For use in trivial cases, such as in mocks, tests, etc.
 module Cardano.Slotting.EpochInfo.Impl
-  ( fixedEpochInfo,
-    -- * Shortcuts
-    fixedEpochInfoEpoch,
+  ( fixedEpochInfoEpoch,
     fixedEpochInfoFirst,
   )
 where
 
-import Cardano.Slotting.EpochInfo.API
 import Cardano.Slotting.Slot (EpochNo (..), EpochSize (..), SlotNo (..))
-import Cardano.Slotting.Time (RelativeTime (..), SlotLength, getSlotLength)
-
--- | The 'EpochInfo' induced by assuming the epoch size and slot length are
--- fixed for the entire system lifetime
-fixedEpochInfo :: Monad m => EpochSize -> SlotLength -> EpochInfo m
-fixedEpochInfo (EpochSize size) slotLength = EpochInfo
-  { epochInfoSize_ = \_ ->
-      return $ EpochSize size,
-    epochInfoFirst_ = \e -> return $ fixedEpochInfoFirst (EpochSize size) e,
-    epochInfoEpoch_ = \sl -> return $ fixedEpochInfoEpoch (EpochSize size) sl,
-    epochInfoSlotToRelativeTime_ = \(SlotNo slot) ->
-      return $ RelativeTime (fromIntegral slot * getSlotLength slotLength)
-  }
 
 -- | The pure computation underlying 'epochInfoFirst' applied to
 -- 'fixedEpochInfo'

--- a/slotting/src/Cardano/Slotting/Slot.hs
+++ b/slotting/src/Cardano/Slotting/Slot.hs
@@ -103,4 +103,4 @@ newtype EpochNo = EpochNo {unEpochNo :: Word64}
 newtype EpochSize = EpochSize {unEpochSize :: Word64}
   deriving stock (Eq, Ord, Generic)
   deriving Show via Quiet EpochSize
-  deriving newtype (Enum, Num, Real, Integral, NoThunks, ToJSON, FromJSON)
+  deriving newtype (Enum, Num, Real, Integral, ToCBOR, FromCBOR, NoThunks, ToJSON, FromJSON)

--- a/slotting/src/Cardano/Slotting/Time.hs
+++ b/slotting/src/Cardano/Slotting/Time.hs
@@ -125,5 +125,11 @@ instance Serialise RelativeTime where
       fromPico = realToFrac
 
 instance Serialise SlotLength where
-  encode = encode . slotLengthToMillisec
-  decode = slotLengthFromMillisec <$> decode
+  encode = toCBOR
+  decode = fromCBOR
+
+instance ToCBOR SlotLength where
+  toCBOR = toCBOR . slotLengthToMillisec
+
+instance FromCBOR SlotLength where
+  fromCBOR = slotLengthFromMillisec <$> fromCBOR


### PR DESCRIPTION
I'm trying (still :-/ ) to add a query on the cardano-node for the ledger configuration. In the case of a Shelley node, that requires sending the `Globals` and hence a `EpochInfo` which currently contains functions and is not serializable! With this PR I'm defunctionalizing `EpochInfo` so it is just data and is now serializable.

Is this safe to do, or do we in fact need the more general functional representation? I've searched through all occurrences of the string "EpochInfo" in the https://github.com/input-output-hk/cardano-haskell repo. I've only found 3 places where we construct an `EpochInfo` and I think they are compatible with this refactoring:
* See https://github.com/input-output-hk/cardano-base/pull/220#pullrequestreview-695609516
* `dummyEpochInfo` ouroboros-network/ouroboros-consensus/src/Ouroboros/Consensus/HardFork/History/EpochInfo.hs
  * all functions throw errors
* `hardForkEpochInfo` ouroboros-network/ouroboros-consensus-test/test-consensus/Test/Consensus/HardFork/History.hs
  * all functions throw errors
* `fixedEpochInfo` cardano-base/slotting/src/Cardano/Slotting/EpochInfo/Impl.hs
  * Super easy to defunctionalize! The arguments to this function have now become the fields of the `EpochInfo` type.