### PR TITLE
Remove overlapping rewrite rules.

### DIFF
--- a/cardano-crypto-class/src/Cardano/Crypto/PackedBytes.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/PackedBytes.hs
@@ -180,11 +180,6 @@ packBytes32 (SBS ba#) =
        (indexWord64BE ba 24)
 {-# INLINE packBytes32 #-}
 
-packBytesN :: ShortByteString -> PackedBytes n
-packBytesN (SBS ba#) = PackedBytes# ba#
-{-# INLINE packBytesN #-}
-
-
 packBytes :: forall n . KnownNat n => ShortByteString -> PackedBytes n
 packBytes sbs@(SBS ba#) =
   let px = Proxy :: Proxy n
@@ -201,7 +196,6 @@ packBytes sbs@(SBS ba#) =
 "packBytes8"  packBytes = packBytes8
 "packBytes28" packBytes = packBytes28
 "packBytes32" packBytes = packBytes32
-"packBytesN"  packBytes = packBytesN
   #-}
 
 
@@ -250,7 +244,6 @@ packPinnedBytes bs =
 "packPinnedBytes8"  packPinnedBytes = packPinnedBytes8
 "packPinnedBytes28" packPinnedBytes = packPinnedBytes28
 "packPinnedBytes32" packPinnedBytes = packPinnedBytes32
-"packPinnedBytesN"  packPinnedBytes = packPinnedBytesN
   #-}
 
 


### PR DESCRIPTION
As per
https://downloads.haskell.org/~ghc/7.0.3/docs/html/users_guide/rewrite-rules.html,
if GHC encounters more than one matching rewrite rule, it will choose
arbitrarily which one fires. As such, the rewrite rules converting
`pack*Bytes` to `pack*BytesN` are problematic - they are always
applicable, and hence may fire in place of the specific ones.

Consequently, we remove them. Since they are optimisations anyway, this
should not change the semantics of the system.