### PR TITLE
Address various libsodium issues

### DIFF
--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Class.hs
@@ -135,6 +135,9 @@ class ( Typeable v
   -- Key generation
   --
 
+  -- | Note that this function may error (with 'SeedBytesExhausted') if the
+  -- provided seed is not long enough. Callers should ensure that the seed has
+  -- is at least 'seedSizeDSIGN' bytes long.
   genKeyDSIGN :: Seed -> SignKeyDSIGN v
 
   --

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed25519.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed25519.hs
@@ -109,13 +109,9 @@ instance DSIGNAlgorithm Ed25519DSIGN where
       VerKeyEd25519DSIGN $
         unsafeDupablePerformIO $
         psbUseAsSizedPtr sk $ \skPtr ->
-        allocaSized $ \seedPtr ->
-        psbCreateSized $ \pkPtr -> do
-            cOrError "deriveVerKeyDSIGN @Ed25519DSIGN" "c_crypto_sign_ed25519_sk_to_seed"
-              $ c_crypto_sign_ed25519_sk_to_seed seedPtr skPtr
-            cOrError "deriveVerKeyDSIGN @Ed25519DSIGN" "c_crypto_sign_ed25519_seed_keypair"
-              $ c_crypto_sign_ed25519_seed_keypair pkPtr skPtr seedPtr
-
+        psbCreateSized $ \pkPtr ->
+          cOrError "deriveVerKeyDSIGN @Ed25519DSIGN" "c_crypto_sign_ed25519_sk_to_pk"
+            $ c_crypto_sign_ed25519_sk_to_pk pkPtr skPtr
 
     --
     -- Core algorithm operations

--- a/cardano-crypto-class/src/Cardano/Crypto/Libsodium/C.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Libsodium/C.hs
@@ -63,22 +63,22 @@ foreign import capi "sodium.h sodium_init"  c_sodium_init :: IO Int
 -- | @void sodium_memzero(void * const pnt, const size_t len);@
 --
 -- <https://libsodium.gitbook.io/doc/memory_management#zeroing-memory>
-foreign import capi "sodium.h sodium_memzero" c_sodium_memzero :: Ptr a -> CSize -> IO ()
+foreign import capi unsafe "sodium.h sodium_memzero" c_sodium_memzero :: Ptr a -> CSize -> IO ()
 
 -- | @void *sodium_malloc(size_t size);@
 --
 -- <https://libsodium.gitbook.io/doc/memory_management>
-foreign import capi "sodium.h sodium_malloc" c_sodium_malloc :: CSize -> IO (Ptr a)
+foreign import capi unsafe "sodium.h sodium_malloc" c_sodium_malloc :: CSize -> IO (Ptr a)
 --
 -- | @void sodium_free(void *ptr);@
 --
 -- <https://libsodium.gitbook.io/doc/memory_management>
-foreign import capi "sodium.h sodium_free" c_sodium_free :: Ptr a -> IO ()
+foreign import capi unsafe "sodium.h sodium_free" c_sodium_free :: Ptr a -> IO ()
 
 -- | @void sodium_free(void *ptr);@
 --
 -- <https://libsodium.gitbook.io/doc/memory_management>
-foreign import capi "sodium.h &sodium_free" c_sodium_free_funptr :: FunPtr (Ptr a -> IO ())
+foreign import capi unsafe "sodium.h &sodium_free" c_sodium_free_funptr :: FunPtr (Ptr a -> IO ())
 
 -------------------------------------------------------------------------------
 -- Hashing: SHA256
@@ -87,16 +87,16 @@ foreign import capi "sodium.h &sodium_free" c_sodium_free_funptr :: FunPtr (Ptr 
 -- | @int crypto_hash_sha256(unsigned char *out, const unsigned char *in, unsigned long long inlen);@
 --
 -- <https://libsodium.gitbook.io/doc/advanced/sha-2_hash_function>
-foreign import capi "sodium.h crypto_hash_sha256" c_crypto_hash_sha256 :: SizedPtr CRYPTO_SHA256_BYTES -> Ptr CUChar -> CULLong -> IO Int
+foreign import capi unsafe "sodium.h crypto_hash_sha256" c_crypto_hash_sha256 :: SizedPtr CRYPTO_SHA256_BYTES -> Ptr CUChar -> CULLong -> IO Int
 
 -- | @int crypto_hash_sha256_init(crypto_hash_sha256_state *state);@
-foreign import capi "sodium.h crypto_hash_sha256_init" c_crypto_hash_sha256_init :: SizedPtr CRYPTO_SHA256_STATE_SIZE -> IO Int
+foreign import capi unsafe "sodium.h crypto_hash_sha256_init" c_crypto_hash_sha256_init :: SizedPtr CRYPTO_SHA256_STATE_SIZE -> IO Int
 
 -- | @int crypto_hash_sha256_update(crypto_hash_sha256_state *state, const unsigned char *in, unsigned long long inlen);@
-foreign import capi "sodium.h crypto_hash_sha256_update" c_crypto_hash_sha256_update :: SizedPtr CRYPTO_SHA256_STATE_SIZE -> Ptr CUChar -> CULLong -> IO Int
+foreign import capi unsafe "sodium.h crypto_hash_sha256_update" c_crypto_hash_sha256_update :: SizedPtr CRYPTO_SHA256_STATE_SIZE -> Ptr CUChar -> CULLong -> IO Int
 
 -- | @int crypto_hash_sha256_final(crypto_hash_sha256_state *state, unsigned char *out);@
-foreign import capi "sodium.h crypto_hash_sha256_final" c_crypto_hash_sha256_final :: SizedPtr CRYPTO_SHA256_STATE_SIZE -> SizedPtr CRYPTO_SHA256_BYTES -> IO Int
+foreign import capi unsafe "sodium.h crypto_hash_sha256_final" c_crypto_hash_sha256_final :: SizedPtr CRYPTO_SHA256_STATE_SIZE -> SizedPtr CRYPTO_SHA256_BYTES -> IO Int
 
 -------------------------------------------------------------------------------
 -- Hashing: Blake2b
@@ -105,20 +105,20 @@ foreign import capi "sodium.h crypto_hash_sha256_final" c_crypto_hash_sha256_fin
 -- | @int crypto_generichash_blake2b(unsigned char *out, size_t outlen, const unsigned char *in, unsigned long long inlen, const unsigned char *key, size_t keylen);@
 --
 -- <https://libsodium.gitbook.io/doc/hashing/generic_hashing>
-foreign import capi "sodium.h crypto_generichash_blake2b" c_crypto_generichash_blake2b
+foreign import capi unsafe "sodium.h crypto_generichash_blake2b" c_crypto_generichash_blake2b
     :: Ptr out -> CSize
     -> Ptr CUChar -> CULLong
     -> Ptr key -> CSize
     -> IO Int
 
 -- | @int crypto_generichash_blake2b_init(crypto_generichash_blake2b_state *state, const unsigned char *key, const size_t keylen, const size_t outlen);@
-foreign import capi "sodium.h crypto_generichash_blake2b_init" c_crypto_generichash_blake2b_init :: SizedPtr CRYPTO_BLAKE2B_256_STATE_SIZE -> Ptr key -> CSize -> CSize -> IO Int
+foreign import capi unsafe "sodium.h crypto_generichash_blake2b_init" c_crypto_generichash_blake2b_init :: SizedPtr CRYPTO_BLAKE2B_256_STATE_SIZE -> Ptr key -> CSize -> CSize -> IO Int
 
 -- | @int crypto_generichash_blake2b_update(crypto_generichash_blake2b_state *state, const unsigned char *in, unsigned long long inlen);@
-foreign import capi "sodium.h crypto_generichash_blake2b_update" c_crypto_generichash_blake2b_update :: SizedPtr CRYPTO_BLAKE2B_256_STATE_SIZE -> Ptr CUChar -> CULLong -> IO Int
+foreign import capi unsafe "sodium.h crypto_generichash_blake2b_update" c_crypto_generichash_blake2b_update :: SizedPtr CRYPTO_BLAKE2B_256_STATE_SIZE -> Ptr CUChar -> CULLong -> IO Int
 
 -- | @int crypto_generichash_blake2b_final(crypto_generichash_blake2b_state *state, unsigned char *out, const size_t outlen);@
-foreign import capi "sodium.h crypto_generichash_blake2b_final" c_crypto_generichash_blake2b_final :: SizedPtr CRYPTO_BLAKE2B_256_STATE_SIZE -> Ptr out -> CSize -> IO Int
+foreign import capi unsafe "sodium.h crypto_generichash_blake2b_final" c_crypto_generichash_blake2b_final :: SizedPtr CRYPTO_BLAKE2B_256_STATE_SIZE -> Ptr out -> CSize -> IO Int
 
 -------------------------------------------------------------------------------
 -- Signing: ED25519
@@ -127,20 +127,20 @@ foreign import capi "sodium.h crypto_generichash_blake2b_final" c_crypto_generic
 -- https://github.com/jedisct1/libsodium/blob/7b67cd1b32915bc957d750e7a15229f2a938ff1a/src/libsodium/include/sodium/crypto_sign_ed25519.h
 
 -- | @int crypto_sign_ed25519_seed_keypair(unsigned char *pk, unsigned char *sk, const unsigned char *seed);@
-foreign import capi "sodium.h crypto_sign_ed25519_seed_keypair" c_crypto_sign_ed25519_seed_keypair
+foreign import capi unsafe "sodium.h crypto_sign_ed25519_seed_keypair" c_crypto_sign_ed25519_seed_keypair
     :: SizedPtr CRYPTO_SIGN_ED25519_PUBLICKEYBYTES
     -> SizedPtr CRYPTO_SIGN_ED25519_SECRETKEYBYTES
     -> SizedPtr CRYPTO_SIGN_ED25519_SEEDBYTES
     -> IO Int
 
 -- | @int crypto_sign_ed25519_sk_to_seed(unsigned char *seed, const unsigned char *sk);@
-foreign import capi "sodium.h crypto_sign_ed25519_sk_to_seed" c_crypto_sign_ed25519_sk_to_seed
+foreign import capi unsafe "sodium.h crypto_sign_ed25519_sk_to_seed" c_crypto_sign_ed25519_sk_to_seed
     :: SizedPtr CRYPTO_SIGN_ED25519_SEEDBYTES
     -> SizedPtr CRYPTO_SIGN_ED25519_SECRETKEYBYTES
     -> IO Int
 
 -- | @int crypto_sign_ed25519_detached(unsigned char *sig, unsigned long long *siglen_p, const unsigned char *m, unsigned long long mlen, const unsigned char *sk);@
-foreign import capi "sodium.h crypto_sign_ed25519_detached" c_crypto_sign_ed25519_detached
+foreign import capi unsafe "sodium.h crypto_sign_ed25519_detached" c_crypto_sign_ed25519_detached
     :: SizedPtr CRYPTO_SIGN_ED25519_BYTES
     -> Ptr CULLong
     -> Ptr CUChar
@@ -149,7 +149,7 @@ foreign import capi "sodium.h crypto_sign_ed25519_detached" c_crypto_sign_ed2551
     -> IO Int
 
 -- | @int crypto_sign_ed25519_verify_detached(const unsigned char *sig, const unsigned char *m, unsigned long long mlen, const unsigned char *pk);@
-foreign import capi "sodium.h crypto_sign_ed25519_verify_detached" c_crypto_sign_ed25519_verify_detached
+foreign import capi unsafe "sodium.h crypto_sign_ed25519_verify_detached" c_crypto_sign_ed25519_verify_detached
     :: SizedPtr CRYPTO_SIGN_ED25519_BYTES
     -> Ptr CUChar
     -> CULLong
@@ -157,7 +157,7 @@ foreign import capi "sodium.h crypto_sign_ed25519_verify_detached" c_crypto_sign
     -> IO Int
 
 -- | @int crypto_sign_ed25519_sk_to_pk(unsigned char *pk, const unsigned char *sk);@
-foreign import capi "sodium.h crypto_sign_ed25519_sk_to_pk" c_crypto_sign_ed25519_sk_to_pk
+foreign import capi unsafe "sodium.h crypto_sign_ed25519_sk_to_pk" c_crypto_sign_ed25519_sk_to_pk
     :: SizedPtr CRYPTO_SIGN_ED25519_PUBLICKEYBYTES
     -> SizedPtr CRYPTO_SIGN_ED25519_SECRETKEYBYTES -> IO Int
 
@@ -168,4 +168,4 @@ foreign import capi "sodium.h crypto_sign_ed25519_sk_to_pk" c_crypto_sign_ed2551
 -- | @int sodium_compare(const void * const b1_, const void * const b2_, size_t len);@
 --
 -- <https://libsodium.gitbook.io/doc/helpers#comparing-large-numbers>
-foreign import capi "sodium.h sodium_compare" c_sodium_compare :: Ptr a -> Ptr a -> CSize -> IO Int
+foreign import capi unsafe "sodium.h sodium_compare" c_sodium_compare :: Ptr a -> Ptr a -> CSize -> IO Int

--- a/cardano-crypto-class/src/Cardano/Crypto/Seed.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Seed.hs
@@ -52,6 +52,8 @@ mkSeedFromBytes :: ByteString -> Seed
 mkSeedFromBytes = Seed
 
 
+-- | Extract the full bytes from a seed. Note that this function does not
+-- guarantee that the result is sufficiently long for the desired seed size!
 getSeedBytes :: Seed -> ByteString
 getSeedBytes (Seed s) = s
 


### PR DESCRIPTION
Each commit may be reviewed independently.

In order, they:
- Ensure enough bytes are passed to the seed.
- Address a potential concurrency issue in `deriveVerKeyDSIGN`.
- Mark most foreign calls to libsodium as `unsafe`.