### PR TITLE
Repair non-deterministic behaviour, increase test count

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ result
 
 # Local development
 stack-local.yaml
+.nvimrc
 
 # Visual Studio Code
 /.vscode

--- a/cabal.project
+++ b/cabal.project
@@ -1,5 +1,8 @@
 index-state: 2021-03-15T00:00:00Z
 
+-- Ensures colourized output from tasty
+test-show-details: direct
+
 packages:
   base-deriving-via
   binary

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed25519.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed25519.hs
@@ -6,6 +6,16 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeApplications #-}
+-- According to the documentation for unsafePerformIO:
+-- 
+-- > Make sure that the either you switch off let-floating 
+-- > (-fno-full-laziness), or that the call to unsafePerformIO cannot float 
+-- > outside a lambda.
+--
+-- If we do not switch off let-floating, our calls to unsafeDupablePerformIO for
+-- FFI functions become nondeterministic in their behaviour when run with
+-- parallelism enabled (such as -with-rtsopts=-N), possibly yielding wrong
+-- answers on a range of tasks, including serialization.
 {-# OPTIONS_GHC -fno-full-laziness #-}
 
 -- | Ed25519 digital signatures.

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed25519.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed25519.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeApplications #-}
+{-# OPTIONS_GHC -fno-full-laziness #-}
 
 -- | Ed25519 digital signatures.
 module Cardano.Crypto.DSIGN.Ed25519
@@ -147,7 +148,6 @@ instance DSIGNAlgorithm Ed25519DSIGN where
     --
     -- Key generation
     --
-
     genKeyDSIGN seed = SignKeyEd25519DSIGN $
       let (sb, _) = getBytesFromSeedT (seedSizeDSIGN (Proxy @Ed25519DSIGN)) seed
       in unsafeDupablePerformIO $ do

--- a/cardano-crypto-tests/cardano-crypto-tests.cabal
+++ b/cardano-crypto-tests/cardano-crypto-tests.cabal
@@ -75,7 +75,7 @@ test-suite test-crypto
                       , cardano-crypto-tests
                       , tasty
 
-  ghc-options:          -threaded
+  ghc-options:          -threaded -rtsopts -with-rtsopts=-N
 
 benchmark bench-crypto
   import:               base, project-config

--- a/cardano-crypto-tests/cardano-crypto-tests.cabal
+++ b/cardano-crypto-tests/cardano-crypto-tests.cabal
@@ -74,6 +74,7 @@ test-suite test-crypto
                       , cardano-crypto-class
                       , cardano-crypto-tests
                       , tasty
+                      , tasty-quickcheck
 
   ghc-options:          -threaded -rtsopts -with-rtsopts=-N
 

--- a/cardano-crypto-tests/test/Main.hs
+++ b/cardano-crypto-tests/test/Main.hs
@@ -15,8 +15,10 @@ main = do
 
 tests :: TestTree
 tests =
+  -- The default QuickCheck test count is 100. This is too few to catch
+  -- anything, so we set a minimum of 1000.
   adjustOption (\(QuickCheckTests i) -> QuickCheckTests $ max i 1000) . 
-    testGroup "ouroboros-consensus" $
+    testGroup "cardano-crypto-class" $
       [ Test.Crypto.DSIGN.tests
       , Test.Crypto.Hash.tests
       , Test.Crypto.KES.tests

--- a/cardano-crypto-tests/test/Main.hs
+++ b/cardano-crypto-tests/test/Main.hs
@@ -4,7 +4,8 @@ import qualified Test.Crypto.DSIGN (tests)
 import qualified Test.Crypto.Hash (tests)
 import qualified Test.Crypto.KES (tests)
 import qualified Test.Crypto.VRF (tests)
-import Test.Tasty
+import Test.Tasty (TestTree, adjustOption, testGroup, defaultMain)
+import Test.Tasty.QuickCheck (QuickCheckTests (QuickCheckTests))
 import Cardano.Crypto.Libsodium (sodiumInit)
 
 main :: IO ()
@@ -14,9 +15,10 @@ main = do
 
 tests :: TestTree
 tests =
-  testGroup "ouroboros-consensus"
-    [ Test.Crypto.DSIGN.tests
-    , Test.Crypto.Hash.tests
-    , Test.Crypto.KES.tests
-    , Test.Crypto.VRF.tests
-    ]
+  adjustOption (\(QuickCheckTests i) -> QuickCheckTests $ max i 1000) . 
+    testGroup "ouroboros-consensus" $
+      [ Test.Crypto.DSIGN.tests
+      , Test.Crypto.Hash.tests
+      , Test.Crypto.KES.tests
+      , Test.Crypto.VRF.tests
+      ]


### PR DESCRIPTION
This addresses two of the issues I raised [here](https://github.com/input-output-hk/cardano-base/pull/252#issuecomment-1016706315), namely:

* The non-deterministic failures in tests produced by running the suite with parallelism enabled; and
* The low test counts.

Unfortunately, the second solution exposed some pathologically slow tests. I have made a list of them below, as well as indicating the time they took to execute on my machine. Overall, even with 24-way parallelism on, running the entire test suite takes _well_ in excess of 100 seconds, which I believe indicates deeper performance problems. This is particularly surprising in several places - for example, multiple serialization tests are on this list.

|Test name|Time required for 1000 tests (s)|
|--------------| :---: |
|`Crypto.KES.SimpleKES.sameVerKey`|18.29|
|`Crypto.KES.SimpleKES.verify.positive`|12.72|
|`Crypto.KES.SimpleKES.verify.negative (key)`|14.78|
|`Crypto.KES.SimpleKES.verify.negative (message)`|14.43|
|`Crypto.KES.SimpleKES.verify.negative (period)`|26.28|
|`Crypto.KES.SimpleKES.serialisation of all KES evolutions.VerKey`|16.1|
|`Crypto.KES.Sum5KES.verify.positive`|11.27|
|`Crypto.KES.Sum5KES.verify.negative (key)`|12.22|
|`Crypto.KES.Sum5KES.verify.negative (message)`|13.91|
|`Crypto.KES.Sum5KES.verify.negative (period)`|17.9|
|`Crypto.KES.Sum5KES.serialisation of all KES evolutions.SignKey`|11.21|
|`Crypto.KES.Sum5KES.serialisation of all KES evolutions.Sig`|11.48|
|`Crypto.KES.CompactSum5KES.verify.negative (period)`|52.07|
|`Crypto.VRF.SimpleVRF.serialisation.raw.VerKey`|13.43|
|`Crypto.VRF.SimpleVRF.serialisation.raw.Cert`|35.11|
|`Crypto.VRF.SimpleVRF.serialisation.size.VerKey`|13.65|
|`Crypto.VRF.SimpleVRF.serialisation.size.Cert`|35.47|
|`Crypto.VRF.SimpleVRF.serialisation.direct CBOR.VerKey`|12.78|
|`Crypto.VRF.SimpleVRF.serialisation.direct CBOR.Cert`|35.59|
|`Crypto.VRF.SimpleVRF.serialisation.To/FromCBOR class.VerKey`|13.81|
|`Crypto.VRF.SimpleVRF.serialisation.To/FromCBOR class.Cert`|35.22|
|`Crypto.VRF.SimpleVRF.serialisation.ToCBOR size.VerKey`|12.75|
|`Crypto.VRF.SimpleVRF.serialisation.ToCBOR size.Cert`|35.2|
|`Crypto.VRF.SimpleVRF.serialisation.direct matches class.VerKey`|13.75|
|`Crypto.VRF.SimpleVRF.serialisation.direct matches class.Cert`|35.15|
|`Crypto.VRF.SimpleVRF.verify.verify positive`|66.95|
|`Crypto.VRF.SimpleVRF.verify.verify negative`|73.87|
|`Crypto.VRF.SimpleVRF.output.sizeOutputVRF`|13.31|
|`Crypto.VRF.SimpleVRF.output.mkTestOutputVRF`|13.13|
|`Crypto.VRF.SimpleVRF.NoThunks.VerKey`|13.41|

I am happy to investigate and repair the sources of these issues if @michaelpj approves.