### PR TITLE
Change KES signature format to be more compact

### DIFF
--- a/cardano-crypto-class/cardano-crypto-class.cabal
+++ b/cardano-crypto-class/cardano-crypto-class.cabal
@@ -65,6 +65,8 @@ library
                         Cardano.Crypto.KES.Simple
                         Cardano.Crypto.KES.Single
                         Cardano.Crypto.KES.Sum
+                        Cardano.Crypto.KES.CompactSingle
+                        Cardano.Crypto.KES.CompactSum
 
                         Cardano.Crypto.PinnedSizedBytes
                         Cardano.Crypto.Seed

--- a/cardano-crypto-class/src/Cardano/Crypto/KES.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES.hs
@@ -10,3 +10,5 @@ import Cardano.Crypto.KES.NeverUsed as X
 import Cardano.Crypto.KES.Simple as X
 import Cardano.Crypto.KES.Single as X
 import Cardano.Crypto.KES.Sum as X
+import Cardano.Crypto.KES.CompactSingle as X
+import Cardano.Crypto.KES.CompactSum as X

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/CompactSingle.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/CompactSingle.hs
@@ -1,0 +1,221 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | A standard signature scheme is a forward-secure signature scheme with a
+-- single time period.
+--
+-- This is the base case in the naive recursive implementation of the sum
+-- composition from section 3 of the \"MMM\" paper:
+--
+-- /Composition and Efficiency Tradeoffs for Forward-Secure Digital Signatures/
+-- By Tal Malkin, Daniele Micciancio and Sara Miner
+-- <https://eprint.iacr.org/2001/034>
+--
+-- Specfically it states:
+--
+-- > In order to unify the presentation, we regard standard signature schemes
+-- > as forward-seure signature schemes with one time period, namely T = 1.
+--
+-- So this module simply provides a wrapper 'CompactSingleKES' that turns any
+-- 'DSIGNAlgorithm' into an instance of 'KESAlgorithm' with a single period.
+--
+-- See "Cardano.Crypto.KES.CompactSum" for the composition case.
+--
+-- Compared to the implementation in 'Cardano.Crypto.KES.Single', this flavor
+-- stores the VerKey used for signing along with the signature. The purpose of
+-- this is so that we can avoid storing a pair of VerKeys at every branch node,
+-- like 'Cardano.Crypto.KES.Sum' does. See 'Cardano.Crypto.KES.CompactSum' for
+-- more details.
+module Cardano.Crypto.KES.CompactSingle (
+    CompactSingleKES
+  , VerKeyKES (..)
+  , SignKeyKES (..)
+  , SigKES (..)
+  ) where
+
+import Data.Proxy (Proxy(..))
+import Data.Typeable (Typeable)
+import GHC.Generics (Generic)
+import NoThunks.Class (NoThunks)
+import qualified Data.ByteString as BS
+import           Control.Monad (guard)
+
+import Control.Exception (assert)
+
+import Cardano.Binary (FromCBOR (..), ToCBOR (..))
+
+import Cardano.Crypto.Hash.Class
+import Cardano.Crypto.DSIGN.Class
+import qualified Cardano.Crypto.DSIGN as DSIGN
+import Cardano.Crypto.KES.Class
+import Control.DeepSeq (NFData)
+
+
+-- | A standard signature scheme is a forward-secure signature scheme with a
+-- single time period.
+--
+data CompactSingleKES d
+
+deriving newtype instance NFData (VerKeyDSIGN d) => NFData (VerKeyKES (CompactSingleKES d))
+deriving newtype instance NFData (SignKeyDSIGN d) => NFData (SignKeyKES (CompactSingleKES d))
+
+deriving anyclass instance (NFData (SigDSIGN d), NFData (VerKeyDSIGN d)) => NFData (SigKES (CompactSingleKES d))
+
+instance (DSIGNAlgorithm d, Typeable d) => KESAlgorithm (CompactSingleKES d) where
+    type SeedSizeKES (CompactSingleKES d) = SeedSizeDSIGN d
+
+    --
+    -- Key and signature types
+    --
+
+    newtype VerKeyKES (CompactSingleKES d) = VerKeyCompactSingleKES (VerKeyDSIGN d)
+        deriving Generic
+
+    newtype SignKeyKES (CompactSingleKES d) = SignKeyCompactSingleKES (SignKeyDSIGN d)
+        deriving Generic
+
+    data SigKES (CompactSingleKES d) = SigCompactSingleKES !(SigDSIGN d) !(VerKeyDSIGN d)
+        deriving Generic
+
+
+    --
+    -- Metadata and basic key operations
+    --
+
+    algorithmNameKES _ = algorithmNameDSIGN (Proxy :: Proxy d) ++ "_kes_2^0"
+
+    deriveVerKeyKES (SignKeyCompactSingleKES sk) =
+        VerKeyCompactSingleKES (deriveVerKeyDSIGN sk)
+
+    hashVerKeyKES (VerKeyCompactSingleKES vk) =
+        castHash (hashVerKeyDSIGN vk)
+
+
+    --
+    -- Core algorithm operations
+    --
+
+    type ContextKES (CompactSingleKES d) = DSIGN.ContextDSIGN d
+    type Signable   (CompactSingleKES d) = DSIGN.Signable     d
+
+    signKES ctxt t a (SignKeyCompactSingleKES sk) =
+        assert (t == 0) $
+        SigCompactSingleKES (signDSIGN ctxt a sk) (deriveVerKeyDSIGN sk)
+
+    verifyKES = verifyOptimizedKES
+
+    updateKES _ctx (SignKeyCompactSingleKES _sk) _to = Nothing
+
+    totalPeriodsKES  _ = 1
+
+    --
+    -- Key generation
+    --
+
+    seedSizeKES _ = seedSizeDSIGN (Proxy :: Proxy d)
+    genKeyKES seed = SignKeyCompactSingleKES (genKeyDSIGN seed)
+
+
+    --
+    -- raw serialise/deserialise
+    --
+
+    sizeVerKeyKES  _ = sizeVerKeyDSIGN  (Proxy :: Proxy d)
+    sizeSignKeyKES _ = sizeSignKeyDSIGN (Proxy :: Proxy d)
+    sizeSigKES     _ = sizeSigDSIGN     (Proxy :: Proxy d) +
+                       sizeVerKeyDSIGN  (Proxy :: Proxy d)
+
+    rawSerialiseVerKeyKES  (VerKeyCompactSingleKES  vk) = rawSerialiseVerKeyDSIGN vk
+    rawSerialiseSignKeyKES (SignKeyCompactSingleKES sk) = rawSerialiseSignKeyDSIGN sk
+    rawSerialiseSigKES     (SigCompactSingleKES sig vk) =
+      rawSerialiseSigDSIGN sig <> rawSerialiseVerKeyDSIGN vk
+
+    rawDeserialiseVerKeyKES  = fmap VerKeyCompactSingleKES  . rawDeserialiseVerKeyDSIGN
+    rawDeserialiseSignKeyKES = fmap SignKeyCompactSingleKES . rawDeserialiseSignKeyDSIGN
+    rawDeserialiseSigKES b   = do
+        guard (BS.length b == fromIntegral size_total)
+        sigma <- rawDeserialiseSigDSIGN  b_sig
+        vk  <- rawDeserialiseVerKeyDSIGN b_vk
+        return (SigCompactSingleKES sigma vk)
+      where
+        b_sig = slice off_sig size_sig b
+        b_vk = slice off_vk size_vk  b
+
+        size_sig   = sizeSigDSIGN    (Proxy :: Proxy d)
+        size_vk    = sizeVerKeyDSIGN (Proxy :: Proxy d)
+        size_total = sizeSigKES    (Proxy :: Proxy (CompactSingleKES d))
+
+        off_sig    = 0 :: Word
+        off_vk     = size_sig
+
+instance (KESAlgorithm (CompactSingleKES d), DSIGNAlgorithm d) => OptimizedKESAlgorithm (CompactSingleKES d) where
+    verifySigKES ctxt t a (SigCompactSingleKES sig vk) =
+      assert (t == 0) $
+      verifyDSIGN ctxt vk a sig
+
+    verKeyFromSigKES _ctxt t (SigCompactSingleKES _ vk) =
+      assert (t == 0) $
+      VerKeyCompactSingleKES vk
+
+
+--
+-- VerKey instances
+--
+
+deriving instance DSIGNAlgorithm d => Show (VerKeyKES (CompactSingleKES d))
+deriving instance DSIGNAlgorithm d => Eq   (VerKeyKES (CompactSingleKES d))
+
+instance DSIGNAlgorithm d => NoThunks (SignKeyKES (CompactSingleKES d))
+
+instance DSIGNAlgorithm d => ToCBOR (VerKeyKES (CompactSingleKES d)) where
+  toCBOR = encodeVerKeyKES
+  encodedSizeExpr _size = encodedVerKeyKESSizeExpr
+
+instance DSIGNAlgorithm d => FromCBOR (VerKeyKES (CompactSingleKES d)) where
+  fromCBOR = decodeVerKeyKES
+
+
+--
+-- SignKey instances
+--
+
+deriving instance DSIGNAlgorithm d => Show (SignKeyKES (CompactSingleKES d))
+
+instance DSIGNAlgorithm d => NoThunks (VerKeyKES  (CompactSingleKES d))
+
+instance DSIGNAlgorithm d => ToCBOR (SignKeyKES (CompactSingleKES d)) where
+  toCBOR = encodeSignKeyKES
+  encodedSizeExpr _size = encodedSignKeyKESSizeExpr
+
+instance DSIGNAlgorithm d => FromCBOR (SignKeyKES (CompactSingleKES d)) where
+  fromCBOR = decodeSignKeyKES
+
+
+--
+-- Sig instances
+--
+
+deriving instance DSIGNAlgorithm d => Show (SigKES (CompactSingleKES d))
+deriving instance DSIGNAlgorithm d => Eq   (SigKES (CompactSingleKES d))
+
+instance DSIGNAlgorithm d => NoThunks (SigKES (CompactSingleKES d))
+
+instance DSIGNAlgorithm d => ToCBOR (SigKES (CompactSingleKES d)) where
+  toCBOR = encodeSigKES
+  encodedSizeExpr _size = encodedSigKESSizeExpr
+
+instance DSIGNAlgorithm d => FromCBOR (SigKES (CompactSingleKES d)) where
+  fromCBOR = decodeSigKES
+
+slice :: Word -> Word -> ByteString -> ByteString
+slice offset size = BS.take (fromIntegral size)
+                  . BS.drop (fromIntegral offset)

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/CompactSum.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/CompactSum.hs
@@ -87,8 +87,7 @@ import           Cardano.Crypto.Util
 import           Cardano.Crypto.Hash.Class
 import           Cardano.Crypto.KES.Class
 import           Cardano.Crypto.KES.CompactSingle (CompactSingleKES)
-import Data.Word (Word8)
-import Control.DeepSeq (NFData)
+import           Control.DeepSeq (NFData)
 
 
 -- | A 2^0 period KES

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/CompactSum.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/CompactSum.hs
@@ -83,6 +83,7 @@ import           NoThunks.Class (NoThunks)
 import           Cardano.Binary (FromCBOR (..), ToCBOR (..))
 
 import           Cardano.Crypto.Seed
+import           Cardano.Crypto.Util
 import           Cardano.Crypto.Hash.Class
 import           Cardano.Crypto.KES.Class
 import           Cardano.Crypto.KES.CompactSingle (CompactSingleKES)
@@ -319,33 +320,6 @@ instance (KESAlgorithm (CompactSumKES h d), OptimizedKESAlgorithm d, HashAlgorit
            | otherwise = t - _T
         (vk_0, vk_1) | t < _T = (verKeyFromSigKES ctxt t' sigma, vk_other)
                      | otherwise = (vk_other, verKeyFromSigKES ctxt t' sigma)
-
-hashPairOfVKeys :: (KESAlgorithm d, HashAlgorithm h)
-                => (VerKeyKES d, VerKeyKES d)
-                -> Hash h (VerKeyKES d, VerKeyKES d)
-hashPairOfVKeys =
-    hashWith $ \(a,b) ->
-      rawSerialiseVerKeyKES a <> rawSerialiseVerKeyKES b
-
-slice :: Word -> Word -> ByteString -> ByteString
-slice offset size = BS.take (fromIntegral size)
-                  . BS.drop (fromIntegral offset)
-
-zeroSeed :: KESAlgorithm d => Proxy d -> Seed
-zeroSeed p = mkSeedFromBytes (BS.replicate seedSize (0 :: Word8))
-  where
-    seedSize :: Int
-    seedSize = fromIntegral (seedSizeKES p)
-
-mungeName :: String -> String
-mungeName basename
-  | (name, '^':nstr) <- span (/= '^') basename
-  , [(n, "")] <- reads nstr
-  = name ++ '^' : show (n+1 :: Word)
-
-  | otherwise
-  = basename ++ "_2^1"
-
 
 --
 -- VerKey instances

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/CompactSum.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/CompactSum.hs
@@ -1,0 +1,400 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | A key evolving signatures implementation.
+--
+-- It is a naive recursive implementation of the sum composition from
+-- section 3.1 of the \"MMM\" paper:
+--
+-- /Composition and Efficiency Tradeoffs for Forward-Secure Digital Signatures/
+-- By Tal Malkin, Daniele Micciancio and Sara Miner
+-- <https://eprint.iacr.org/2001/034>
+--
+-- Specfically we do the binary sum composition directly as in the paper, and
+-- then use that in a nested\/recursive fashion to construct a 7-level deep
+-- binary tree version.
+--
+-- This relies on "Cardano.Crypto.KES.CompactSingle" for the base case.
+--
+-- Compared to the implementation in 'Cardano.Crypto.KES.Sum', this flavor
+-- stores only one VerKey in the branch node.
+--
+-- Consider the following Merkle tree:
+--
+-- @
+--       (A)
+--      /   \
+--   (B)     (C)
+--   / \     / \
+-- (D) (E) (F) (G)
+--      ^
+--  0   1   2   3
+-- @
+--
+-- The caret points at leaf node E, indicating that the current period is 1.
+-- The signatures for leaf nodes D through G all contain their respective
+-- DSIGN keys; the signature for branch node B however only holds the signature
+-- for node E, and the VerKey for node D. It can reconstruct its own VerKey
+-- from these two. The signature for branch node A (the root node), then, only
+-- contains the VerKey for node C, and the signature for node B. In other
+-- words, the number of individual hashes to be stored equals the depth of the
+-- Merkle tree. Compare that to the older, naive 'SumKES', where each branch
+-- node stores two VerKeys: here, the number of keys to store is the depth of
+-- the tree times two.
+--
+-- Note that when we verify such a signature, we need to also compare the
+-- ultimate VerKey at the root against the one passed in externally, because
+-- all VerKeys until that point have been derived from the (user-supplied, so
+-- untrusted) signature. But we only need to do this once, at the tree root,
+-- so we split up the verification into two parts: verifying a signature
+-- against its embedded VerKey, and comparing that VerKey against the
+-- externally supplied target key.
+module Cardano.Crypto.KES.CompactSum (
+    CompactSumKES
+  , VerKeyKES (..)
+  , SignKeyKES (..)
+  , SigKES (..)
+
+    -- * Type aliases for powers of binary sums
+  , CompactSum0KES
+  , CompactSum1KES
+  , CompactSum2KES
+  , CompactSum3KES
+  , CompactSum4KES
+  , CompactSum5KES
+  , CompactSum6KES
+  , CompactSum7KES
+  ) where
+
+import           Data.Proxy (Proxy(..))
+import           Data.Typeable (Typeable)
+import           GHC.Generics (Generic)
+import qualified Data.ByteString as BS
+import           Control.Monad (guard)
+import           NoThunks.Class (NoThunks)
+
+import           Cardano.Binary (FromCBOR (..), ToCBOR (..))
+
+import           Cardano.Crypto.Seed
+import           Cardano.Crypto.Hash.Class
+import           Cardano.Crypto.KES.Class
+import           Cardano.Crypto.KES.CompactSingle (CompactSingleKES)
+import Data.Word (Word8)
+import Control.DeepSeq (NFData)
+
+
+-- | A 2^0 period KES
+type CompactSum0KES d   = CompactSingleKES d
+
+-- | A 2^1 period KES
+type CompactSum1KES d h = CompactSumKES h (CompactSum0KES d)
+
+-- | A 2^2 period KES
+type CompactSum2KES d h = CompactSumKES h (CompactSum1KES d h)
+
+-- | A 2^3 period KES
+type CompactSum3KES d h = CompactSumKES h (CompactSum2KES d h)
+
+-- | A 2^4 period KES
+type CompactSum4KES d h = CompactSumKES h (CompactSum3KES d h)
+
+-- | A 2^5 period KES
+type CompactSum5KES d h = CompactSumKES h (CompactSum4KES d h)
+
+-- | A 2^6 period KES
+type CompactSum6KES d h = CompactSumKES h (CompactSum5KES d h)
+
+-- | A 2^7 period KES
+type CompactSum7KES d h = CompactSumKES h (CompactSum6KES d h)
+
+
+-- | A composition of two KES schemes to give a KES scheme with the sum of
+-- the time periods.
+--
+-- While we could do this with two independent KES schemes (i.e. two types)
+-- we only need it for two instances of the same scheme, and we save
+-- substantially on the size of the type and runtime dictionaries if we do it
+-- this way, especially when we start applying it recursively.
+--
+data CompactSumKES h d
+
+instance (NFData (SigKES d), NFData (VerKeyKES d)) =>
+  NFData (SigKES (CompactSumKES h d)) where
+
+instance (NFData (SignKeyKES d), NFData (VerKeyKES d)) =>
+  NFData (SignKeyKES (CompactSumKES h d)) where
+
+instance (OptimizedKESAlgorithm d, HashAlgorithm h, Typeable d)
+      => KESAlgorithm (CompactSumKES h d) where
+
+    type SeedSizeKES (CompactSumKES h d) = SeedSizeKES d
+
+    --
+    -- Key and signature types
+    --
+
+    -- | From Section 3,1:
+    --
+    -- The verification key @vk@ for the sum scheme is the hash of the
+    -- verification keys @vk_0, vk_1@ of the two constituent schemes.
+    --
+    newtype VerKeyKES (CompactSumKES h d) =
+              VerKeyCompactSumKES (Hash h (VerKeyKES d, VerKeyKES d))
+        deriving Generic
+        deriving newtype NFData
+
+    -- | From Figure 3: @(sk_0, r_1, vk_0, vk_1)@
+    --
+    data SignKeyKES (CompactSumKES h d) =
+           SignKeyCompactSumKES !(SignKeyKES d)
+                         !Seed
+                         !(VerKeyKES d)
+                         !(VerKeyKES d)
+        deriving Generic
+
+    -- | From Figure 3: @(sigma, vk_0, vk_1)@
+    --
+    data SigKES (CompactSumKES h d) =
+           SigCompactSumKES !(SigKES d) -- contains VerKey for this branch!
+                     !(VerKeyKES d)
+        deriving Generic
+
+
+    --
+    -- Metadata and basic key operations
+    --
+
+    algorithmNameKES _ = mungeName (algorithmNameKES (Proxy :: Proxy d))
+
+    deriveVerKeyKES (SignKeyCompactSumKES _ _ vk_0 vk_1) =
+        VerKeyCompactSumKES (hashPairOfVKeys (vk_0, vk_1))
+
+    -- The verification key in this scheme is actually a hash already
+    -- however the type of hashVerKeyKES says the caller gets to choose
+    -- the hash, not the implementation. So that's why we have to hash
+    -- the hash here. We could alternatively provide a "key identifier"
+    -- function and let the implementation choose what that is.
+    hashVerKeyKES (VerKeyCompactSumKES vk) = castHash (hashWith hashToBytes vk)
+
+
+    --
+    -- Core algorithm operations
+    --
+
+    type Signable   (CompactSumKES h d) = Signable   d
+    type ContextKES (CompactSumKES h d) = ContextKES d
+
+    signKES ctxt t a (SignKeyCompactSumKES sk _r_1 vk_0 vk_1) =
+        SigCompactSumKES sigma vk_other
+      where
+        (sigma, vk_other)
+          | t < _T    = (signKES ctxt  t       a sk, vk_1)
+          | otherwise = (signKES ctxt (t - _T) a sk, vk_0)
+
+        _T = totalPeriodsKES (Proxy :: Proxy d)
+
+    verifyKES = verifyOptimizedKES
+
+    updateKES ctx (SignKeyCompactSumKES sk r_1 vk_0 vk_1) t
+      | t+1 <  _T = do sk' <- updateKES ctx sk t
+                       return $ SignKeyCompactSumKES sk' r_1 vk_0 vk_1
+      | t+1 == _T = do let sk' = genKeyKES r_1
+                       return $ SignKeyCompactSumKES sk' zero vk_0 vk_1
+      | otherwise = do sk' <- updateKES ctx sk (t - _T)
+                       return $ SignKeyCompactSumKES sk' r_1 vk_0 vk_1
+      where
+        _T = totalPeriodsKES (Proxy :: Proxy d)
+        zero = zeroSeed (Proxy :: Proxy d)
+
+    totalPeriodsKES  _ = 2 * totalPeriodsKES (Proxy :: Proxy d)
+
+
+    --
+    -- Key generation
+    --
+
+    seedSizeKES _ = seedSizeKES (Proxy :: Proxy d)
+    genKeyKES r = SignKeyCompactSumKES sk_0 r1 vk_0 vk_1
+      where
+        (r0, r1) = expandSeed (Proxy :: Proxy h) r
+
+        sk_0 = genKeyKES r0
+        vk_0 = deriveVerKeyKES sk_0
+
+        sk_1 = genKeyKES r1
+        vk_1 = deriveVerKeyKES sk_1
+
+
+    --
+    -- raw serialise/deserialise
+    --
+
+    sizeVerKeyKES  _ = sizeHash       (Proxy :: Proxy h)
+    sizeSignKeyKES _ = sizeSignKeyKES (Proxy :: Proxy d)
+                     + seedSizeKES    (Proxy :: Proxy d)
+                     + sizeVerKeyKES  (Proxy :: Proxy d) * 2
+    sizeSigKES     _ = sizeSigKES     (Proxy :: Proxy d)
+                     + sizeVerKeyKES  (Proxy :: Proxy d)
+
+    rawSerialiseVerKeyKES  (VerKeyCompactSumKES  vk) = hashToBytes vk
+
+    rawSerialiseSignKeyKES (SignKeyCompactSumKES sk r_1 vk_0 vk_1) =
+      mconcat
+        [ rawSerialiseSignKeyKES sk
+        , getSeedBytes r_1
+        , rawSerialiseVerKeyKES vk_0
+        , rawSerialiseVerKeyKES vk_1
+        ]
+
+    rawSerialiseSigKES (SigCompactSumKES sigma vk_other) =
+      mconcat
+        [ rawSerialiseSigKES sigma
+        , rawSerialiseVerKeyKES vk_other
+        ]
+
+    rawDeserialiseVerKeyKES = fmap VerKeyCompactSumKES  . hashFromBytes
+
+    rawDeserialiseSignKeyKES b = do
+        guard (BS.length b == fromIntegral size_total)
+        sk   <- rawDeserialiseSignKeyKES b_sk
+        let r = mkSeedFromBytes          b_r
+        vk_0 <- rawDeserialiseVerKeyKES  b_vk0
+        vk_1 <- rawDeserialiseVerKeyKES  b_vk1
+        return (SignKeyCompactSumKES sk r vk_0 vk_1)
+      where
+        b_sk  = slice off_sk  size_sk b
+        b_r   = slice off_r   size_r  b
+        b_vk0 = slice off_vk0 size_vk b
+        b_vk1 = slice off_vk1 size_vk b
+
+        size_sk    = sizeSignKeyKES (Proxy :: Proxy d)
+        size_r     = seedSizeKES    (Proxy :: Proxy d)
+        size_vk    = sizeVerKeyKES  (Proxy :: Proxy d)
+        size_total = sizeSignKeyKES (Proxy :: Proxy (CompactSumKES h d))
+
+        off_sk     = 0 :: Word
+        off_r      = size_sk
+        off_vk0    = off_r + size_r
+        off_vk1    = off_vk0 + size_vk
+
+    rawDeserialiseSigKES b = do
+        guard (BS.length b == fromIntegral size_total)
+        sigma <- rawDeserialiseSigKES    b_sig
+        vk  <- rawDeserialiseVerKeyKES b_vk
+        return (SigCompactSumKES sigma vk)
+      where
+        b_sig = slice off_sig size_sig b
+        b_vk  = slice off_vk  size_vk  b
+
+        size_sig   = sizeSigKES    (Proxy :: Proxy d)
+        size_vk    = sizeVerKeyKES (Proxy :: Proxy d)
+        size_total = sizeSigKES    (Proxy :: Proxy (CompactSumKES h d))
+
+        off_sig    = 0 :: Word
+        off_vk     = size_sig
+
+instance (KESAlgorithm (CompactSumKES h d), OptimizedKESAlgorithm d, HashAlgorithm h) => OptimizedKESAlgorithm (CompactSumKES h d) where
+    verifySigKES ctxt t a (SigCompactSumKES sigma _) =
+      verifySigKES ctxt t' a sigma
+      where
+        _T = totalPeriodsKES (Proxy :: Proxy d)
+        t' | t < _T = t
+           | otherwise = t - _T
+
+    verKeyFromSigKES ctxt t (SigCompactSumKES sigma vk_other) =
+      VerKeyCompactSumKES $ hashPairOfVKeys (vk_0, vk_1)
+      where
+        _T = totalPeriodsKES (Proxy :: Proxy d)
+        t' | t < _T = t
+           | otherwise = t - _T
+        (vk_0, vk_1) | t < _T = (verKeyFromSigKES ctxt t' sigma, vk_other)
+                     | otherwise = (vk_other, verKeyFromSigKES ctxt t' sigma)
+
+hashPairOfVKeys :: (KESAlgorithm d, HashAlgorithm h)
+                => (VerKeyKES d, VerKeyKES d)
+                -> Hash h (VerKeyKES d, VerKeyKES d)
+hashPairOfVKeys =
+    hashWith $ \(a,b) ->
+      rawSerialiseVerKeyKES a <> rawSerialiseVerKeyKES b
+
+slice :: Word -> Word -> ByteString -> ByteString
+slice offset size = BS.take (fromIntegral size)
+                  . BS.drop (fromIntegral offset)
+
+zeroSeed :: KESAlgorithm d => Proxy d -> Seed
+zeroSeed p = mkSeedFromBytes (BS.replicate seedSize (0 :: Word8))
+  where
+    seedSize :: Int
+    seedSize = fromIntegral (seedSizeKES p)
+
+mungeName :: String -> String
+mungeName basename
+  | (name, '^':nstr) <- span (/= '^') basename
+  , [(n, "")] <- reads nstr
+  = name ++ '^' : show (n+1 :: Word)
+
+  | otherwise
+  = basename ++ "_2^1"
+
+
+--
+-- VerKey instances
+--
+
+deriving instance HashAlgorithm h => Show (VerKeyKES (CompactSumKES h d))
+deriving instance Eq   (VerKeyKES (CompactSumKES h d))
+
+instance (KESAlgorithm d) => NoThunks (SignKeyKES (CompactSumKES h d))
+
+instance (OptimizedKESAlgorithm d, HashAlgorithm h, Typeable d)
+      => ToCBOR (VerKeyKES (CompactSumKES h d)) where
+  toCBOR = encodeVerKeyKES
+  encodedSizeExpr _size = encodedVerKeyKESSizeExpr
+
+instance (OptimizedKESAlgorithm d, HashAlgorithm h, Typeable d)
+      => FromCBOR (VerKeyKES (CompactSumKES h d)) where
+  fromCBOR = decodeVerKeyKES
+
+
+--
+-- SignKey instances
+--
+
+deriving instance KESAlgorithm d => Show (SignKeyKES (CompactSumKES h d))
+
+instance (OptimizedKESAlgorithm d) => NoThunks (VerKeyKES  (CompactSumKES h d))
+
+instance (OptimizedKESAlgorithm d, HashAlgorithm h, Typeable d)
+      => ToCBOR (SignKeyKES (CompactSumKES h d)) where
+  toCBOR = encodeSignKeyKES
+  encodedSizeExpr _size = encodedSignKeyKESSizeExpr
+
+instance (OptimizedKESAlgorithm d, HashAlgorithm h, Typeable d)
+      => FromCBOR (SignKeyKES (CompactSumKES h d)) where
+  fromCBOR = decodeSignKeyKES
+
+
+--
+-- Sig instances
+--
+
+deriving instance KESAlgorithm d => Show (SigKES (CompactSumKES h d))
+deriving instance KESAlgorithm d => Eq   (SigKES (CompactSumKES h d))
+
+instance KESAlgorithm d => NoThunks (SigKES (CompactSumKES h d))
+
+instance (OptimizedKESAlgorithm d, HashAlgorithm h, Typeable d)
+      => ToCBOR (SigKES (CompactSumKES h d)) where
+  toCBOR = encodeSigKES
+  encodedSizeExpr _size = encodedSigKESSizeExpr
+
+instance (OptimizedKESAlgorithm d, HashAlgorithm h, Typeable d)
+      => FromCBOR (SigKES (CompactSumKES h d)) where
+  fromCBOR = decodeSigKES

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/CompactSum.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/CompactSum.hs
@@ -159,10 +159,13 @@ instance (OptimizedKESAlgorithm d, HashAlgorithm h, Typeable d)
                          !(VerKeyKES d)
         deriving Generic
 
-    -- | From Figure 3: @(sigma, vk_0, vk_1)@
+    -- | Figure 3 gives: @(sigma, vk_0, vk_1)@ - however, we store only the
+    -- \"off-side\" VK in the branch, and calculate the \"on-side\" one from
+    -- the leaf VK (stored in the leaf node, see 'CompactSingleKES') and the
+    -- \"off-side\" VK's along the Merkle path.
     --
     data SigKES (CompactSumKES h d) =
-           SigCompactSumKES !(SigKES d) -- contains VerKey for this branch!
+           SigCompactSumKES !(SigKES d) -- includes VerKeys for the Merkle subpath
                      !(VerKeyKES d)
         deriving Generic
 

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Mock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Mock.hs
@@ -100,8 +100,10 @@ instance KnownNat t => KESAlgorithm (MockKES t) where
                    (SignKeyMockKES vk t)
 
     verifyKES () vk t a (SigMockKES h (SignKeyMockKES vk' t'))
+      | vk /= vk'
+      = Left "KES verification failed"
+
       | t' == t
-      , vk == vk'
       , castHash (hashWith getSignableRepresentation a) == h
       = Right ()
 
@@ -109,7 +111,6 @@ instance KnownNat t => KESAlgorithm (MockKES t) where
       = Left "KES verification failed"
 
     totalPeriodsKES  _ = fromIntegral (natVal (Proxy @ t))
-
 
     --
     -- Key generation

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Sum.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Sum.hs
@@ -49,6 +49,7 @@ import           NoThunks.Class (NoThunks)
 
 import           Cardano.Binary (FromCBOR (..), ToCBOR (..))
 
+import           Cardano.Crypto.Util
 import           Cardano.Crypto.Seed
 import           Cardano.Crypto.Hash.Class
 import           Cardano.Crypto.KES.Class
@@ -277,31 +278,6 @@ instance (KESAlgorithm d, HashAlgorithm h, Typeable d)
         off_vk0    = size_sig
         off_vk1    = off_vk0 + size_vk
 
-hashPairOfVKeys :: (KESAlgorithm d, HashAlgorithm h)
-                => (VerKeyKES d, VerKeyKES d)
-                -> Hash h (VerKeyKES d, VerKeyKES d)
-hashPairOfVKeys =
-    hashWith $ \(a,b) ->
-      rawSerialiseVerKeyKES a <> rawSerialiseVerKeyKES b
-
-slice :: Word -> Word -> ByteString -> ByteString
-slice offset size = BS.take (fromIntegral size)
-                  . BS.drop (fromIntegral offset)
-
-zeroSeed :: KESAlgorithm d => Proxy d -> Seed
-zeroSeed p = mkSeedFromBytes (BS.replicate seedSize (0 :: Word8))
-  where
-    seedSize :: Int
-    seedSize = fromIntegral (seedSizeKES p)
-
-mungeName :: String -> String
-mungeName basename
-  | (name, '^':nstr) <- span (/= '^') basename
-  , [(n, "")] <- reads nstr
-  = name ++ '^' : show (n+1 :: Word)
-
-  | otherwise
-  = basename ++ "_2^1"
 
 
 --

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Sum.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Sum.hs
@@ -54,8 +54,7 @@ import           Cardano.Crypto.Seed
 import           Cardano.Crypto.Hash.Class
 import           Cardano.Crypto.KES.Class
 import           Cardano.Crypto.KES.Single (SingleKES)
-import Data.Word (Word8)
-import Control.DeepSeq (NFData)
+import           Control.DeepSeq (NFData)
 
 
 -- | A 2^0 period KES

--- a/cardano-crypto-class/src/Cardano/Crypto/Util.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Util.hs
@@ -17,6 +17,9 @@ module Cardano.Crypto.Util
   -- * Low level conversions
   , bytesToNatural
   , naturalToBytes
+
+  -- * ByteString manipulation
+  , slice
   )
 where
 
@@ -122,4 +125,8 @@ bytesToInteger (BS.PS fp (GHC.I# off#) (GHC.I# len#)) =
         -- The last parmaeter (`1#`) tells the import function to use big
         -- endian encoding.
         in GMP.importIntegerFromAddr addrOff# (GHC.int2Word# len#) 1#
+
+slice :: Word -> Word -> ByteString -> ByteString
+slice offset size = BS.take (fromIntegral size)
+                  . BS.drop (fromIntegral offset)
 

--- a/cardano-crypto-tests/src/Bench/Crypto/KES.hs
+++ b/cardano-crypto-tests/src/Bench/Crypto/KES.hs
@@ -15,6 +15,7 @@ import Cardano.Crypto.DSIGN.Ed25519
 import Cardano.Crypto.Hash.Blake2b
 import Cardano.Crypto.KES.Class
 import Cardano.Crypto.KES.Sum
+import Cardano.Crypto.KES.CompactSum
 import Cardano.Crypto.Seed
 import qualified Data.ByteString as BS (pack)
 import Data.Maybe (fromJust)
@@ -57,6 +58,8 @@ benchmarks :: Benchmark
 benchmarks = bgroup "KES"
   [ bench_kes @Proxy @(Sum6KES Ed25519DSIGN Blake2b_256) Proxy "Sum6KES"
   , bench_kes @Proxy @(Sum7KES Ed25519DSIGN Blake2b_256) Proxy "Sum7KES"
+  , bench_kes @Proxy @(CompactSum6KES Ed25519DSIGN Blake2b_256) Proxy "CompactSum6KES"
+  , bench_kes @Proxy @(CompactSum7KES Ed25519DSIGN Blake2b_256) Proxy "CompactSum7KES"
   ]
 
 bench_kes :: forall proxy v

--- a/cardano-crypto-tests/src/Test/Crypto/KES.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/KES.hs
@@ -43,10 +43,10 @@ tests =
   , testKESAlgorithm (Proxy :: Proxy (Sum1KES Ed25519DSIGN Blake2b_256)) "Sum1KES"
   , testKESAlgorithm (Proxy :: Proxy (Sum2KES Ed25519DSIGN Blake2b_256)) "Sum2KES"
   , testKESAlgorithm (Proxy :: Proxy (Sum5KES Ed25519DSIGN Blake2b_256)) "Sum5KES"
-  , testKESAlgorithm (Proxy :: Proxy (CompactSingleKES Ed25519DSIGN))  "SingleKES"
-  , testKESAlgorithm (Proxy :: Proxy (CompactSum1KES Ed25519DSIGN Blake2b_256)) "Sum1KES"
-  , testKESAlgorithm (Proxy :: Proxy (CompactSum2KES Ed25519DSIGN Blake2b_256)) "Sum2KES"
-  , testKESAlgorithm (Proxy :: Proxy (CompactSum5KES Ed25519DSIGN Blake2b_256)) "Sum5KES"
+  , testKESAlgorithm (Proxy :: Proxy (CompactSingleKES Ed25519DSIGN))  "CompactSingleKES"
+  , testKESAlgorithm (Proxy :: Proxy (CompactSum1KES Ed25519DSIGN Blake2b_256)) "CompactSum1KES"
+  , testKESAlgorithm (Proxy :: Proxy (CompactSum2KES Ed25519DSIGN Blake2b_256)) "CompactSum2KES"
+  , testKESAlgorithm (Proxy :: Proxy (CompactSum5KES Ed25519DSIGN Blake2b_256)) "CompactSum5KES"
   ]
 
 -- We normally ensure that we avoid naively comparing signing keys by not

--- a/cardano-crypto-tests/src/Test/Crypto/KES.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/KES.hs
@@ -43,17 +43,25 @@ tests =
   , testKESAlgorithm (Proxy :: Proxy (Sum1KES Ed25519DSIGN Blake2b_256)) "Sum1KES"
   , testKESAlgorithm (Proxy :: Proxy (Sum2KES Ed25519DSIGN Blake2b_256)) "Sum2KES"
   , testKESAlgorithm (Proxy :: Proxy (Sum5KES Ed25519DSIGN Blake2b_256)) "Sum5KES"
+  , testKESAlgorithm (Proxy :: Proxy (CompactSingleKES Ed25519DSIGN))  "SingleKES"
+  , testKESAlgorithm (Proxy :: Proxy (CompactSum1KES Ed25519DSIGN Blake2b_256)) "Sum1KES"
+  , testKESAlgorithm (Proxy :: Proxy (CompactSum2KES Ed25519DSIGN Blake2b_256)) "Sum2KES"
+  , testKESAlgorithm (Proxy :: Proxy (CompactSum5KES Ed25519DSIGN Blake2b_256)) "Sum5KES"
   ]
 
 -- We normally ensure that we avoid naively comparing signing keys by not
 -- providing instances, but for tests it is fine, so we provide the orphan
--- instance here.
+-- instances here.
 deriving instance Eq (SignKeyDSIGN d) => Eq (SignKeyKES (SimpleKES d t))
 
 deriving instance Eq (SignKeyDSIGN d)
                => Eq (SignKeyKES (SingleKES d))
 deriving instance (KESAlgorithm d, Eq (SignKeyKES d))
                => Eq (SignKeyKES (SumKES h d))
+deriving instance Eq (SignKeyDSIGN d)
+               => Eq (SignKeyKES (CompactSingleKES d))
+deriving instance (KESAlgorithm d, Eq (SignKeyKES d))
+               => Eq (SignKeyKES (CompactSumKES h d))
 
 testKESAlgorithm
   :: forall v proxy.


### PR DESCRIPTION
Change KES signature representation and serialization format.

This is so that we can reduce the size of KES signatures.

Previously, we stored in the signature:

- At the leaf node level (SingleKES):
    - The DSIGN signature of the leaf
- At the branch node level (SumKES):
    - The signature of the 'active' child node (the subtree containing the current period)
    - The DSIGN VK's of both child nodes

This means that for a Merkle tree N levels deep, we store 1 DSIGN signature + 2N-1 DSIGN VK's.

In the new implementation, we store:

- At the leaf node level (SingleKES):
    - The DSIGN signature of the leaf
    - The DSIGN VK for that signature
- At the branch node level (SumKES):
    - The signature of the 'active' child node
    - The DSIGN VK for the 'inactive' child node

This representation reduces storage size to 1 DSIGN signature + N DSIGN VK's.

For performance reasons, we now split the verification process into two steps:

1. verifyDSIGN on the 'sigma' part of the signature. We include the VerKey for the leaf node in the signature itself, and just verify against that. This is not sufficient as validation on its own, hence...
2. ...recursively calculate the root VerKey along the Merkle path down to the leaf node, and compare it against the VerKey to verify against.

The advantage of this is that we only ever calculate the hashes we
absolutely need, and avoid duplicate calculation efforts.

In order to facilitate migrating from the old representation to the new one,
the old SumKES has been left (mostly) unchanged, and the new implementation has
been added under the name CompactSumKES (with CompactSingleKES as the leaf
node type).
