### PR TITLE
Serialise packed bytes

### DIFF
--- a/cardano-crypto-class/cardano-crypto-class.cabal
+++ b/cardano-crypto-class/cardano-crypto-class.cabal
@@ -103,6 +103,7 @@ library
                       , memory
                       , nothunks
                       , primitive
+                      , serialise
                       , text
                       , transformers
                       , vector

--- a/cardano-crypto-class/src/Cardano/Crypto/PackedBytes.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/PackedBytes.hs
@@ -20,6 +20,9 @@ module Cardano.Crypto.PackedBytes
   , xorPackedBytes
   ) where
 
+import Codec.Serialise (Serialise(..))
+import Codec.Serialise.Decoding (decodeBytes)
+import Codec.Serialise.Encoding (encodeBytes)
 import Control.DeepSeq
 import Control.Monad.Primitive
 import Data.Bits
@@ -83,6 +86,10 @@ instance NFData (PackedBytes n) where
   rnf PackedBytes28 {} = ()
   rnf PackedBytes32 {} = ()
   rnf PackedBytes#  {} = ()
+
+instance Serialise (PackedBytes n) where
+  encode = encodeBytes . unpackPinnedBytes
+  decode = packPinnedBytesN <$> decodeBytes
 
 xorPackedBytes :: PackedBytes n -> PackedBytes n -> PackedBytes n
 xorPackedBytes (PackedBytes8 x) (PackedBytes8 y) = PackedBytes8 (x `xor` y)


### PR DESCRIPTION
`ouroboros-network` has an orphan `Serialise` instance on `Hash`:
https://github.com/input-output-hk/ouroboros-network/blob/22d9b995e2c302fb14532aa459bc6b81627267bc/ouroboros-consensus/src/Ouroboros/Consensus/Util/Orphans.hs#L64

That gets propagated to places like this:
https://github.com/input-output-hk/ouroboros-network/blob/22d9b995e2c302fb14532aa459bc6b81627267bc/ouroboros-consensus-mock/src/Ouroboros/Consensus/Mock/Ledger/UTxO.hs#L70-L72

Since `PackedBytes` isn't exported (intentionally?), I wonder if adding the `Serialise` instance here makes sense?
If this is the way to go we'd love to add some tests as well.