### PR TITLE
Packed bytes hash using GADTs

### DIFF
--- a/cardano-crypto-class/cardano-crypto-class.cabal
+++ b/cardano-crypto-class/cardano-crypto-class.cabal
@@ -88,6 +88,8 @@ library
 
                         Cardano.Foreign
 
+  other-modules:        Cardano.Crypto.PackedBytes
+
   build-depends:        aeson
                       , base
                       , base16-bytestring >= 1

--- a/cardano-crypto-class/src/Cardano/Crypto/Hash/Blake2b.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Hash/Blake2b.hs
@@ -1,9 +1,4 @@
-{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE MagicHash #-}
-{-# LANGUAGE PackageImports #-}
-{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
 -- | Implementation of the Blake2b hashing algorithm, with various sizes.
@@ -22,128 +17,19 @@ import Foreign.Ptr (castPtr, nullPtr)
 import Foreign.C.Error (errnoToIOError, getErrno)
 import GHC.IO.Exception (ioException)
 
-import           Control.DeepSeq (NFData)
 import qualified Data.ByteString as B
-import           Data.ByteString.Short (ShortByteString)
-import qualified Data.ByteString.Short.Internal as SBSI
-import qualified Data.ByteString.Short as SBS
 import qualified Data.ByteString.Internal as BI
-import           Data.Word (Word64, Word32)
-import           NoThunks.Class (NoThunks)
-import           GHC.Generics (Generic)
-import qualified Data.Primitive.ByteArray as BA
-import qualified Control.Monad.ST as ST
 
 data Blake2b_224
 data Blake2b_256
 
-data PackedBytes32 =
-  PackedBytes32
-    {-# UNPACK #-} !Word64
-    {-# UNPACK #-} !Word64
-    {-# UNPACK #-} !Word64
-    {-# UNPACK #-} !Word64
-  deriving (Eq, Ord, Generic)
-
-instance NoThunks PackedBytes32
-instance NFData PackedBytes32
-
-baToSBS :: BA.ByteArray -> ShortByteString
-baToSBS (BA.ByteArray bytes#) = SBSI.SBS bytes#
-
-baFromSBS :: ShortByteString -> BA.ByteArray
-baFromSBS (SBSI.SBS bytes#) = BA.ByteArray bytes#
-
--- | Converts a ShortByteString into a Blake2b_224 hash rep.
---   This will error if the bytestring length is not 28.
-unsafePackBlake2b224 :: ShortByteString -> PackedBytes32
-unsafePackBlake2b224 sbs =
-  if SBS.length sbs == 28
-  then packed
-  else error $
-        "Attempted to cast bytestring of length "
-     <> show (SBS.length sbs)
-     <> " into Blake2b256 hash rep, but the required length is 32."
-  where
-{- [Note: Primitive Indices]
-We interpret the bytestring as 3 Word64s follows by a Word32
-The offset of read by indexByteArray# is the argument multiplied by the size of the
-primitive being read.
-For the Word64, we read indices 0,1,2.
-We read the Word32 at the index whose calculated offset for Word32 is the same
-as the offset we'd get by reading a Word64 at index 3.
-Since Word64 is twice as large, this is index 6.
-
-┏━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━┳━━━━┓
-┃ 0       ┃ 1       ┃ 2       ┃ 3  ┃
-┗━━━━━━━━━┻━━━━━━━━━┻━━━━━━━━━┻━━━━┛
-
-┏━━━━━━━━━┳━━━━━━━━━┳━━━━━━━━━┳━━━━┓
-┃ 0  | 1  ┃ 2  | 3  ┃ 4  | 5  ┃ 6  ┃
-┗━━━━━━━━━┻━━━━━━━━━┻━━━━━━━━━┻━━━━┛
--}
-  packed = (PackedBytes32 x0 x1 x2 x3)
-  ba = baFromSBS sbs
-  x0 = BA.indexByteArray ba 0
-  x1 = BA.indexByteArray ba 1
-  x2 = BA.indexByteArray ba 2
-  x3' :: Word32
-  x3' = BA.indexByteArray ba 6
-  -- this fromIntegral is safe since this Word64 is wider than Word32
-  x3 = fromIntegral x3'
-
-unpackBlake2b224 :: PackedBytes32 -> ShortByteString
-unpackBlake2b224 (PackedBytes32 x0 x1 x2 x3) = baToSBS $ ST.runST $ do
-  -- this fromIntegral is safe since this Word64 is a widened Word32.
-  let x3' = fromIntegral x3 :: Word32
-  destination <- BA.newByteArray 28
-  -- See [Note: Primitive Indices]
-  BA.writeByteArray destination 0 x0
-  BA.writeByteArray destination 1 x1
-  BA.writeByteArray destination 2 x2
-  BA.writeByteArray destination 6 x3'
-  BA.unsafeFreezeByteArray destination
-
--- | Converts a ShortByteString into a Blake2b_256 hash rep.
---   This will error if the bytestring length is not 32.
-unsafePackBlake2b256 :: ShortByteString -> PackedBytes32
-unsafePackBlake2b256 sbs =
-   if SBS.length sbs == 32
-   then packed
-   else error $
-         "Attempted to cast bytestring of length "
-      <> show (SBS.length sbs)
-      <> " into Blake2b256 hash rep, but the required length is 32."
-  where
-  packed = PackedBytes32 x0 x1 x2 x3
-  ba = baFromSBS sbs
-  x0 = BA.indexByteArray ba 0
-  x1 = BA.indexByteArray ba 1
-  x2 = BA.indexByteArray ba 2
-  x3 = BA.indexByteArray ba 3
-
-unpackBlake2b256 :: PackedBytes32 -> ShortByteString
-unpackBlake2b256 (PackedBytes32 x0 x1 x2 x3) = baToSBS $ ST.runST $ do
-  destination <- BA.newByteArray 32
-  BA.writeByteArray destination 0 x0
-  BA.writeByteArray destination 1 x1
-  BA.writeByteArray destination 2 x2
-  BA.writeByteArray destination 3 x3
-  BA.unsafeFreezeByteArray destination
-
 instance HashAlgorithm Blake2b_224 where
   type SizeHash Blake2b_224 = 28
-  type HashRep Blake2b_224 = PackedBytes32
-  unsafeToHashRep _ = unsafePackBlake2b224
-  fromHashRep _ = unpackBlake2b224
   hashAlgorithmName _ = "blake2b_224"
   digest _ = blake2b_libsodium 28
 
 instance HashAlgorithm Blake2b_256 where
   type SizeHash Blake2b_256 = 32
-  type HashRep Blake2b_256 = PackedBytes32
-  unsafeToHashRep _ = unsafePackBlake2b256
-  fromHashRep _ = unpackBlake2b256
   hashAlgorithmName _ = "blake2b_256"
   digest _ = blake2b_libsodium 32
 

--- a/cardano-crypto-class/src/Cardano/Crypto/Hash/SHA256.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Hash/SHA256.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE PackageImports #-}
 {-# LANGUAGE TypeFamilies #-}
 
 -- | Implementation of the SHA256 hashing algorithm.

--- a/cardano-crypto-class/src/Cardano/Crypto/Hash/Short.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Hash/Short.hs
@@ -1,10 +1,7 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE PackageImports #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
 
 -- | Implementation of short hashing algorithm, suitable for testing.
 module Cardano.Crypto.Hash.Short

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Sum.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Sum.hs
@@ -309,9 +309,9 @@ mungeName basename
 --
 
 deriving instance HashAlgorithm h => Show (VerKeyKES (SumKES h d))
-deriving instance HashAlgorithm h => Eq   (VerKeyKES (SumKES h d))
+deriving instance Eq   (VerKeyKES (SumKES h d))
 
-instance (HashAlgorithm h, KESAlgorithm d) => NoThunks (SignKeyKES (SumKES h d))
+instance (KESAlgorithm d) => NoThunks (SignKeyKES (SumKES h d))
 
 instance (KESAlgorithm d, HashAlgorithm h, Typeable d)
       => ToCBOR (VerKeyKES (SumKES h d)) where
@@ -329,7 +329,7 @@ instance (KESAlgorithm d, HashAlgorithm h, Typeable d)
 
 deriving instance KESAlgorithm d => Show (SignKeyKES (SumKES h d))
 
-instance (HashAlgorithm h, KESAlgorithm d) => NoThunks (VerKeyKES  (SumKES h d))
+instance (KESAlgorithm d) => NoThunks (VerKeyKES  (SumKES h d))
 
 instance (KESAlgorithm d, HashAlgorithm h, Typeable d)
       => ToCBOR (SignKeyKES (SumKES h d)) where

--- a/cardano-crypto-class/src/Cardano/Crypto/PackedBytes.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/PackedBytes.hs
@@ -1,0 +1,371 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeFamilyDependencies #-}
+{-# LANGUAGE UnboxedTuples #-}
+
+module Cardano.Crypto.PackedBytes
+  ( PackedBytes(..)
+  , packBytes
+  , packPinnedBytes
+  , unpackBytes
+  , unpackPinnedBytes
+  , xorPackedBytes
+  ) where
+
+import Control.DeepSeq
+import Control.Monad.Primitive
+import Data.Bits
+import Data.ByteString
+import Data.ByteString.Internal as BS (accursedUnutterablePerformIO,
+                                       fromForeignPtr, toForeignPtr)
+import Data.ByteString.Short.Internal as SBS
+import Data.Primitive.ByteArray
+import Data.Primitive.PrimArray (PrimArray(..), imapPrimArray, indexPrimArray)
+import Data.Typeable
+import Foreign.ForeignPtr
+import Foreign.Ptr (castPtr)
+import Foreign.Storable (peekByteOff)
+import GHC.Exts
+import GHC.ForeignPtr (ForeignPtr(ForeignPtr), ForeignPtrContents(PlainPtr))
+import GHC.ST
+import GHC.TypeLits
+import GHC.Word
+import NoThunks.Class
+
+#include "MachDeps.h"
+
+
+data PackedBytes (n :: Nat) where
+  PackedBytes8  :: {-# UNPACK #-} !Word64
+                -> PackedBytes 8
+  PackedBytes28 :: {-# UNPACK #-} !Word64
+                -> {-# UNPACK #-} !Word64
+                -> {-# UNPACK #-} !Word64
+                -> {-# UNPACK #-} !Word32
+                -> PackedBytes 28
+  PackedBytes32 :: {-# UNPACK #-} !Word64
+                -> {-# UNPACK #-} !Word64
+                -> {-# UNPACK #-} !Word64
+                -> {-# UNPACK #-} !Word64
+                -> PackedBytes 32
+  PackedBytes# :: ByteArray# -> PackedBytes n
+
+deriving via OnlyCheckWhnfNamed "PackedBytes" (PackedBytes n) instance NoThunks (PackedBytes n)
+
+instance Eq (PackedBytes n) where
+  PackedBytes8 x == PackedBytes8 y = x == y
+  PackedBytes28 x0 x1 x2 x3 == PackedBytes28 y0 y1 y2 y3 =
+    x0 == y0 && x1 == y1 && x2 == y2 && x3 == y3
+  PackedBytes32 x0 x1 x2 x3 == PackedBytes32 y0 y1 y2 y3 =
+    x0 == y0 && x1 == y1 && x2 == y2 && x3 == y3
+  x1 == x2 = unpackBytes x1 == unpackBytes x2
+  {-# INLINE (==) #-}
+
+instance Ord (PackedBytes n) where
+  compare (PackedBytes8 x) (PackedBytes8 y) = compare x y
+  compare (PackedBytes28 x0 x1 x2 x3) (PackedBytes28 y0 y1 y2 y3) =
+    compare x0 y0 <> compare x1 y1 <> compare x2 y2 <> compare x3 y3
+  compare (PackedBytes32 x0 x1 x2 x3) (PackedBytes32 y0 y1 y2 y3) =
+    compare x0 y0 <> compare x1 y1 <> compare x2 y2 <> compare x3 y3
+  compare x1 x2 = compare (unpackBytes x1) (unpackBytes x2)
+  {-# INLINE compare #-}
+
+instance NFData (PackedBytes n) where
+  rnf PackedBytes8  {} = ()
+  rnf PackedBytes28 {} = ()
+  rnf PackedBytes32 {} = ()
+  rnf PackedBytes#  {} = ()
+
+xorPackedBytes :: PackedBytes n -> PackedBytes n -> PackedBytes n
+xorPackedBytes (PackedBytes8 x) (PackedBytes8 y) = PackedBytes8 (x `xor` y)
+xorPackedBytes (PackedBytes28 x0 x1 x2 x3) (PackedBytes28 y0 y1 y2 y3) =
+  PackedBytes28 (x0 `xor` y0) (x1 `xor` y1) (x2 `xor` y2) (x3 `xor` y3)
+xorPackedBytes (PackedBytes32 x0 x1 x2 x3) (PackedBytes32 y0 y1 y2 y3) =
+  PackedBytes32 (x0 `xor` y0) (x1 `xor` y1) (x2 `xor` y2) (x3 `xor` y3)
+xorPackedBytes (PackedBytes# ba1#) (PackedBytes# ba2#) =
+  let pa1 = PrimArray ba1# :: PrimArray Word8
+      pa2 = PrimArray ba2# :: PrimArray Word8
+   in case imapPrimArray (xor . indexPrimArray pa1) pa2 of
+        PrimArray pa# -> PackedBytes# pa#
+xorPackedBytes _ _ =
+  error "Impossible case. GHC can't figure out that pattern match is exhaustive."
+{-# INLINE xorPackedBytes #-}
+
+
+withMutableByteArray :: Int -> (forall s . MutableByteArray s -> ST s ()) -> ByteArray
+withMutableByteArray n f = do
+  runST $ do
+    mba <- newByteArray n
+    f mba
+    unsafeFreezeByteArray mba
+{-# INLINE withMutableByteArray #-}
+
+withPinnedMutableByteArray :: Int -> (forall s . MutableByteArray s -> ST s ()) -> ByteArray
+withPinnedMutableByteArray n f = do
+  runST $ do
+    mba <- newPinnedByteArray n
+    f mba
+    unsafeFreezeByteArray mba
+{-# INLINE withPinnedMutableByteArray #-}
+
+unpackBytes :: PackedBytes n -> ShortByteString
+unpackBytes = byteArrayToShortByteString . unpackBytesWith withMutableByteArray
+{-# INLINE unpackBytes #-}
+
+unpackPinnedBytes :: PackedBytes n -> ByteString
+unpackPinnedBytes = byteArrayToByteString . unpackBytesWith withPinnedMutableByteArray
+{-# INLINE unpackPinnedBytes #-}
+
+
+unpackBytesWith ::
+     (Int -> (forall s. MutableByteArray s -> ST s ()) -> ByteArray)
+  -> PackedBytes n
+  -> ByteArray
+unpackBytesWith allocate (PackedBytes8 w) =
+  allocate 8  $ \mba -> writeWord64BE mba 0 w
+unpackBytesWith allocate (PackedBytes28 w0 w1 w2 w3) =
+  allocate 28 $ \mba -> do
+    writeWord64BE mba 0  w0
+    writeWord64BE mba 8  w1
+    writeWord64BE mba 16 w2
+    writeWord32BE mba 24 w3
+unpackBytesWith allocate (PackedBytes32 w0 w1 w2 w3) =
+  allocate 32 $ \mba -> do
+    writeWord64BE mba 0  w0
+    writeWord64BE mba 8  w1
+    writeWord64BE mba 16 w2
+    writeWord64BE mba 24 w3
+unpackBytesWith _ (PackedBytes# ba#) = ByteArray ba#
+{-# INLINE unpackBytesWith #-}
+
+
+packBytes8 :: ShortByteString -> PackedBytes 8
+packBytes8 (SBS ba#) =
+  let ba = ByteArray ba#
+   in PackedBytes8 (indexWord64BE ba 0)
+{-# INLINE packBytes8 #-}
+
+packBytes28 :: ShortByteString -> PackedBytes 28
+packBytes28 (SBS ba#) =
+  let ba = ByteArray ba#
+  in PackedBytes28
+       (indexWord64BE ba 0)
+       (indexWord64BE ba 8)
+       (indexWord64BE ba 16)
+       (indexWord32BE ba 24)
+{-# INLINE packBytes28 #-}
+
+packBytes32 :: ShortByteString -> PackedBytes 32
+packBytes32 (SBS ba#) =
+  let ba = ByteArray ba#
+  in PackedBytes32
+       (indexWord64BE ba 0)
+       (indexWord64BE ba 8)
+       (indexWord64BE ba 16)
+       (indexWord64BE ba 24)
+{-# INLINE packBytes32 #-}
+
+packBytesN :: ShortByteString -> PackedBytes n
+packBytesN (SBS ba#) = PackedBytes# ba#
+{-# INLINE packBytesN #-}
+
+
+packBytes :: forall n . KnownNat n => ShortByteString -> PackedBytes n
+packBytes sbs@(SBS ba#) =
+  let px = Proxy :: Proxy n
+   in case sameNat px (Proxy :: Proxy 8) of
+        Just Refl -> packBytes8 sbs
+        Nothing -> case sameNat px (Proxy :: Proxy 28) of
+          Just Refl -> packBytes28 sbs
+          Nothing -> case sameNat px (Proxy :: Proxy 32) of
+            Just Refl -> packBytes32 sbs
+            Nothing   -> PackedBytes# ba#
+{-# INLINE[1] packBytes #-}
+
+{-# RULES
+"packBytes8"  packBytes = packBytes8
+"packBytes28" packBytes = packBytes28
+"packBytes32" packBytes = packBytes32
+"packBytesN"  packBytes = packBytesN
+  #-}
+
+
+packPinnedBytes8 :: ByteString -> PackedBytes 8
+packPinnedBytes8 bs = unsafeWithByteStringPtr bs (fmap PackedBytes8 . (`peekWord64BE` 0))
+{-# INLINE packPinnedBytes8 #-}
+
+packPinnedBytes28 :: ByteString -> PackedBytes 28
+packPinnedBytes28 bs =
+  unsafeWithByteStringPtr bs $ \ptr ->
+    PackedBytes28
+      <$> peekWord64BE ptr 0
+      <*> peekWord64BE ptr 8
+      <*> peekWord64BE ptr 16
+      <*> peekWord32BE ptr 24
+{-# INLINE packPinnedBytes28 #-}
+
+packPinnedBytes32 :: ByteString -> PackedBytes 32
+packPinnedBytes32 bs =
+  unsafeWithByteStringPtr bs $ \ptr -> PackedBytes32 <$> peekWord64BE ptr 0
+                                                   <*> peekWord64BE ptr 8
+                                                   <*> peekWord64BE ptr 16
+                                                   <*> peekWord64BE ptr 24
+{-# INLINE packPinnedBytes32 #-}
+
+packPinnedBytesN :: ByteString -> PackedBytes n
+packPinnedBytesN bs =
+  case toShort bs of
+    SBS ba# -> PackedBytes# ba#
+{-# INLINE packPinnedBytesN #-}
+
+
+packPinnedBytes :: forall n . KnownNat n => ByteString -> PackedBytes n
+packPinnedBytes bs =
+  let px = Proxy :: Proxy n
+   in case sameNat px (Proxy :: Proxy 8) of
+        Just Refl -> packPinnedBytes8 bs
+        Nothing -> case sameNat px (Proxy :: Proxy 28) of
+          Just Refl -> packPinnedBytes28 bs
+          Nothing -> case sameNat px (Proxy :: Proxy 32) of
+            Just Refl -> packPinnedBytes32 bs
+            Nothing   -> packPinnedBytesN bs
+{-# INLINE[1] packPinnedBytes #-}
+
+{-# RULES
+"packPinnedBytes8"  packPinnedBytes = packPinnedBytes8
+"packPinnedBytes28" packPinnedBytes = packPinnedBytes28
+"packPinnedBytes32" packPinnedBytes = packPinnedBytes32
+"packPinnedBytesN"  packPinnedBytes = packPinnedBytesN
+  #-}
+
+
+--- Primitive architecture agnostic helpers
+
+#if WORD_SIZE_IN_BITS == 64
+
+indexWord64BE :: ByteArray -> Int -> Word64
+indexWord64BE (ByteArray ba#) (I# i#) =
+#ifdef WORDS_BIGENDIAN
+  W64# (indexWord8ArrayAsWord64# ba# i#)
+#else
+  W64# (byteSwap64# (indexWord8ArrayAsWord64# ba# i#))
+#endif
+{-# INLINE indexWord64BE #-}
+
+peekWord64BE :: Ptr a -> Int -> IO Word64
+peekWord64BE ptr i =
+#ifndef WORDS_BIGENDIAN
+  byteSwap64 <$>
+#endif
+  peekByteOff (castPtr ptr) i
+{-# INLINE peekWord64BE #-}
+
+
+writeWord64BE :: MutableByteArray s -> Int -> Word64 -> ST s ()
+writeWord64BE (MutableByteArray mba#) (I# i#) (W64# w#) =
+  primitive_ (writeWord8ArrayAsWord64# mba# i# wbe#)
+  where
+#ifdef WORDS_BIGENDIAN
+    !wbe# = w#
+#else
+    !wbe# = byteSwap64# w#
+#endif
+{-# INLINE writeWord64BE #-}
+
+#elif WORD_SIZE_IN_BITS == 32
+
+indexWord64BE :: ByteArray -> Int -> Word64
+indexWord64BE ba i =
+  (fromIntegral (indexWord32BE ba i) `shiftL` 32) .|. fromIntegral (indexWord32BE ba (i + 4))
+{-# INLINE indexWord64BE #-}
+
+peekWord64BE :: Ptr a -> Int -> IO Word64
+peekWord64BE ptr i = do
+  u <- peekWord32BE ptr i
+  l <- peekWord32BE ptr (i + 4)
+  pure ((fromIntegral u `shiftL` 32) .|. fromIntegral l)
+{-# INLINE peekWord64BE #-}
+
+writeWord64BE :: MutableByteArray s -> Int -> Word64 -> ST s ()
+writeWord64BE mba i w64 = do
+  writeWord32BE mba i (fromIntegral (w64 `shiftR` 32))
+  writeWord32BE mba (i + 4) (fromIntegral w64)
+{-# INLINE writeWord64BE #-}
+
+#else
+#error "Unsupported architecture"
+#endif
+
+
+indexWord32BE :: ByteArray -> Int -> Word32
+indexWord32BE (ByteArray ba#) (I# i#) =
+#ifdef WORDS_BIGENDIAN
+  W32# (indexWord8ArrayAsWord32# ba# i#)
+#else
+  W32# (narrow32Word# (byteSwap32# (indexWord8ArrayAsWord32# ba# i#)))
+#endif
+{-# INLINE indexWord32BE #-}
+
+peekWord32BE :: Ptr a -> Int -> IO Word32
+peekWord32BE ptr i =
+#ifndef WORDS_BIGENDIAN
+  byteSwap32 <$>
+#endif
+  peekByteOff (castPtr ptr) i
+{-# INLINE peekWord32BE #-}
+
+
+writeWord32BE :: MutableByteArray s -> Int -> Word32 -> ST s ()
+writeWord32BE (MutableByteArray mba#) (I# i#) (W32# w#) =
+  primitive_ (writeWord8ArrayAsWord32# mba# i# wbe#)
+  where
+#ifdef WORDS_BIGENDIAN
+    !wbe# = w#
+#else
+    !wbe# = narrow32Word# (byteSwap32# w#)
+#endif
+{-# INLINE writeWord32BE #-}
+
+byteArrayToShortByteString :: ByteArray -> ShortByteString
+byteArrayToShortByteString (ByteArray ba#) = SBS ba#
+{-# INLINE byteArrayToShortByteString #-}
+
+byteArrayToByteString :: ByteArray -> ByteString
+byteArrayToByteString ba
+  | isByteArrayPinned ba =
+    BS.fromForeignPtr (pinnedByteArrayToForeignPtr ba) 0 (sizeofByteArray ba)
+  | otherwise = SBS.fromShort (byteArrayToShortByteString ba)
+{-# INLINE byteArrayToByteString #-}
+
+pinnedByteArrayToForeignPtr :: ByteArray -> ForeignPtr a
+pinnedByteArrayToForeignPtr (ByteArray ba#) =
+  ForeignPtr (byteArrayContents# ba#) (PlainPtr (unsafeCoerce# ba#))
+{-# INLINE pinnedByteArrayToForeignPtr #-}
+
+-- Usage of `accursedUnutterablePerformIO` here is safe because we only use it
+-- for indexing into an immutable `ByteString`, which is analogous to
+-- `Data.ByteString.index`.  Make sure you know what you are doing before using
+-- this function.
+unsafeWithByteStringPtr :: ByteString -> (Ptr b -> IO a) -> a
+unsafeWithByteStringPtr bs f =
+  accursedUnutterablePerformIO $
+    case toForeignPtr bs of
+      (fp, offset, _) ->
+        unsafeWithForeignPtr (plusForeignPtr fp offset) f
+{-# INLINE unsafeWithByteStringPtr #-}
+
+#if !MIN_VERSION_base(4,15,0)
+-- | A compatibility wrapper for 'GHC.ForeignPtr.unsafeWithForeignPtr' provided
+-- by GHC 9.0.1 and later.
+unsafeWithForeignPtr :: ForeignPtr a -> (Ptr a -> IO b) -> IO b
+unsafeWithForeignPtr = withForeignPtr
+{-# INLINE unsafeWithForeignPtr #-}
+#endif

--- a/cardano-crypto-tests/src/Test/Crypto/Hash.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/Hash.hs
@@ -1,5 +1,8 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -9,12 +12,16 @@ module Test.Crypto.Hash
 where
 
 import Cardano.Crypto.Hash
-import qualified Data.ByteString as SB
+import Data.Bifunctor
+import qualified Data.Bits as Bits (xor)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Short as SBS
 import Data.Maybe (fromJust)
-import Data.Proxy (Proxy (..))
+import Data.Proxy (Proxy(..))
+import Data.String (fromString)
+import GHC.TypeLits
 import Test.Crypto.Util (prop_cbor, prop_cbor_size, prop_no_thunks)
 import Test.QuickCheck
-import Data.String(fromString)
 import Test.QuickCheck.Instances ()
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.QuickCheck (testProperty)
@@ -35,6 +42,8 @@ tests =
 
     , testSodiumHashAlgorithm (Proxy :: Proxy SHA256)
     , testSodiumHashAlgorithm (Proxy :: Proxy Blake2b_256)
+
+    , testPackedBytes
     ]
 
 testHashAlgorithm
@@ -67,6 +76,56 @@ testSodiumHashAlgorithm p =
     ]
     where n = hashAlgorithmName p
 
+
+testPackedBytesN :: forall n. KnownNat n => TestHash n -> TestTree
+testPackedBytesN h = do
+  testGroup
+    (hashAlgorithmName (Proxy :: Proxy (TestHash n)))
+    [ testProperty "roundtrip" $ prop_roundtrip h
+    , testProperty "compare" $ prop_compare h
+    , testProperty "xor" $ prop_xor h
+    ]
+
+testPackedBytes :: TestTree
+testPackedBytes =
+  testGroup
+    "PackedBytes"
+    [ testPackedBytesN (TestHash :: TestHash 0)
+    , testPackedBytesN (TestHash :: TestHash 1)
+    , testPackedBytesN (TestHash :: TestHash 2)
+    , testPackedBytesN (TestHash :: TestHash 3)
+    , testPackedBytesN (TestHash :: TestHash 4)
+    , testPackedBytesN (TestHash :: TestHash 5)
+    , testPackedBytesN (TestHash :: TestHash 6)
+    , testPackedBytesN (TestHash :: TestHash 7)
+    , testPackedBytesN (TestHash :: TestHash 8)
+    , testPackedBytesN (TestHash :: TestHash 9)
+    , testPackedBytesN (TestHash :: TestHash 10)
+    , testPackedBytesN (TestHash :: TestHash 11)
+    , testPackedBytesN (TestHash :: TestHash 12)
+    , testPackedBytesN (TestHash :: TestHash 13)
+    , testPackedBytesN (TestHash :: TestHash 14)
+    , testPackedBytesN (TestHash :: TestHash 15)
+    , testPackedBytesN (TestHash :: TestHash 16)
+    , testPackedBytesN (TestHash :: TestHash 17)
+    , testPackedBytesN (TestHash :: TestHash 18)
+    , testPackedBytesN (TestHash :: TestHash 19)
+    , testPackedBytesN (TestHash :: TestHash 20)
+    , testPackedBytesN (TestHash :: TestHash 21)
+    , testPackedBytesN (TestHash :: TestHash 22)
+    , testPackedBytesN (TestHash :: TestHash 23)
+    , testPackedBytesN (TestHash :: TestHash 24)
+    , testPackedBytesN (TestHash :: TestHash 25)
+    , testPackedBytesN (TestHash :: TestHash 26)
+    , testPackedBytesN (TestHash :: TestHash 27)
+    , testPackedBytesN (TestHash :: TestHash 28)
+    , testPackedBytesN (TestHash :: TestHash 29)
+    , testPackedBytesN (TestHash :: TestHash 30)
+    , testPackedBytesN (TestHash :: TestHash 31)
+    , testPackedBytesN (TestHash :: TestHash 32)
+    ]
+
+
 prop_hash_cbor :: HashAlgorithm h => Hash h Int -> Property
 prop_hash_cbor = prop_cbor
 
@@ -78,7 +137,7 @@ prop_hash_correct_sizeHash
   => Hash h a
   -> Property
 prop_hash_correct_sizeHash h =
-  SB.length (hashToBytes h) === fromIntegral (sizeHash (Proxy :: Proxy h))
+  BS.length (hashToBytes h) === fromIntegral (sizeHash (Proxy :: Proxy h))
 
 prop_hash_show_read
   :: forall h a. HashAlgorithm h
@@ -97,7 +156,7 @@ prop_hash_hashFromStringAsHex_hashToStringFromHash h = fromJust (hashFromStringA
 
 prop_libsodium_model
   :: forall h. NaCl.SodiumHashAlgorithm h
-  => Proxy h -> SB.ByteString -> Property
+  => Proxy h -> BS.ByteString -> Property
 prop_libsodium_model p bs = expected === actual
   where
     mlsb = NaCl.digestMLockedBS p bs
@@ -110,5 +169,59 @@ prop_libsodium_model p bs = expected === actual
 --
 
 instance HashAlgorithm h => Arbitrary (Hash h a) where
-  arbitrary = castHash . hashWith SB.pack <$> vector 16
+  arbitrary = castHash . hashWith BS.pack <$> vector 16
   shrink = const []
+
+--
+-- Test Hash Algorithm
+--
+
+data TestHash (n :: Nat) = TestHash
+
+instance KnownNat n => HashAlgorithm (TestHash n) where
+  type SizeHash (TestHash n) = n
+  hashAlgorithmName px = "TestHash " ++ show (sizeHash px)
+  digest px _ = BS.pack (replicate (fromIntegral (sizeHash px)) 0)
+
+prop_roundtrip ::
+     forall n. KnownNat n
+  => TestHash n
+  -> Property
+prop_roundtrip h =
+  forAll (vectorOf (fromInteger (natVal h)) arbitrary) $ \xs ->
+    let sbs = SBS.pack xs
+        bs = SBS.fromShort sbs
+        sbsHash = hashFromBytesShort sbs :: Maybe (Hash (TestHash n) ())
+        bsHash = hashFromBytes bs :: Maybe (Hash (TestHash n) ())
+     in fmap hashToBytesShort sbsHash === Just sbs .&&.
+        fmap hashToBytes bsHash === Just bs
+
+prop_compare ::
+     forall n. KnownNat n
+  => TestHash n
+  -> Property
+prop_compare h =
+  let n = fromInteger (natVal h)
+      distinct k = splitAt k <$> vectorOf (k * 2) arbitrary
+      prefixCount = max 0 (n - 2)
+      prefix = replicate prefixCount 0
+      similar = bimap (prefix ++) (prefix ++) <$> distinct (n - prefixCount)
+   in forAll (frequency [(10, distinct n), (40, similar)]) $ \(xs1, xs2) ->
+        let sbs1 = SBS.pack xs1
+            sbs2 = SBS.pack xs2
+         in compare
+              (hashFromBytesShort sbs1 :: Maybe (Hash (TestHash n) ()))
+              (hashFromBytesShort sbs2 :: Maybe (Hash (TestHash n) ())) ===
+            compare sbs1 sbs2
+
+prop_xor ::
+     forall n. KnownNat n
+  => TestHash n
+  -> Property
+prop_xor h =
+  let n = fromInteger (natVal h)
+   in forAll (bimap BS.pack BS.pack . splitAt n <$> vectorOf (n * 2) arbitrary) $ \(bs1, bs2) ->
+        Just (BS.pack (BS.zipWith Bits.xor bs1 bs2)) ===
+        (hashToBytes <$>
+         (xor <$> (hashFromBytes bs1 :: Maybe (Hash (TestHash n) ()))
+              <*> (hashFromBytes bs2 :: Maybe (Hash (TestHash n) ()))))


### PR DESCRIPTION
This is yet another alternative approach to the one that was already merged in #229 and the other two less popular ones: #230 and #231

The benefit of this approach is that all the instances (`Eq`, `Ord`, etc.) can be derived for `Hash` as before and it is efficient (no extra memory overhead for constructors, as it is with regular sum types)

The only drawback is `PackedBytes` can't be unpacked with `UNPACK` pragma, because of being implemented with GADTs.

Few extra bonus points:

* Support for 32bit CPUs
* Improved performance of `xor` (handled the TODO)
* Direct conversion to/from `ByteString` as opposed to going through `ShortByteString`
* Tests that verify all the conversion and correctness of Ord instance, which is sensitive to endianness, if not handled properly