### PR TITLE
Bump iohk-nix and drop nixpkgs pin

### DIFF
--- a/nix/haskell.nix
+++ b/nix/haskell.nix
@@ -7,7 +7,7 @@
 , buildPackages
 , config ? {}
 # GHC attribute name
-, compiler ? config.haskellNix.compiler or "ghc8105"
+, compiler ? config.haskellNix.compiler or "ghc8107"
 # Enable profiling
 , profiling ? config.haskellNix.profiling or false
 }:

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -31,24 +31,11 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "266ca46a8d1cb4286b9699b4fd435066e88440ac",
-        "sha256": "132fbnnpp7bbfqv3dgvn9xi9dc1gsn9mivbqnxmglgmlv4lmrad8",
+        "rev": "0a0126d8fb1bdc61ce1fd2ef61cf396de800fdad",
+        "sha256": "0gwppj37fphjssw9s99xs7yyxylxzi6fdc9g1sq6w7yyx46lrf0i",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/iohk-nix/archive/266ca46a8d1cb4286b9699b4fd435066e88440ac.tar.gz",
+        "url": "https://github.com/input-output-hk/iohk-nix/archive/0a0126d8fb1bdc61ce1fd2ef61cf396de800fdad.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz",
         "version": "60fe72cf807a4ec4409a53883d5c3af77f60f721"
-    },
-    "nixpkgs": {
-        "builtin": true,
-        "branch": "nixpkgs-unstable",
-        "description": "Nix Packages collection",
-        "homepage": "",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "1882c6b7368fd284ad01b0a5b5601ef136321292",
-        "sha256": "0zg7ak2mcmwzi2kg29g4v9fvbvs0viykjsg2pwaphm1fi13s7s0i",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/1882c6b7368fd284ad01b0a5b5601ef136321292.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
It looks like the nixpkgs pin from `haskell.nix` *is* actually new
enough.

I didn't get cache hits until I switched to 8.10.7, which seems like a
good idea anyway.