### PR TITLE
SECP256k1 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ result
 
 # Local development
 stack-local.yaml
+.nvimrc
 
 # Visual Studio Code
 /.vscode

--- a/cabal.project
+++ b/cabal.project
@@ -30,10 +30,4 @@ source-repository-package
   location: https://github.com/input-output-hk/cardano-crypto
   tag: 2547ad1e80aeabca2899951601079408becbc92c
   --sha256: 1p2kg2w02q5w1cvqzhfhqmxviy4xrzada3mmb096j2n6hfr20kri
-
-source-repository-package
-  type: git
-  location: https://github.com/haskoin/secp256k1-haskell
-  tag: 885d0953d5a0fb08be181a80f3643b0135b04bcb
-  --sha256: sha256-LcbALevNfaiP5a1IyB9gieJulsxEgvf/+jLuCC3mvK4=
  

--- a/cabal.project
+++ b/cabal.project
@@ -30,3 +30,10 @@ source-repository-package
   location: https://github.com/input-output-hk/cardano-crypto
   tag: 2547ad1e80aeabca2899951601079408becbc92c
   --sha256: 1p2kg2w02q5w1cvqzhfhqmxviy4xrzada3mmb096j2n6hfr20kri
+
+source-repository-package
+  type: git
+  location: https://github.com/haskoin/secp256k1-haskell
+  tag: 885d0953d5a0fb08be181a80f3643b0135b04bcb
+  --sha256: sha256-LcbALevNfaiP5a1IyB9gieJulsxEgvf/+jLuCC3mvK4=
+ 

--- a/cardano-crypto-class/cardano-crypto-class.cabal
+++ b/cardano-crypto-class/cardano-crypto-class.cabal
@@ -98,6 +98,7 @@ library
                       , bytestring
                       , cardano-binary
                       , cardano-prelude
+                      , cereal
                       , cryptonite
                       , deepseq
                       , integer-gmp

--- a/cardano-crypto-class/cardano-crypto-class.cabal
+++ b/cardano-crypto-class/cardano-crypto-class.cabal
@@ -31,7 +31,6 @@ common project-config
                         -Wincomplete-uni-patterns
                         -Wpartial-fields
                         -Wredundant-constraints
-                        -Wunused-packages
 
   if (!flag(development))
     ghc-options:        -Werror
@@ -106,6 +105,7 @@ library
                       , nothunks
                       , primitive
                       , serialise
+                      , secp256k1-haskell
                       , text
                       , transformers
                       , vector

--- a/cardano-crypto-class/cardano-crypto-class.cabal
+++ b/cardano-crypto-class/cardano-crypto-class.cabal
@@ -31,6 +31,7 @@ common project-config
                         -Wincomplete-uni-patterns
                         -Wpartial-fields
                         -Wredundant-constraints
+                        -Wunused-packages
 
   if (!flag(development))
     ghc-options:        -Werror

--- a/cardano-crypto-class/cardano-crypto-class.cabal
+++ b/cardano-crypto-class/cardano-crypto-class.cabal
@@ -49,6 +49,7 @@ library
                         Cardano.Crypto.DSIGN.Ed448
                         Cardano.Crypto.DSIGN.Mock
                         Cardano.Crypto.DSIGN.NeverUsed
+                        Cardano.Crypto.DSIGN.SECP256k1
 
                         Cardano.Crypto.Hash.Blake2b
                         Cardano.Crypto.Hash.Class

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN.hs
@@ -9,3 +9,4 @@ import Cardano.Crypto.DSIGN.Ed25519 as X
 import Cardano.Crypto.DSIGN.Ed448 as X
 import Cardano.Crypto.DSIGN.Mock as X
 import Cardano.Crypto.DSIGN.NeverUsed as X
+import Cardano.Crypto.DSIGN.SECP256k1 as X

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/SECP256k1.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/SECP256k1.hs
@@ -20,14 +20,36 @@ import GHC.Generics (Generic)
 import Control.DeepSeq (NFData)
 import qualified Crypto.Secp256k1 as SECP
 import NoThunks.Class (NoThunks)
-import Cardano.Crypto.DSIGN.Class (DSIGNAlgorithm (VerKeyDSIGN, SignKeyDSIGN, SigDSIGN,
-  SeedSizeDSIGN, SizeSigDSIGN, SizeSignKeyDSIGN, SizeVerKeyDSIGN, algorithmNameDSIGN,
-  deriveVerKeyDSIGN, signDSIGN, verifyDSIGN, genKeyDSIGN, rawSerialiseSigDSIGN,
-  Signable, rawSerialiseVerKeyDSIGN, rawSerialiseSignKeyDSIGN, rawDeserialiseVerKeyDSIGN,
-  rawDeserialiseSignKeyDSIGN, rawDeserialiseSigDSIGN), encodeVerKeyDSIGN, 
-  encodedVerKeyDSIGNSizeExpr, decodeVerKeyDSIGN, encodeSignKeyDSIGN, 
-  encodedSignKeyDESIGNSizeExpr, decodeSignKeyDSIGN, encodeSigDSIGN, 
-  encodedSigDSIGNSizeExpr, decodeSigDSIGN)
+import Cardano.Crypto.DSIGN.Class (
+  DSIGNAlgorithm (VerKeyDSIGN, 
+                  SignKeyDSIGN, 
+                  SigDSIGN,
+                  SeedSizeDSIGN, 
+                  SizeSigDSIGN, 
+                  SizeSignKeyDSIGN, 
+                  SizeVerKeyDSIGN, 
+                  algorithmNameDSIGN,
+                  deriveVerKeyDSIGN, 
+                  signDSIGN, 
+                  verifyDSIGN, 
+                  genKeyDSIGN, 
+                  rawSerialiseSigDSIGN,
+                  Signable, 
+                  rawSerialiseVerKeyDSIGN, 
+                  rawSerialiseSignKeyDSIGN, 
+                  rawDeserialiseVerKeyDSIGN,
+                  rawDeserialiseSignKeyDSIGN, 
+                  rawDeserialiseSigDSIGN), 
+  encodeVerKeyDSIGN, 
+  encodedVerKeyDSIGNSizeExpr, 
+  decodeVerKeyDSIGN, 
+  encodeSignKeyDSIGN, 
+  encodedSignKeyDESIGNSizeExpr, 
+  decodeSignKeyDSIGN, 
+  encodeSigDSIGN, 
+  encodedSigDSIGNSizeExpr, 
+  decodeSigDSIGN
+  )
 
 data SECP256k1DSIGN
 

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/SECP256k1.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/SECP256k1.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ConstraintKinds #-}
+{-# OPTIONS_GHC -Wno-orphans #-} -- need NoThunks for secp256k1-haskell types
+
+module Cardano.Crypto.DSIGN.SECP256k1 where
+
+import Data.Kind (Type)
+import GHC.Generics (Generic)
+import Control.DeepSeq (NFData)
+import qualified Crypto.Secp256k1 as SECP
+import NoThunks.Class (NoThunks)
+import Cardano.Crypto.DSIGN.Class (DSIGNAlgorithm (VerKeyDSIGN, SignKeyDSIGN, SigDSIGN,
+  SeedSizeDSIGN, SizeSigDSIGN, SizeSignKeyDSIGN, SizeVerKeyDSIGN, algorithmNameDSIGN,
+  deriveVerKeyDSIGN, signDSIGN, verifyDSIGN, genKeyDSIGN, rawSerialiseSigDSIGN,
+  Signable))
+
+data SECP256k1DSIGN
+
+instance NoThunks (VerKeyDSIGN SECP256k1DSIGN)
+
+instance NoThunks (SignKeyDSIGN SECP256k1DSIGN)
+
+instance NoThunks (SigDSIGN SECP256k1DSIGN)
+
+instance DSIGNAlgorithm SECP256k1DSIGN where
+  type SeedSizeDSIGN SECP256k1DSIGN = 32
+  type SizeSigDSIGN SECP256k1DSIGN = 72
+  type SizeSignKeyDSIGN SECP256k1DSIGN = 32
+  type SizeVerKeyDSIGN SECP256k1DSIGN = 33 -- approximate, as it's 257 bits
+  type Signable SECP256k1DSIGN = ((~) SECP.Msg)
+  newtype VerKeyDSIGN SECP256k1DSIGN = VerKeySECP256k1 SECP.PubKey
+    deriving newtype (Eq, NFData)
+    deriving stock (Show, Generic)
+  newtype SignKeyDSIGN SECP256k1DSIGN = SignKeySECP256k1 SECP.SecKey
+    deriving newtype (Eq, NFData)
+    deriving stock (Show, Generic)
+  newtype SigDSIGN SECP256k1DSIGN = SigSECP256k1 SECP.Sig
+    deriving newtype (Eq, NFData)
+    deriving stock (Show, Generic)
+  algorithmNameDSIGN _ = "secp256k1"
+  deriveVerKeyDSIGN (SignKeySECP256k1 sk) = VerKeySECP256k1 . SECP.derivePubKey $ sk
+  signDSIGN () msg (SignKeySECP256k1 k) = _
+  verifyDSIGN = _
+  genKeyDSIGN = _
+  rawSerialiseSigDSIGN = _
+
+-- Required orphans
+
+instance NoThunks SECP.PubKey
+
+instance NoThunks SECP.SecKey
+
+instance NoThunks SECP.Sig

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/SECP256k1.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/SECP256k1.hs
@@ -61,9 +61,9 @@ instance NoThunks (SigDSIGN SECP256k1DSIGN)
 
 instance DSIGNAlgorithm SECP256k1DSIGN where
   type SeedSizeDSIGN SECP256k1DSIGN = 32
-  type SizeSigDSIGN SECP256k1DSIGN = 72
+  type SizeSigDSIGN SECP256k1DSIGN = 64
   type SizeSignKeyDSIGN SECP256k1DSIGN = 32
-  type SizeVerKeyDSIGN SECP256k1DSIGN = 33 -- approximate, as it's 257 bits
+  type SizeVerKeyDSIGN SECP256k1DSIGN = 64
   type Signable SECP256k1DSIGN = ((~) SECP.Msg)
   newtype VerKeyDSIGN SECP256k1DSIGN = VerKeySECP256k1 SECP.PubKey
     deriving newtype (Eq, NFData)

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/SECP256k1.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/SECP256k1.hs
@@ -5,10 +5,16 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -Wno-orphans #-} -- need NoThunks for secp256k1-haskell types
 
 module Cardano.Crypto.DSIGN.SECP256k1 where
 
+import Cardano.Binary (FromCBOR (fromCBOR), ToCBOR (toCBOR, encodedSizeExpr))
+import Data.ByteString (ByteString)
+import Crypto.Random (getRandomBytes)
+import Cardano.Crypto.Seed (runMonadRandomWithSeed)
+import Data.Serialize (Serialize (get, put), runPut, runGet)
 import Data.Kind (Type)
 import GHC.Generics (Generic)
 import Control.DeepSeq (NFData)
@@ -17,7 +23,11 @@ import NoThunks.Class (NoThunks)
 import Cardano.Crypto.DSIGN.Class (DSIGNAlgorithm (VerKeyDSIGN, SignKeyDSIGN, SigDSIGN,
   SeedSizeDSIGN, SizeSigDSIGN, SizeSignKeyDSIGN, SizeVerKeyDSIGN, algorithmNameDSIGN,
   deriveVerKeyDSIGN, signDSIGN, verifyDSIGN, genKeyDSIGN, rawSerialiseSigDSIGN,
-  Signable))
+  Signable, rawSerialiseVerKeyDSIGN, rawSerialiseSignKeyDSIGN, rawDeserialiseVerKeyDSIGN,
+  rawDeserialiseSignKeyDSIGN, rawDeserialiseSigDSIGN), encodeVerKeyDSIGN, 
+  encodedVerKeyDSIGNSizeExpr, decodeVerKeyDSIGN, encodeSignKeyDSIGN, 
+  encodedSignKeyDESIGNSizeExpr, decodeSignKeyDSIGN, encodeSigDSIGN, 
+  encodedSigDSIGNSizeExpr, decodeSigDSIGN)
 
 data SECP256k1DSIGN
 
@@ -44,10 +54,43 @@ instance DSIGNAlgorithm SECP256k1DSIGN where
     deriving stock (Show, Generic)
   algorithmNameDSIGN _ = "secp256k1"
   deriveVerKeyDSIGN (SignKeySECP256k1 sk) = VerKeySECP256k1 . SECP.derivePubKey $ sk
-  signDSIGN () msg (SignKeySECP256k1 k) = _
-  verifyDSIGN = _
-  genKeyDSIGN = _
-  rawSerialiseSigDSIGN = _
+  signDSIGN () msg (SignKeySECP256k1 k) = SigSECP256k1 . SECP.signMsg k $ msg
+  verifyDSIGN () (VerKeySECP256k1 pk) msg (SigSECP256k1 sig) = 
+    if SECP.verifySig pk sig msg
+    then pure ()
+    else Left "SECP256k1 signature not verified"
+  genKeyDSIGN seed = runMonadRandomWithSeed seed $ do
+    bs <- getRandomBytes 32
+    case SECP.secKey bs of 
+      Nothing -> error "Failed to construct a SECP256k1 secret key unexpectedly"
+      Just sk -> pure . SignKeySECP256k1 $ sk
+  rawSerialiseSigDSIGN (SigSECP256k1 sig) = putting sig
+  rawSerialiseVerKeyDSIGN (VerKeySECP256k1 pk) = putting pk
+  rawSerialiseSignKeyDSIGN (SignKeySECP256k1 sk) = putting sk
+  rawDeserialiseVerKeyDSIGN bs = VerKeySECP256k1 <$> (eitherToMaybe . getting $ bs)
+  rawDeserialiseSignKeyDSIGN bs = SignKeySECP256k1 <$> (eitherToMaybe . getting $ bs)
+  rawDeserialiseSigDSIGN bs = SigSECP256k1 <$> (eitherToMaybe . getting $ bs)
+
+instance ToCBOR (VerKeyDSIGN SECP256k1DSIGN) where
+  toCBOR = encodeVerKeyDSIGN
+  encodedSizeExpr _ = encodedVerKeyDSIGNSizeExpr
+
+instance FromCBOR (VerKeyDSIGN SECP256k1DSIGN) where
+  fromCBOR = decodeVerKeyDSIGN
+
+instance ToCBOR (SignKeyDSIGN SECP256k1DSIGN) where
+  toCBOR = encodeSignKeyDSIGN
+  encodedSizeExpr _ = encodedSignKeyDESIGNSizeExpr
+
+instance FromCBOR (SignKeyDSIGN SECP256k1DSIGN) where
+  fromCBOR = decodeSignKeyDSIGN
+
+instance ToCBOR (SigDSIGN SECP256k1DSIGN) where
+  toCBOR = encodeSigDSIGN
+  encodedSizeExpr _ = encodedSigDSIGNSizeExpr
+
+instance FromCBOR (SigDSIGN SECP256k1DSIGN) where
+  fromCBOR = decodeSigDSIGN
 
 -- Required orphans
 
@@ -56,3 +99,15 @@ instance NoThunks SECP.PubKey
 instance NoThunks SECP.SecKey
 
 instance NoThunks SECP.Sig
+
+-- Helpers
+
+eitherToMaybe :: forall (a :: Type) (b :: Type) . 
+  Either b a -> Maybe a
+eitherToMaybe = either (const Nothing) pure
+
+putting :: forall (a :: Type) . (Serialize a) => a -> ByteString
+putting = runPut . put
+
+getting :: forall (a :: Type) . (Serialize a) => ByteString -> Either String a
+getting = runGet get

--- a/cardano-crypto-tests/cardano-crypto-tests.cabal
+++ b/cardano-crypto-tests/cardano-crypto-tests.cabal
@@ -59,8 +59,10 @@ library
                       , cryptonite
                       , formatting
                       , nothunks
+                      , pretty-show
                       , QuickCheck
                       , quickcheck-instances
+                      , secp256k1-haskell
                       , tasty
                       , tasty-quickcheck
                       , criterion
@@ -75,7 +77,7 @@ test-suite test-crypto
                       , cardano-crypto-tests
                       , tasty
 
-  ghc-options:          -threaded
+  ghc-options:          -threaded -O2
 
 benchmark bench-crypto
   import:               base, project-config

--- a/cardano-crypto-tests/src/Test/Crypto/DSIGN.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/DSIGN.hs
@@ -11,16 +11,121 @@ module Test.Crypto.DSIGN
   )
 where
 
+import Text.Show.Pretty (ppShow)
+import Control.Monad (replicateM)
+import Data.ByteString (ByteString)
+import qualified GHC.Exts as GHC
+import qualified Test.QuickCheck.Gen as Gen
+import qualified Crypto.Secp256k1 as SECP
+import Data.Kind (Type)
 import Data.Proxy (Proxy (..))
-
-import Cardano.Crypto.DSIGN
-import Cardano.Crypto.Util (SignableRepresentation(..))
-
-import Test.Crypto.Util hiding (label)
+import Cardano.Crypto.DSIGN (
+  MockDSIGN, 
+  Ed25519DSIGN, 
+  Ed448DSIGN,
+  SECP256k1DSIGN,
+  DSIGNAlgorithm (VerKeyDSIGN,
+                  SignKeyDSIGN,
+                  SigDSIGN,
+                  ContextDSIGN,
+                  Signable,
+                  rawSerialiseVerKeyDSIGN,
+                  rawDeserialiseVerKeyDSIGN,
+                  rawSerialiseSignKeyDSIGN,
+                  rawDeserialiseSignKeyDSIGN,
+                  rawSerialiseSigDSIGN,
+                  rawDeserialiseSigDSIGN),
+  sizeVerKeyDSIGN,
+  sizeSignKeyDSIGN,
+  sizeSigDSIGN,
+  encodeVerKeyDSIGN,
+  decodeVerKeyDSIGN,
+  encodeSignKeyDSIGN,
+  decodeSignKeyDSIGN,
+  encodeSigDSIGN,
+  decodeSigDSIGN,
+  signDSIGN,
+  deriveVerKeyDSIGN,
+  verifyDSIGN,
+  genKeyDSIGN,
+  seedSizeDSIGN,
+  )
+import Cardano.Binary (FromCBOR, ToCBOR)
+import Test.Crypto.Util (
+  Message,
+  prop_raw_serialise,
+  prop_size_serialise,
+  prop_cbor_with,
+  prop_cbor,
+  prop_cbor_size,
+  prop_cbor_direct_vs_class,
+  prop_no_thunks,
+  arbitrarySeedOfSize
+  )
 import Test.Crypto.Instances ()
-import Test.QuickCheck ((=/=), (===), (==>), Arbitrary(..), Gen, Property)
+import Test.QuickCheck (
+  (=/=), 
+  (===), 
+  Arbitrary(..), 
+  Gen, 
+  Property,
+  forAllShow
+  )
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.QuickCheck (testProperty)
+
+-- Captures ways of generating each of the associated types of DSIGN
+data TypesMethodology (a :: Type) = 
+  TypesMethodology (Gen (VerKeyDSIGN a))
+                   (Gen (SignKeyDSIGN a))
+                   (Gen (SigDSIGN a))
+
+mockMethodology :: TypesMethodology MockDSIGN
+mockMethodology = TypesMethodology defaultVerKeyGen 
+                                   defaultSignKeyGen 
+                                   defaultSigGen
+
+ed25519Methodology :: TypesMethodology Ed25519DSIGN
+ed25519Methodology = TypesMethodology defaultVerKeyGen 
+                                      defaultSignKeyGen 
+                                      defaultSigGen
+
+ed448Methodology :: TypesMethodology Ed448DSIGN
+ed448Methodology = TypesMethodology defaultVerKeyGen 
+                                    defaultSignKeyGen
+                                    defaultSigGen
+
+secp256k1Methodology :: TypesMethodology SECP256k1DSIGN
+secp256k1Methodology = TypesMethodology defaultVerKeyGen
+                                        defaultSignKeyGen
+                                        go
+  where
+    go :: Gen (SigDSIGN SECP256k1DSIGN)
+    go = do
+      msg <- genSECPMsg
+      signDSIGN () msg <$> defaultSignKeyGen
+
+genSECPMsg :: Gen SECP.Msg
+genSECPMsg = Gen.suchThatMap go SECP.msg
+  where
+    go :: Gen ByteString
+    go = GHC.fromListN 32 <$> replicateM 32 arbitrary
+
+defaultVerKeyGen :: forall (a :: Type) . 
+  (DSIGNAlgorithm a) => Gen (VerKeyDSIGN a)
+defaultVerKeyGen = deriveVerKeyDSIGN <$> defaultSignKeyGen @a
+
+defaultSignKeyGen :: forall (a :: Type).
+  (DSIGNAlgorithm a) => Gen (SignKeyDSIGN a)
+defaultSignKeyGen = 
+  genKeyDSIGN <$> arbitrarySeedOfSize (seedSizeDSIGN (Proxy :: Proxy a))
+
+defaultSigGen :: forall (a :: Type) . 
+  (DSIGNAlgorithm a, ContextDSIGN a ~ (), Signable a Message) => 
+  Gen (SigDSIGN a)
+defaultSigGen = do
+  msg :: Message <- arbitrary
+  signDSIGN () msg <$> defaultSignKeyGen
 
 {- HLINT ignore "Use <$>" -}
 {- HLINT ignore "Reduce duplication" -}
@@ -31,166 +136,159 @@ import Test.Tasty.QuickCheck (testProperty)
 tests :: TestTree
 tests =
   testGroup "Crypto.DSIGN"
-    [ testDSIGNAlgorithm (Proxy :: Proxy MockDSIGN) "MockDSIGN"
-    , testDSIGNAlgorithm (Proxy :: Proxy Ed25519DSIGN) "Ed25519DSIGN"
-    , testDSIGNAlgorithm (Proxy :: Proxy Ed448DSIGN) "Ed448DSIGN"
+    [ testDSIGNAlgorithm mockMethodology (arbitrary @Message) "MockDSIGN"
+    , testDSIGNAlgorithm ed25519Methodology (arbitrary @Message) "Ed25519DSIGN"
+    , testDSIGNAlgorithm ed448Methodology (arbitrary @Message) "Ed448DSIGN"
+    , testDSIGNAlgorithm secp256k1Methodology genSECPMsg "SECP-256k1"
     ]
 
-testDSIGNAlgorithm
-  :: forall proxy v. ( DSIGNAlgorithm v
-                     , ToCBOR (VerKeyDSIGN v)
-                     , FromCBOR (VerKeyDSIGN v)
-                     , ToCBOR (SignKeyDSIGN v)
-                     , FromCBOR (SignKeyDSIGN v)
-                     , Eq (SignKeyDSIGN v)   -- no Eq for signing keys normally
-                     , ToCBOR (SigDSIGN v)
-                     , FromCBOR (SigDSIGN v)
-                     , Signable v ~ SignableRepresentation
-                     , ContextDSIGN v ~ ()
-                     )
-  => proxy v
-  -> String
-  -> TestTree
-testDSIGNAlgorithm _ n =
-  testGroup n
-    [ testGroup "serialisation"
-      [ testGroup "raw"
-        [ testProperty "VerKey"  $ prop_raw_serialise @(VerKeyDSIGN v)
-                                                      rawSerialiseVerKeyDSIGN
-                                                      rawDeserialiseVerKeyDSIGN
-        , testProperty "SignKey" $ prop_raw_serialise @(SignKeyDSIGN v)
-                                                      rawSerialiseSignKeyDSIGN
-                                                      rawDeserialiseSignKeyDSIGN
-        , testProperty "Sig"     $ prop_raw_serialise @(SigDSIGN v)
-                                                      rawSerialiseSigDSIGN
-                                                      rawDeserialiseSigDSIGN
+testDSIGNAlgorithm :: forall (v :: Type) (a :: Type).
+  (DSIGNAlgorithm v, 
+   Signable v a, 
+   ContextDSIGN v ~ (), 
+   Show a,
+   Eq (SignKeyDSIGN v),
+   Eq a,
+   ToCBOR (VerKeyDSIGN v),
+   FromCBOR (VerKeyDSIGN v),
+   ToCBOR (SignKeyDSIGN v),
+   FromCBOR (SignKeyDSIGN v),
+   ToCBOR (SigDSIGN v),
+   FromCBOR (SigDSIGN v)) =>
+  TypesMethodology v -> 
+  Gen a -> 
+  String -> 
+  TestTree
+testDSIGNAlgorithm (TypesMethodology genVK genSK genSig) genMsg name = 
+  testGroup name [
+    testGroup "serialisation" [
+      testGroup "raw" [
+        testProperty "VerKey" . 
+          forAllShow genVK 
+                     ppShow $
+                     prop_raw_serialise rawSerialiseVerKeyDSIGN rawDeserialiseVerKeyDSIGN,
+        testProperty "SignKey" .
+          forAllShow genSK
+                     ppShow $
+                     prop_raw_serialise rawSerialiseSignKeyDSIGN rawDeserialiseSignKeyDSIGN,
+        testProperty "Sig" . 
+          forAllShow genSig 
+                     ppShow $ 
+                     prop_raw_serialise rawSerialiseSigDSIGN rawDeserialiseSigDSIGN
+        ],
+      testGroup "size" [
+        testProperty "VerKey" . 
+          forAllShow genVK 
+                     ppShow $
+                     prop_size_serialise rawSerialiseVerKeyDSIGN (sizeVerKeyDSIGN (Proxy @v)),
+        testProperty "SignKey" . 
+          forAllShow genSK
+                     ppShow $ 
+                     prop_size_serialise rawSerialiseSignKeyDSIGN (sizeSignKeyDSIGN (Proxy @v)),
+        testProperty "Sig" .
+          forAllShow genSig
+                     ppShow $ 
+                     prop_size_serialise rawSerialiseSigDSIGN (sizeSigDSIGN (Proxy @v))
+        ],
+      testGroup "direct CBOR" [
+        testProperty "VerKey" . 
+          forAllShow genVK
+                     ppShow $ 
+                     prop_cbor_with encodeVerKeyDSIGN decodeVerKeyDSIGN,
+        testProperty "SignKey" . 
+          forAllShow genSK
+                     ppShow $ 
+                     prop_cbor_with encodeSignKeyDSIGN decodeSignKeyDSIGN,
+        testProperty "Sig" . 
+          forAllShow genSig
+                     ppShow $ 
+                     prop_cbor_with encodeSigDSIGN decodeSigDSIGN
+        ],
+      testGroup "To/FromCBOR class" [
+        testProperty "VerKey" . forAllShow genVK ppShow $ prop_cbor,
+        testProperty "SignKey" . forAllShow genSK ppShow $ prop_cbor,
+        testProperty "Sig" . forAllShow genSig ppShow $ prop_cbor
+        ],
+      testGroup "ToCBOR size" [
+        testProperty "VerKey" . forAllShow genVK ppShow $ prop_cbor_size,
+        testProperty "SignKey" . forAllShow genSK ppShow $ prop_cbor_size,
+        testProperty "Sig" . forAllShow genSig ppShow $ prop_cbor_size
+        ],
+      testGroup "direct matches class" [
+        testProperty "VerKey" . 
+          forAllShow genVK ppShow $ 
+          prop_cbor_direct_vs_class encodeVerKeyDSIGN,
+        testProperty "SignKey" . 
+          forAllShow genSK ppShow $ 
+          prop_cbor_direct_vs_class encodeSignKeyDSIGN,
+        testProperty "Sig" . 
+          forAllShow genSig ppShow $ 
+          prop_cbor_direct_vs_class encodeSigDSIGN
         ]
-
-      , testGroup "size"
-        [ testProperty "VerKey"  $ prop_size_serialise @(VerKeyDSIGN v)
-                                                       rawSerialiseVerKeyDSIGN
-                                                       (sizeVerKeyDSIGN (Proxy @ v))
-        , testProperty "SignKey" $ prop_size_serialise @(SignKeyDSIGN v)
-                                                       rawSerialiseSignKeyDSIGN
-                                                       (sizeSignKeyDSIGN (Proxy @ v))
-        , testProperty "Sig"     $ prop_size_serialise @(SigDSIGN v)
-                                                       rawSerialiseSigDSIGN
-                                                       (sizeSigDSIGN (Proxy @ v))
-        ]
-
-      , testGroup "direct CBOR"
-        [ testProperty "VerKey"  $ prop_cbor_with @(VerKeyDSIGN v)
-                                                  encodeVerKeyDSIGN
-                                                  decodeVerKeyDSIGN
-        , testProperty "SignKey" $ prop_cbor_with @(SignKeyDSIGN v)
-                                                  encodeSignKeyDSIGN
-                                                  decodeSignKeyDSIGN
-        , testProperty "Sig"     $ prop_cbor_with @(SigDSIGN v)
-                                                  encodeSigDSIGN
-                                                  decodeSigDSIGN
-        ]
-
-      , testGroup "To/FromCBOR class"
-        [ testProperty "VerKey"  $ prop_cbor @(VerKeyDSIGN v)
-        , testProperty "SignKey" $ prop_cbor @(SignKeyDSIGN v)
-        , testProperty "Sig"     $ prop_cbor @(SigDSIGN v)
-        ]
-
-      , testGroup "ToCBOR size"
-        [ testProperty "VerKey"  $ prop_cbor_size @(VerKeyDSIGN v)
-        , testProperty "SignKey" $ prop_cbor_size @(SignKeyDSIGN v)
-        , testProperty "Sig"     $ prop_cbor_size @(SigDSIGN v)
-        ]
-
-      , testGroup "direct matches class"
-        [ testProperty "VerKey"  $ prop_cbor_direct_vs_class @(VerKeyDSIGN v)
-                                                             encodeVerKeyDSIGN
-        , testProperty "SignKey" $ prop_cbor_direct_vs_class @(SignKeyDSIGN v)
-                                                             encodeSignKeyDSIGN
-        , testProperty "Sig"     $ prop_cbor_direct_vs_class @(SigDSIGN v)
-                                                             encodeSigDSIGN
-        ]
-      ]
-
-    , testGroup "verify"
-      [ testProperty "verify positive" $ prop_dsign_verify_pos @v
-      , testProperty "verify newgative (wrong key)" $ prop_dsign_verify_neg_key @v
-      , testProperty "verify newgative (wrong message)" $ prop_dsign_verify_neg_msg @v
-      ]
-
-    , testGroup "NoThunks"
-      [ testProperty "VerKey"  $ prop_no_thunks @(VerKeyDSIGN v)
-      , testProperty "SignKey" $ prop_no_thunks @(SignKeyDSIGN v)
-      , testProperty "Sig"     $ prop_no_thunks @(SigDSIGN v)
+      ],
+    testGroup "verify" [
+      testProperty "signing and verifying with matching keys" . 
+        forAllShow ((,) <$> genMsg <*> genSK) ppShow $
+        prop_dsign_verify,
+      testProperty "verifying with wrong key" . 
+        forAllShow genWrongKey ppShow $
+        prop_dsign_verify_wrong_key,
+      testProperty "verifying wrong message" . 
+        forAllShow genWrongMsg ppShow $ 
+        prop_dsign_verify_wrong_msg
+      ],
+    testGroup "NoThunks" [
+      testProperty "VerKey" . forAllShow genVK ppShow $ prop_no_thunks,
+      testProperty "SignKey" . forAllShow genSK ppShow $ prop_no_thunks,
+      testProperty "Sig" . forAllShow genSig ppShow $ prop_no_thunks
       ]
     ]
-
--- | If we sign a message @a@ with the signing key, then we can verify the
--- signature using the corresponding verification key.
---
-prop_dsign_verify_pos
-  :: forall v. (DSIGNAlgorithm v, ContextDSIGN v ~ (), Signable v ~ SignableRepresentation)
-  => Message
-  -> SignKeyDSIGN v
-  -> Property
-prop_dsign_verify_pos a sk =
-  let sig = signDSIGN () a sk
-      vk = deriveVerKeyDSIGN sk
-  in verifyDSIGN () vk a sig === Right ()
-
--- | If we sign a message @a@ with one signing key, if we try to verify the
--- signature (and message @a@) using a verification key corresponding to a
--- different signing key, then the verification fails.
---
-prop_dsign_verify_neg_key
-  :: forall v. (DSIGNAlgorithm v, Eq (SignKeyDSIGN v),
-                ContextDSIGN v ~ (), Signable v ~ SignableRepresentation)
-  => Message
-  -> SignKeyDSIGN v
-  -> SignKeyDSIGN v
-  -> Property
-prop_dsign_verify_neg_key a sk sk' =
-  sk /= sk' ==>
-    let sig = signDSIGN () a sk
-        vk' = deriveVerKeyDSIGN sk'
-    in verifyDSIGN () vk' a sig =/= Right ()
-
-
--- | If we sign a message @a@ with one signing key, if we try to verify the
--- signature with a message other than @a@, then the verification fails.
---
-prop_dsign_verify_neg_msg
-  :: forall v. (DSIGNAlgorithm v,
-                ContextDSIGN v ~ (), Signable v ~ SignableRepresentation)
-  => Message
-  -> Message
-  -> SignKeyDSIGN v
-  -> Property
-prop_dsign_verify_neg_msg a a' sk =
-  a /= a' ==>
-    let sig = signDSIGN () a sk
-        vk = deriveVerKeyDSIGN sk
-    in verifyDSIGN () vk a' sig =/= Right ()
-
---
--- Arbitrary instances
---
-
-instance DSIGNAlgorithm v => Arbitrary (VerKeyDSIGN v) where
-  arbitrary = deriveVerKeyDSIGN <$> arbitrary
-  shrink = const []
-
-instance DSIGNAlgorithm v => Arbitrary (SignKeyDSIGN v) where
-  arbitrary = genKeyDSIGN <$> arbitrarySeedOfSize seedSize
     where
-      seedSize = seedSizeDSIGN (Proxy :: Proxy v)
-  shrink = const []
+      genWrongKey :: Gen (a, SignKeyDSIGN v, SignKeyDSIGN v)
+      genWrongKey = do
+        sk1 <- genSK
+        sk2 <- Gen.suchThat genSK (/= sk1)
+        msg <- genMsg
+        pure (msg, sk1, sk2)
+      genWrongMsg :: Gen (a, a, SignKeyDSIGN v)
+      genWrongMsg = do
+        msg1 <- genMsg
+        msg2 <- Gen.suchThat genMsg (/= msg1)
+        sk <- genSK
+        pure (msg1, msg2, sk)
 
-instance (DSIGNAlgorithm v,
-          ContextDSIGN v ~ (), Signable v ~ SignableRepresentation)
-      => Arbitrary (SigDSIGN v) where
-  arbitrary = do
-    a <- arbitrary :: Gen Message
-    sk <- arbitrary
-    return $ signDSIGN () a sk
-  shrink = const []
+-- If we sign a message with the key, we can verify the signature with the
+-- corresponding verification key.
+prop_dsign_verify  
+  :: forall (v :: Type) (a :: Type) . 
+  (DSIGNAlgorithm v, ContextDSIGN v ~ (), Signable v a) 
+  => (a, SignKeyDSIGN v)
+  -> Property
+prop_dsign_verify (msg, sk) = 
+  let signed = signDSIGN () msg sk
+      vk = deriveVerKeyDSIGN sk
+    in verifyDSIGN () vk msg signed === Right ()
+
+-- If we sign a message with one key, and try to verify with another, then
+-- verification fails.
+prop_dsign_verify_wrong_key
+  :: forall (v :: Type) (a :: Type) .
+  (DSIGNAlgorithm v, Signable v a, ContextDSIGN v ~ ()) 
+  => (a, SignKeyDSIGN v, SignKeyDSIGN v) 
+  -> Property
+prop_dsign_verify_wrong_key (msg, sk, sk') = 
+  let signed = signDSIGN () msg sk
+      vk' = deriveVerKeyDSIGN sk'
+    in verifyDSIGN () vk' msg signed =/= Right ()
+
+-- If we signa a message with a key, but then try to verify with a different
+-- message, then verification fails.
+prop_dsign_verify_wrong_msg 
+  :: forall (v :: Type) (a :: Type) .
+  (DSIGNAlgorithm v, Signable v a, ContextDSIGN v ~ ())
+  => (a, a, SignKeyDSIGN v)
+  -> Property
+prop_dsign_verify_wrong_msg (msg, msg', sk) = 
+  let signed = signDSIGN () msg sk
+      vk = deriveVerKeyDSIGN sk
+    in verifyDSIGN () vk msg' signed =/= Right ()


### PR DESCRIPTION
This is the first stage of [solving this issue](https://github.com/input-output-hk/plutus/issues/4233), as per [this request](https://github.com/input-output-hk/plutus/issues/4233#issuecomment-976718634). 

A few questions remain outstanding:

* <s>The size of the verification key (that is, public key) is not an exact multiple of 8 bits, as it's compressed and DER-encoded, for a total of 257 bits. I've thus set it to be 33 bytes in the implementation, but I am unsure if this is correct.</s>
* Secret key generation has to be implemented partially, as the original implementation returns in a `Maybe`. According to the implementation, we ensure that the only invariant is met, but this seems suspicious.

Tagging @michaelpj for review.