### PR TITLE
Packed bytes with offset

### DIFF
--- a/cardano-crypto-class/src/Cardano/Crypto/Hash/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Hash/Class.hs
@@ -224,7 +224,7 @@ hashFromStringAsHex = hashFromTextAsHex . Text.pack
 -- | Convert the hash to hex encoding, as 'Text'.
 --
 hashToTextAsHex :: Hash h a -> Text
-hashToTextAsHex = Text.decodeUtf8 . hashToBytesAsHex
+hashToTextAsHex = Text.decodeLatin1 . hashToBytesAsHex
 
 -- | Make a hash from hex-encoded 'Text' representation.
 --
@@ -262,13 +262,13 @@ instance HashAlgorithm h => IsString (Hash h a) where
       Nothing -> error ("fromString: cannot decode hash " ++ show str)
 
 instance HashAlgorithm h => ToJSONKey (Hash h a) where
-  toJSONKey = Aeson.toJSONKeyText hashToText
+  toJSONKey = Aeson.toJSONKeyText hashToTextAsHex
 
 instance HashAlgorithm h => FromJSONKey (Hash h a) where
   fromJSONKey = Aeson.FromJSONKeyTextParser parseHash
 
 instance HashAlgorithm h => ToJSON (Hash h a) where
-  toJSON = toJSON . hashToText
+  toJSON = toJSON . hashToTextAsHex
 
 instance HashAlgorithm h => FromJSON (Hash h a) where
   parseJSON = Aeson.withText "hash" parseHash
@@ -278,10 +278,6 @@ instance HeapWords (Hash h a) where
   heapWords (UnsafeHashRep (PackedBytes28 _ _ _ _)) = 1 + 4
   heapWords (UnsafeHashRep (PackedBytes32 _ _ _ _)) = 1 + 4
   heapWords (UnsafeHashRep (PackedBytes# ba#)) = heapWords (SBSI.SBS ba#)
-
--- utils used in the instances above
-hashToText :: Hash h a -> Text
-hashToText = Text.decodeLatin1 . hashToBytesAsHex
 
 parseHash :: HashAlgorithm crypto => Text -> Aeson.Parser (Hash crypto a)
 parseHash t =

--- a/cardano-crypto-class/src/Cardano/Crypto/Hash/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Hash/Class.hs
@@ -164,7 +164,7 @@ hashFromBytes ::
   -> Maybe (Hash h a)
 hashFromBytes bytes
   | BS.length bytes == fromIntegral (sizeHash (Proxy :: Proxy h))
-  = Just $! UnsafeHashRep (packPinnedBytes bytes)
+  = Just $ UnsafeHashRep (packPinnedBytes bytes)
 
   | otherwise
   = Nothing

--- a/cardano-crypto-class/src/Cardano/Crypto/PackedBytes.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/PackedBytes.hs
@@ -219,7 +219,7 @@ packBytesMaybe bs offset = do
       size = fromInteger (natVal' (proxy# @n))
   guard (offset >= 0)
   guard (size <= bufferSize - offset)
-  Just $! packBytes bs offset
+  Just $ packBytes bs offset
 
 
 packPinnedBytes8 :: ByteString -> PackedBytes 8


### PR DESCRIPTION
It is useful for address deserialization to be able to create a hash from a [Short]ByteString with an offset, therefore avoiding unnecessary copy when creating a hash from bytes located in a larger ByteString.

Also switches to faster `decodeLatin1` for hex encoded hashes.