### PR TITLE
Add `NFData` instance for `StrictSeq`

### DIFF
--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Class.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
@@ -42,6 +43,7 @@ module Cardano.Crypto.DSIGN.Class
   )
 where
 
+import Control.DeepSeq (NFData)
 import qualified Data.ByteString as BS
 import Data.ByteString (ByteString)
 import Data.Kind (Type)
@@ -242,6 +244,8 @@ newtype SignedDSIGN v a = SignedDSIGN (SigDSIGN v)
 
 deriving instance DSIGNAlgorithm v => Show (SignedDSIGN v a)
 deriving instance DSIGNAlgorithm v => Eq   (SignedDSIGN v a)
+
+deriving instance NFData (SigDSIGN v) => NFData (SignedDSIGN v a)
 
 instance DSIGNAlgorithm v => NoThunks (SignedDSIGN v a)
   -- use generic instance

--- a/slotting/src/Cardano/Slotting/Slot.hs
+++ b/slotting/src/Cardano/Slotting/Slot.hs
@@ -20,7 +20,7 @@ where
 
 import Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import Codec.Serialise (Serialise (..))
-import Control.DeepSeq (NFData)
+import Control.DeepSeq (NFData (rnf))
 import Data.Aeson (FromJSON, ToJSON)
 import Data.Typeable (Typeable)
 import Data.Word (Word64)
@@ -68,6 +68,11 @@ instance Bounded t => Bounded (WithOrigin t) where
   minBound = Origin
   maxBound = At maxBound
 
+instance NFData a => NFData (WithOrigin a) where
+  rnf Origin = ()
+  rnf (At t) = rnf t
+
+
 at :: t -> WithOrigin t
 at = At
 
@@ -98,9 +103,9 @@ withOriginFromMaybe (Just t) = At t
 newtype EpochNo = EpochNo {unEpochNo :: Word64}
   deriving stock (Eq, Ord, Generic)
   deriving Show via Quiet EpochNo
-  deriving newtype (Enum, Num, Serialise, ToCBOR, FromCBOR, NoThunks, ToJSON, FromJSON)
+  deriving newtype (Enum, Num, Serialise, ToCBOR, FromCBOR, NoThunks, ToJSON, FromJSON, NFData)
 
 newtype EpochSize = EpochSize {unEpochSize :: Word64}
   deriving stock (Eq, Ord, Generic)
   deriving Show via Quiet EpochSize
-  deriving newtype (Enum, Num, Real, Integral, NoThunks, ToJSON, FromJSON)
+  deriving newtype (Enum, Num, Real, Integral, ToCBOR, FromCBOR, NoThunks, ToJSON, FromJSON, NFData)

--- a/strict-containers/src/Data/Sequence/Strict.hs
+++ b/strict-containers/src/Data/Sequence/Strict.hs
@@ -64,6 +64,7 @@ where
 
 import Codec.Serialise (Serialise)
 import Control.Arrow ((***))
+import Control.DeepSeq (NFData)
 import Data.Foldable (foldl', toList)
 import Data.Sequence (Seq)
 import qualified Data.Sequence as Seq
@@ -105,7 +106,7 @@ infixl 5 :|>
 -- value to WHNF.
 newtype StrictSeq a = StrictSeq {fromStrict :: Seq a}
   deriving stock (Eq, Ord, Show)
-  deriving newtype (Foldable, Monoid, Semigroup, Serialise)
+  deriving newtype (Foldable, Monoid, Semigroup, Serialise, NFData)
 
 instance Functor StrictSeq where
   fmap f (StrictSeq s) = StrictSeq . forceElemsToWHNF $ fmap f s

--- a/strict-containers/src/Data/Sequence/Strict.hs
+++ b/strict-containers/src/Data/Sequence/Strict.hs
@@ -65,6 +65,7 @@ where
 import Codec.Serialise (Serialise)
 import Control.Arrow ((***))
 import Control.DeepSeq (NFData)
+import Data.Aeson (FromJSON(..), ToJSON(..))
 import Data.Foldable (foldl', toList)
 import Data.Sequence (Seq)
 import qualified Data.Sequence as Seq
@@ -121,6 +122,12 @@ instance Traversable StrictSeq where
 instance NoThunks a => NoThunks (StrictSeq a) where
   showTypeOf _ = "StrictSeq"
   wNoThunks ctxt = noThunksInValues ctxt . toList
+
+instance FromJSON a => FromJSON (StrictSeq a) where
+  parseJSON = fmap fromList . parseJSON
+
+instance ToJSON a => ToJSON (StrictSeq a) where
+  toJSON = toJSON . toList
 
 -- | A helper function for the ':<|' pattern.
 viewFront :: StrictSeq a -> Maybe (a, StrictSeq a)


### PR DESCRIPTION
Also moves some orphan instances from ledger: 
* `NFData` for: `WithOrigin`, `EpochNo`, `EpochSize`
* `ToCBOR` and `FromCBOR` for `EpochSize`
* `ToJSON`, `FromJSON` for `StrictSeq`