### PR TITLE
Fix FromCBOR and ToCBOR instances for UTCTime

### DIFF
--- a/binary/src/Cardano/Binary/FromCBOR.hs
+++ b/binary/src/Cardano/Binary/FromCBOR.hs
@@ -470,6 +470,7 @@ instance (FromCBOR a) => FromCBOR (Vector.Vector a) where
 
 instance FromCBOR UTCTime where
   fromCBOR = do
+    enforceSize "UTCTime" 3
     year <- decodeInteger
     dayOfYear <- decodeInt
     timeOfDayPico <- decodeInteger

--- a/binary/src/Cardano/Binary/ToCBOR.hs
+++ b/binary/src/Cardano/Binary/ToCBOR.hs
@@ -692,10 +692,12 @@ instance (ToCBOR a) => ToCBOR (Vector.Vector a) where
 --------------------------------------------------------------------------------
 
 instance ToCBOR UTCTime where
-  toCBOR (UTCTime day timeOfDay)
-    = encodeInteger year
-    <> encodeInt dayOfYear
-    <> encodeInteger timeOfDayPico
+  toCBOR (UTCTime day timeOfDay) = mconcat [
+      encodeListLen 3
+    , encodeInteger year
+    , encodeInt dayOfYear
+    , encodeInteger timeOfDayPico
+    ]
     where
       (year, dayOfYear) = toOrdinalDate day
       timeOfDayPico = diffTimeToPicoseconds timeOfDay


### PR DESCRIPTION
It seems I made a previous blunder not knowing that we must explicitly encode list lengths.