### PR TITLE
Use latest nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -18,10 +18,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "1729233076f84649aee3b98100a378df88cc8675",
-        "sha256": "14j1zy94bfvcs415ipz8kghbhlcbvp2n6zq5pakmmld1ba1k3qcd",
+        "rev": "41682ea1fdc9c236bdf81c800bc5ad23c427d59c",
+        "sha256": "06wkcgbg3apgv8qmfpwgk61db1h48mpirhfvcv90m02shrx07m4z",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/1729233076f84649aee3b98100a378df88cc8675.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/41682ea1fdc9c236bdf81c800bc5ad23c427d59c.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz",
         "version": "962ecfed3a4fb656b5a91d89159291e00ed766bc"
     },

--- a/shell.nix
+++ b/shell.nix
@@ -35,6 +35,8 @@ let
       niv
       pkgconfig
       sqlite-interactive
+      pkgs.nix
+      pkgs.cacert
     ];
 
     tools = {


### PR DESCRIPTION
This relates to [this suggestion here](https://github.com/input-output-hk/iohk-nix/pull/503#issuecomment-1034952292). Ultimately, this is needed for [Schnorr signature support](https://github.com/input-output-hk/plutus/pull/4368#issuecomment-1031782137).