### PR TITLE
Perform serialization of KES and DSIGN sign keys in MLocked memory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ stack-local.yaml
 # ghcid
 **/.ghcid
 **/ghcid.txt
+tags

--- a/cabal.project
+++ b/cabal.project
@@ -14,6 +14,7 @@ packages:
   orphans-deriving-via
   slotting
   strict-containers
+  scrap
 
 -- Disable tests in a dependency (which are currently broken)
 package cardano-crypto

--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,6 @@ packages:
   orphans-deriving-via
   slotting
   strict-containers
-  scrap
 
 -- Disable tests in a dependency (which are currently broken)
 package cardano-crypto

--- a/cardano-crypto-class/cardano-crypto-class.cabal
+++ b/cardano-crypto-class/cardano-crypto-class.cabal
@@ -18,6 +18,7 @@ copyright:          2019-2021 IOHK
 category:           Currency
 build-type:         Simple
 extra-source-files: README.md
+extra-source-files: cbits/mlocked-pool.h
 
 flag development
   description: Disable `-Werror`
@@ -94,6 +95,9 @@ library
     Cardano.Crypto.VRF.NeverUsed
     Cardano.Crypto.VRF.Simple
     Cardano.Foreign
+
+  c-sources:
+    cbits/mlocked-pool.c
 
   other-modules:
     Cardano.Crypto.PackedBytes

--- a/cardano-crypto-class/cardano-crypto-class.cabal
+++ b/cardano-crypto-class/cardano-crypto-class.cabal
@@ -50,7 +50,9 @@ library
     Cardano.Crypto.DSIGN
     Cardano.Crypto.DSIGN.Class
     Cardano.Crypto.DSIGN.Ed25519
+    Cardano.Crypto.DSIGN.Ed25519ML
     Cardano.Crypto.DSIGN.Ed448
+    Cardano.Crypto.DSIGNM.Class
     Cardano.Crypto.DSIGN.Mock
     Cardano.Crypto.DSIGN.NeverUsed
     Cardano.Crypto.Hash
@@ -65,6 +67,7 @@ library
     Cardano.Crypto.KES.Class
     Cardano.Crypto.KES.CompactSingle
     Cardano.Crypto.KES.CompactSum
+    Cardano.Crypto.KES.ForgetMock
     Cardano.Crypto.KES.Mock
     Cardano.Crypto.KES.NeverUsed
     Cardano.Crypto.KES.Simple
@@ -80,7 +83,9 @@ library
     Cardano.Crypto.Libsodium.MLockedBytes
     Cardano.Crypto.Libsodium.MLockedBytes.Internal
     Cardano.Crypto.Libsodium.UnsafeC
+    Cardano.Crypto.MonadSodium
     Cardano.Crypto.PinnedSizedBytes
+    Cardano.Crypto.SafePinned
     Cardano.Crypto.Seed
     Cardano.Crypto.Util
     Cardano.Crypto.VRF
@@ -105,9 +110,13 @@ library
     , ghc-prim
     , integer-gmp
     , memory
+    , mtl
     , nothunks
     , primitive
+    , random
+    , secp256k1-haskell
     , serialise
+    , stm
     , text
     , transformers
     , vector

--- a/cardano-crypto-class/cardano-crypto-class.cabal
+++ b/cardano-crypto-class/cardano-crypto-class.cabal
@@ -19,6 +19,7 @@ category:           Currency
 build-type:         Simple
 extra-source-files: README.md
 extra-source-files: cbits/mlocked-pool.h
+                  , cbits/mlocked-pool.c
 
 flag development
   description: Disable `-Werror`

--- a/cardano-crypto-class/cbits/mlocked-pool.c
+++ b/cardano-crypto-class/cbits/mlocked-pool.c
@@ -11,7 +11,7 @@
 
 #define POOL_ITEM_SIZE 32U
 
-static size_t page_size = 0x10000;
+static size_t page_size = 4096;
 typedef struct mlocked_pool_t mlocked_pool_t;
 
 static void mlocked_pool_init();

--- a/cardano-crypto-class/cbits/mlocked-pool.c
+++ b/cardano-crypto-class/cbits/mlocked-pool.c
@@ -37,7 +37,7 @@ static mlocked_pool_t global_pool;
 static void mlocked_pool_atexit()
 {
     pthread_mutex_lock(&mlocked_pool_mutex);
-    fprintf(stderr, "mlocked_pool_atexit %i x %u\n", global_pool.pool_size, page_size);
+    // fprintf(stderr, "mlocked_pool_atexit %i x %u\n", global_pool.pool_size, page_size);
     mlocked_pool_reset(&global_pool);
     pthread_mutex_unlock(&mlocked_pool_mutex);
 }
@@ -74,7 +74,7 @@ static void mlocked_pool_grow(mlocked_pool_t *p)
     void* new_page;
 
     p->pool_size++;
-    fprintf(stderr, "mlocked_pool_grow %i x %u\n", p->pool_size, page_size);
+    // fprintf(stderr, "mlocked_pool_grow %i x %u\n", p->pool_size, page_size);
     p->pool = realloc(p->pool, p->pool_size * sizeof(void*));
     new_page = sodium_malloc(page_size);
     p->pool[p->pool_size - 1] = new_page;
@@ -93,7 +93,7 @@ static void mlocked_pool_stack_grow(mlocked_pool_t *p)
         p->stack_cap = 64;
     else
         p->stack_cap <<= 1;
-    fprintf(stderr, "mlocked_pool_stack_grow %i\n", p->stack_cap);
+    // fprintf(stderr, "mlocked_pool_stack_grow %i\n", p->stack_cap);
     p->stack = realloc(p->stack, p->stack_cap * sizeof(void*));
 }
 

--- a/cardano-crypto-class/cbits/mlocked-pool.c
+++ b/cardano-crypto-class/cbits/mlocked-pool.c
@@ -1,0 +1,123 @@
+#include <stdlib.h>
+#include <sodium.h>
+#include <memory.h>
+#include <assert.h>
+#include <stdbool.h>
+
+#define POOL_ITEM_SIZE 32U
+
+#ifndef DEFAULT_PAGE_SIZE
+# ifdef PAGE_SIZE
+#  define DEFAULT_PAGE_SIZE PAGE_SIZE
+# else
+#  define DEFAULT_PAGE_SIZE 0x10000
+# endif
+#endif
+
+typedef struct mlocked_pool_t mlocked_pool_t;
+
+static void mlocked_pool_init(mlocked_pool_t *p);
+static void mlocked_pool_reset(mlocked_pool_t *p);
+static void mlocked_pool_grow(mlocked_pool_t *p);
+static void mlocked_stack_grow(mlocked_pool_t *p);
+static void mlocked_stack_push(mlocked_pool_t *p, void* val);
+static bool mlocked_stack_pop(void** dst, mlocked_pool_t *p);
+
+typedef struct mlocked_pool_t {
+    void **stack;
+    void **pool;
+    size_t stack_cap;
+    size_t stack_top;
+    size_t pool_size;
+} mlocked_pool_t;
+
+static void mlocked_pool_init(mlocked_pool_t *p)
+{
+    memset(p, 0, sizeof(mlocked_pool_t));
+}
+
+static void mlocked_pool_reset(mlocked_pool_t *p)
+{
+    free(p->stack);
+    for (size_t i = 0; i < p->pool_size; ++i) {
+        sodium_free(p->pool[i]);
+    }
+    free(p->pool);
+    mlocked_pool_init(p);
+}
+
+static void mlocked_pool_grow(mlocked_pool_t *p)
+{
+    size_t i;
+    void* new_page;
+
+    p->pool_size++;
+    p->pool = realloc(p->pool, p->pool_size);
+    new_page = sodium_malloc(DEFAULT_PAGE_SIZE);
+    p->pool[p->pool_size - 1] = new_page;
+    for (i = 0; i < DEFAULT_PAGE_SIZE; i += POOL_ITEM_SIZE) {
+        mlocked_stack_push(p, new_page + i);
+    }
+}
+
+static void mlocked_stack_grow(mlocked_pool_t *p)
+{
+    size_t i;
+
+    p->stack_cap <<= 1;
+    p->stack = realloc(p->stack, p->stack_cap);
+}
+
+static void mlocked_stack_push(mlocked_pool_t *p, void* val)
+{
+    if (p->stack_top >= p->stack_cap) {
+        mlocked_stack_grow(p);
+    }
+    p->stack[(p->stack_top)++] = val;
+}
+
+static bool mlocked_stack_pop(void** dst, mlocked_pool_t *p)
+{
+    if (p->stack_top == 0)
+        return false;
+    *dst = p->stack[--(p->stack_top)];
+    return true;
+}
+
+static mlocked_pool_t global_pool;
+static bool initialized = false;
+
+static void mlocked_atexit()
+{
+    mlocked_pool_reset(&global_pool);
+}
+
+void* mlocked_stack_malloc(size_t size)
+{
+    void* item;
+    bool success;
+
+    assert(size <= POOL_ITEM_SIZE);
+
+    if (size > POOL_ITEM_SIZE)
+        return NULL;
+
+    if (!initialized) {
+        mlocked_pool_init(&global_pool);
+        atexit(mlocked_atexit);
+        initialized = true;
+    }
+    if (global_pool.stack_top >= global_pool.stack_cap) {
+        mlocked_pool_grow(&global_pool);
+    }
+    success = mlocked_stack_pop(&item, &global_pool);
+    assert(success);
+    return item;
+}
+
+void mlocked_free(void* item)
+{
+    assert(initialized);
+    sodium_memzero(item, POOL_ITEM_SIZE);
+    mlocked_stack_push(&global_pool, item);
+}

--- a/cardano-crypto-class/cbits/mlocked-pool.c
+++ b/cardano-crypto-class/cbits/mlocked-pool.c
@@ -36,7 +36,9 @@ static mlocked_pool_t global_pool;
 
 static void mlocked_pool_init()
 {
+    #ifdef _SC_PAGESIZE
     page_size = sysconf(_SC_PAGESIZE);
+    #endif
     pthread_mutex_init(&mlocked_pool_mutex, NULL);
     // fprintf(stderr, "mlocked_pool_init\n");
     pthread_mutex_lock(&mlocked_pool_mutex);

--- a/cardano-crypto-class/cbits/mlocked-pool.h
+++ b/cardano-crypto-class/cbits/mlocked-pool.h
@@ -1,0 +1,27 @@
+// mlocked-pool.h
+//
+// A special-purpose memory allocator for space-efficient use of mlocked
+// memory.
+// This allocator uses a memory pool behind the scenes, allocating page-sized
+// chunks of mlocked memory, and then handing out item-sized chunks of them
+// using a stack of pointers.
+//
+// The item size of 32 bytes was chosen to accommodate Ed25519 sign keys; by
+// packing such keys tightly into pages, we can accommodate 128 individual keys
+// per 4kiB page.
+
+#define POOL_ITEM_SIZE 32U
+
+// Allocate POOL_ITEM_SIZE bytes of memory. It is possible to demand any other
+// size; however, demanding more than POOL_ITEM_SIZE bytes will cause this
+// function to fail by returning NULL, and demanding less will cause it to
+// still allocate POOL_ITEM_SIZE bytes.
+void* mlocked_stack_malloc(size_t);
+
+// Free memory previously allocated with mlocked_stack_malloc.
+//
+// WARNING: do not pass memory to this function that was not originally
+// allocated by mlocked_stack_malloc. Doing so will mark the memory you passed
+// as available for future allocations, and it will end up being returned from
+// mlocked_stack_malloc() without actually being mlocked.
+void mlocked_free(void* item);

--- a/cardano-crypto-class/cbits/mlocked-pool.h
+++ b/cardano-crypto-class/cbits/mlocked-pool.h
@@ -16,7 +16,7 @@
 // size; however, demanding more than POOL_ITEM_SIZE bytes will cause this
 // function to fail by returning NULL, and demanding less will cause it to
 // still allocate POOL_ITEM_SIZE bytes.
-void* mlocked_stack_malloc(size_t);
+void* mlocked_pool_malloc(size_t);
 
 // Free memory previously allocated with mlocked_stack_malloc.
 //
@@ -24,4 +24,4 @@ void* mlocked_stack_malloc(size_t);
 // allocated by mlocked_stack_malloc. Doing so will mark the memory you passed
 // as available for future allocations, and it will end up being returned from
 // mlocked_stack_malloc() without actually being mlocked.
-void mlocked_free(void* item);
+void mlocked_pool_free(void* item);

--- a/cardano-crypto-class/memory-example/Main.hs
+++ b/cardano-crypto-class/memory-example/Main.hs
@@ -43,16 +43,18 @@ main = do
     -- example SHA256 hash
     do
       let input = SB.pack [0..255]
-      let MLSB hash = digestMLockedBS (Proxy @SHA256) input
+      mlsb@(MLSB hash) <- digestMLockedBS (Proxy @SHA256) input
       traceMLockedForeignPtr hash
       print (digest (Proxy @SHA256) input)
+      mlsbFinalize mlsb
 
     -- example Blake2b_256 hash
     do
       let input = SB.pack [0..255]
-      let MLSB hash = digestMLockedBS (Proxy @Blake2b_256) input
+      mlsb@(MLSB hash) <- digestMLockedBS (Proxy @Blake2b_256) input
       traceMLockedForeignPtr hash
       print (digest (Proxy @Blake2b_256) input)
+      mlsbFinalize mlsb
 
 example
     :: [String]
@@ -72,8 +74,9 @@ example args alloc = do
     traceMLockedForeignPtr fptr
 
     -- smoke test that hashing works
-    MLSB hash <- withMLockedForeignPtr fptr $ \ptr ->
-        return $ digestMLockedStorable (Proxy @SHA256) ptr
+    mlsb@(MLSB hash) <- withMLockedForeignPtr fptr $ \ptr ->
+        digestMLockedStorable (Proxy @SHA256) ptr
+    mlsbFinalize mlsb
     traceMLockedForeignPtr hash
 
     -- force finalizers

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN.hs
@@ -6,7 +6,9 @@ module Cardano.Crypto.DSIGN
 where
 
 import Cardano.Crypto.DSIGN.Class as X
+import Cardano.Crypto.DSIGNM.Class as X
 import Cardano.Crypto.DSIGN.Ed25519 as X
+import Cardano.Crypto.DSIGN.Ed25519ML as X
 import Cardano.Crypto.DSIGN.Ed448 as X
 import Cardano.Crypto.DSIGN.Mock as X
 import Cardano.Crypto.DSIGN.NeverUsed as X

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Class.hs
@@ -38,7 +38,7 @@ module Cardano.Crypto.DSIGN.Class
 
     -- * Encoded 'Size' expresssions
   , encodedVerKeyDSIGNSizeExpr
-  , encodedSignKeyDESIGNSizeExpr
+  , encodedSignKeyDSIGNSizeExpr
   , encodedSigDSIGNSizeExpr
   )
 where
@@ -290,8 +290,8 @@ encodedVerKeyDSIGNSizeExpr _proxy =
 -- | 'Size' expression for 'SignKeyDSIGN' which is using 'sizeSignKeyDSIGN'
 -- encoded as 'Size'.
 --
-encodedSignKeyDESIGNSizeExpr :: forall v. DSIGNAlgorithm v => Proxy (SignKeyDSIGN v) -> Size
-encodedSignKeyDESIGNSizeExpr _proxy =
+encodedSignKeyDSIGNSizeExpr :: forall v. DSIGNAlgorithm v => Proxy (SignKeyDSIGN v) -> Size
+encodedSignKeyDSIGNSizeExpr _proxy =
       -- 'encodeBytes' envelope
       fromIntegral ((withWordSize :: Word -> Integer) (sizeSignKeyDSIGN (Proxy :: Proxy v)))
       -- payload

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/EcdsaSecp256k1.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/EcdsaSecp256k1.hs
@@ -26,33 +26,33 @@ import Control.DeepSeq (NFData)
 import qualified Crypto.Secp256k1 as ECDSA
 import NoThunks.Class (NoThunks)
 import Cardano.Crypto.DSIGN.Class (
-  DSIGNAlgorithm (VerKeyDSIGN, 
-                  SignKeyDSIGN, 
+  DSIGNAlgorithm (VerKeyDSIGN,
+                  SignKeyDSIGN,
                   SigDSIGN,
-                  SeedSizeDSIGN, 
-                  SizeSigDSIGN, 
-                  SizeSignKeyDSIGN, 
-                  SizeVerKeyDSIGN, 
+                  SeedSizeDSIGN,
+                  SizeSigDSIGN,
+                  SizeSignKeyDSIGN,
+                  SizeVerKeyDSIGN,
                   algorithmNameDSIGN,
-                  deriveVerKeyDSIGN, 
-                  signDSIGN, 
-                  verifyDSIGN, 
-                  genKeyDSIGN, 
+                  deriveVerKeyDSIGN,
+                  signDSIGN,
+                  verifyDSIGN,
+                  genKeyDSIGN,
                   rawSerialiseSigDSIGN,
-                  Signable, 
-                  rawSerialiseVerKeyDSIGN, 
-                  rawSerialiseSignKeyDSIGN, 
+                  Signable,
+                  rawSerialiseVerKeyDSIGN,
+                  rawSerialiseSignKeyDSIGN,
                   rawDeserialiseVerKeyDSIGN,
-                  rawDeserialiseSignKeyDSIGN, 
-                  rawDeserialiseSigDSIGN), 
-  encodeVerKeyDSIGN, 
-  encodedVerKeyDSIGNSizeExpr, 
-  decodeVerKeyDSIGN, 
-  encodeSignKeyDSIGN, 
-  encodedSignKeyDESIGNSizeExpr, 
-  decodeSignKeyDSIGN, 
-  encodeSigDSIGN, 
-  encodedSigDSIGNSizeExpr, 
+                  rawDeserialiseSignKeyDSIGN,
+                  rawDeserialiseSigDSIGN),
+  encodeVerKeyDSIGN,
+  encodedVerKeyDSIGNSizeExpr,
+  decodeVerKeyDSIGN,
+  encodeSignKeyDSIGN,
+  encodedSignKeyDSIGNSizeExpr,
+  decodeSignKeyDSIGN,
+  encodeSigDSIGN,
+  encodedSigDSIGNSizeExpr,
   decodeSigDSIGN
   )
 
@@ -70,40 +70,40 @@ instance DSIGNAlgorithm EcdsaSecp256k1DSIGN where
   type SizeSignKeyDSIGN EcdsaSecp256k1DSIGN = 32
   type SizeVerKeyDSIGN EcdsaSecp256k1DSIGN = 64
   type Signable EcdsaSecp256k1DSIGN = ((~) ECDSA.Msg)
-  newtype VerKeyDSIGN EcdsaSecp256k1DSIGN = 
+  newtype VerKeyDSIGN EcdsaSecp256k1DSIGN =
     VerKeyEcdsaSecp256k1 ECDSA.PubKey
     deriving newtype (Eq, NFData)
     deriving stock (Show, Generic)
-  newtype SignKeyDSIGN EcdsaSecp256k1DSIGN = 
+  newtype SignKeyDSIGN EcdsaSecp256k1DSIGN =
     SignKeyEcdsaSecp256k1 ECDSA.SecKey
     deriving newtype (Eq, NFData)
     deriving stock (Show, Generic)
-  newtype SigDSIGN EcdsaSecp256k1DSIGN = 
+  newtype SigDSIGN EcdsaSecp256k1DSIGN =
     SigEcdsaSecp256k1 ECDSA.Sig
     deriving newtype (Eq, NFData)
     deriving stock (Show, Generic)
   algorithmNameDSIGN _ = "ecdsa-secp256k1"
-  deriveVerKeyDSIGN (SignKeyEcdsaSecp256k1 sk) = 
+  deriveVerKeyDSIGN (SignKeyEcdsaSecp256k1 sk) =
     VerKeyEcdsaSecp256k1 . ECDSA.derivePubKey $ sk
-  signDSIGN () msg (SignKeyEcdsaSecp256k1 k) = 
+  signDSIGN () msg (SignKeyEcdsaSecp256k1 k) =
     SigEcdsaSecp256k1 . ECDSA.signMsg k $ msg
-  verifyDSIGN () (VerKeyEcdsaSecp256k1 pk) msg (SigEcdsaSecp256k1 sig) = 
+  verifyDSIGN () (VerKeyEcdsaSecp256k1 pk) msg (SigEcdsaSecp256k1 sig) =
     if ECDSA.verifySig pk sig msg
     then pure ()
     else Left "ECDSA-SECP256k1 signature not verified"
   genKeyDSIGN seed = runMonadRandomWithSeed seed $ do
     bs <- getRandomBytes 32
-    case ECDSA.secKey bs of 
+    case ECDSA.secKey bs of
       Nothing -> error "Failed to construct a ECDSA-SECP256k1 secret key unexpectedly"
       Just sk -> pure . SignKeyEcdsaSecp256k1 $ sk
   rawSerialiseSigDSIGN (SigEcdsaSecp256k1 sig) = putting sig
   rawSerialiseVerKeyDSIGN (VerKeyEcdsaSecp256k1 pk) = putting pk
   rawSerialiseSignKeyDSIGN (SignKeyEcdsaSecp256k1 sk) = putting sk
-  rawDeserialiseVerKeyDSIGN bs = 
+  rawDeserialiseVerKeyDSIGN bs =
     VerKeyEcdsaSecp256k1 <$> (eitherToMaybe . getting $ bs)
-  rawDeserialiseSignKeyDSIGN bs = 
+  rawDeserialiseSignKeyDSIGN bs =
     SignKeyEcdsaSecp256k1 <$> (eitherToMaybe . getting $ bs)
-  rawDeserialiseSigDSIGN bs = 
+  rawDeserialiseSigDSIGN bs =
     SigEcdsaSecp256k1 <$> (eitherToMaybe . getting $ bs)
 
 instance ToCBOR (VerKeyDSIGN EcdsaSecp256k1DSIGN) where
@@ -115,7 +115,7 @@ instance FromCBOR (VerKeyDSIGN EcdsaSecp256k1DSIGN) where
 
 instance ToCBOR (SignKeyDSIGN EcdsaSecp256k1DSIGN) where
   toCBOR = encodeSignKeyDSIGN
-  encodedSizeExpr _ = encodedSignKeyDESIGNSizeExpr
+  encodedSizeExpr _ = encodedSignKeyDSIGNSizeExpr
 
 instance FromCBOR (SignKeyDSIGN EcdsaSecp256k1DSIGN) where
   fromCBOR = decodeSignKeyDSIGN
@@ -137,7 +137,7 @@ instance NoThunks ECDSA.Sig
 
 -- Helpers
 
-eitherToMaybe :: forall (a :: Type) (b :: Type) . 
+eitherToMaybe :: forall (a :: Type) (b :: Type) .
   Either b a -> Maybe a
 eitherToMaybe = either (const Nothing) pure
 

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed25519.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed25519.hs
@@ -85,6 +85,7 @@ instance DSIGNAlgorithm Ed25519DSIGN where
     -- (the libsodium \"seed\"). And because of this, we need to define the
     -- sign key size to be SEEDBYTES (which is 32), not PRIVATEKEYBYTES (which
     -- would be 64).
+    -- (the libsodium \"seed\").
     type SizeSignKeyDSIGN Ed25519DSIGN = CRYPTO_SIGN_ED25519_SEEDBYTES
     -- | Ed25519 signature size is 64 octets
     type SizeSigDSIGN     Ed25519DSIGN = CRYPTO_SIGN_ED25519_BYTES
@@ -195,7 +196,7 @@ instance FromCBOR (VerKeyDSIGN Ed25519DSIGN) where
 
 instance ToCBOR (SignKeyDSIGN Ed25519DSIGN) where
   toCBOR = encodeSignKeyDSIGN
-  encodedSizeExpr _ = encodedSignKeyDESIGNSizeExpr
+  encodedSizeExpr _ = encodedSignKeyDSIGNSizeExpr
 
 instance FromCBOR (SignKeyDSIGN Ed25519DSIGN) where
   fromCBOR = decodeSignKeyDSIGN

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed25519ML.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed25519ML.hs
@@ -1,0 +1,226 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+
+-- | Ed25519 digital signatures. This flavor of Ed25519 stores secrets in
+-- mlocked memory to make sure they cannot leak to disk via swapping.
+module Cardano.Crypto.DSIGN.Ed25519ML
+  ( Ed25519DSIGNM
+  , SigDSIGNM (..)
+  , SignKeyDSIGNM (..)
+  , VerKeyDSIGNM (..)
+  )
+where
+
+import Control.DeepSeq (NFData)
+import GHC.Generics (Generic)
+import NoThunks.Class (NoThunks)
+import System.IO.Unsafe (unsafeDupablePerformIO)
+import GHC.IO.Exception (ioException)
+import Control.Monad (unless)
+import Foreign.C.Error (errnoToIOError, getErrno)
+import Foreign.Ptr (castPtr, nullPtr)
+import qualified Data.ByteString as BS
+-- import qualified Data.ByteString.Unsafe as BS
+import Data.Proxy
+import Control.Exception (evaluate)
+
+import Cardano.Binary (FromCBOR (..), ToCBOR (..))
+
+import Cardano.Foreign
+import Cardano.Crypto.PinnedSizedBytes
+import Cardano.Crypto.Libsodium.C
+-- import Cardano.Crypto.Libsodium.Memory.Internal
+import Cardano.Crypto.Libsodium (MLockedSizedBytes)
+-- import Cardano.Crypto.Libsodium.MLockedBytes
+import Cardano.Crypto.MonadSodium (MonadSodium (..), mlsbToByteString, mlsbFromByteStringCheck)
+
+import Cardano.Crypto.DSIGNM.Class
+-- import Cardano.Crypto.Seed
+import Cardano.Crypto.Util (SignableRepresentation(..))
+
+
+data Ed25519DSIGNM
+
+instance NoThunks (VerKeyDSIGNM Ed25519DSIGNM)
+instance NoThunks (SignKeyDSIGNM Ed25519DSIGNM)
+instance NoThunks (SigDSIGNM Ed25519DSIGNM)
+
+-- | Convert C-style return code / errno error reporting into Haskell
+-- exceptions.
+--
+-- Runs an IO action (which should be some FFI call into C) that returns a
+-- result code; if the result code returned is nonzero, fetch the errno, and
+-- throw a suitable IO exception.
+cOrError :: String -> String -> IO Int -> IO ()
+cOrError contextDesc cFunName action = do
+  res <- action
+  unless (res == 0) $ do
+      errno <- getErrno
+      ioException $ errnoToIOError (contextDesc ++ ": " ++ cFunName) errno Nothing Nothing
+
+instance DSIGNMAlgorithmBase Ed25519DSIGNM where
+    type SeedSizeDSIGNM Ed25519DSIGNM = CRYPTO_SIGN_ED25519_SEEDBYTES
+    -- | Ed25519 key size is 32 octets
+    -- (per <https://tools.ietf.org/html/rfc8032#section-5.1.6>)
+    type SizeVerKeyDSIGNM  Ed25519DSIGNM = CRYPTO_SIGN_ED25519_PUBLICKEYBYTES
+    -- | Ed25519 secret key size is 32 octets; however, libsodium packs both
+    -- the secret key and the public key into a 64-octet compound and exposes
+    -- that as the secret key; the actual 32-octet secret key is called
+    -- \"seed\" in libsodium. For backwards compatibility reasons and
+    -- efficiency, we use the 64-octet compounds internally (this is what
+    -- libsodium expects), but we only serialize the 32-octet secret key part
+    -- (the libsodium \"seed\").
+    type SizeSignKeyDSIGNM Ed25519DSIGNM = CRYPTO_SIGN_ED25519_SEEDBYTES
+    -- | Ed25519 signature size is 64 octets
+    type SizeSigDSIGNM     Ed25519DSIGNM = CRYPTO_SIGN_ED25519_BYTES
+
+    --
+    -- Key and signature types
+    --
+
+    newtype VerKeyDSIGNM Ed25519DSIGNM = VerKeyEd25519DSIGNM (PinnedSizedBytes (SizeVerKeyDSIGNM Ed25519DSIGNM))
+        deriving (Show, Eq, Generic)
+        deriving newtype NFData
+
+    -- Note that the size of the internal key data structure is the SECRET KEY
+    -- bytes as per libsodium, while the declared key size (for serialization)
+    -- is libsodium's SEED bytes. We expand 32-octet keys to 64-octet ones
+    -- during deserialization, and we delete the 32 octets that contain the
+    -- public key from the secret key before serializing.
+    newtype SignKeyDSIGNM Ed25519DSIGNM = SignKeyEd25519DSIGNM (MLockedSizedBytes CRYPTO_SIGN_ED25519_SECRETKEYBYTES)
+        deriving (Show, Eq, Generic)
+        deriving newtype NFData
+
+    newtype SigDSIGNM Ed25519DSIGNM = SigEd25519DSIGNM (PinnedSizedBytes (SizeSigDSIGNM Ed25519DSIGNM))
+        deriving (Show, Eq, Generic)
+        deriving newtype NFData
+
+    --
+    -- Metadata and basic key operations
+    --
+
+    algorithmNameDSIGNM _ = "ed25519-ml"
+
+    --
+    -- Core algorithm operations
+    --
+
+    type SignableM Ed25519DSIGNM = SignableRepresentation
+
+    verifyDSIGNM () (VerKeyEd25519DSIGNM vk) a (SigEd25519DSIGNM sig) =
+        let bs = getSignableRepresentation a
+        in unsafeDupablePerformIO $
+          BS.useAsCStringLen bs $ \(ptr, len) ->
+          psbUseAsSizedPtr vk $ \vkPtr ->
+          psbUseAsSizedPtr sig $ \sigPtr -> do
+              res <- c_crypto_sign_ed25519_verify_detached sigPtr (castPtr ptr) (fromIntegral len) vkPtr
+              if res == 0
+              then return (Right ())
+              else do
+                  -- errno <- getErrno
+                  return (Left  "Verification failed")
+
+    --
+    -- raw serialise/deserialise
+    --
+
+    rawSerialiseVerKeyDSIGNM   (VerKeyEd25519DSIGNM vk) = psbToByteString vk
+    rawSerialiseSigDSIGNM      (SigEd25519DSIGNM sig) = psbToByteString sig
+
+    rawDeserialiseVerKeyDSIGNM  = fmap VerKeyEd25519DSIGNM . psbFromByteStringCheck
+    rawDeserialiseSigDSIGNM     = fmap SigEd25519DSIGNM . psbFromByteStringCheck
+
+instance DSIGNMAlgorithm IO Ed25519DSIGNM where
+    deriveVerKeyDSIGNM (SignKeyEd25519DSIGNM sk) =
+      VerKeyEd25519DSIGNM <$> do
+        mlsbUseAsSizedPtr sk $ \skPtr -> do
+          psbCreateSized $ \pkPtr ->
+            cOrError "deriveVerKeyDSIGNM @Ed25519DSIGNM" "c_crypto_sign_ed25519_sk_to_pk"
+              $ c_crypto_sign_ed25519_sk_to_pk pkPtr skPtr
+
+    signDSIGNM () a (SignKeyEd25519DSIGNM sk) =
+      let bs = getSignableRepresentation a
+      in SigEd25519DSIGNM <$> do
+          BS.useAsCStringLen bs $ \(ptr, len) ->
+            mlsbUseAsSizedPtr sk $ \skPtr ->
+            allocaSized $ \pkPtr -> do
+                cOrError "signDSIGNM @Ed25519DSIGNM" "c_crypto_sign_ed25519_sk_to_pk"
+                  $ c_crypto_sign_ed25519_sk_to_pk pkPtr skPtr
+                psbCreateSized $ \sigPtr -> do
+                  cOrError "signDSIGNM @Ed25519DSIGNM" "c_crypto_sign_ed25519_detached"
+                    $ c_crypto_sign_ed25519_detached sigPtr nullPtr (castPtr ptr) (fromIntegral len) skPtr
+
+    --
+    -- Key generation
+    --
+    genKeyDSIGNM seed = SignKeyEd25519DSIGNM <$> do
+          sk <- mlsbNew
+          mlsbUseAsSizedPtr sk $ \skPtr ->
+            mlsbUseAsCPtr seed $ \seedPtr ->
+            allocaSized $ \pkPtr -> do
+                cOrError "genKeyDSIGNM @Ed25519DSIGNM" "c_crypto_sign_ed25519_seed_keypair"
+                  $ c_crypto_sign_ed25519_seed_keypair pkPtr skPtr (SizedPtr . castPtr $ seedPtr)
+          return sk
+
+    getSeedDSIGNM _ (SignKeyEd25519DSIGNM sk) = do
+        seed <- mlsbNew
+        mlsbUseAsSizedPtr sk $ \skPtr ->
+          mlsbUseAsSizedPtr seed $ \seedPtr ->
+            cOrError "rawSerialiseSignKeyDSIGNM @Ed25519DSIGNM" "c_crypto_sign_ed25519_sk_to_seed"
+              $ c_crypto_sign_ed25519_sk_to_seed seedPtr skPtr
+        return seed
+
+    --
+    -- Secure forgetting
+    --
+    forgetSignKeyDSIGNM (SignKeyEd25519DSIGNM sk) = do
+      mlsbFinalize sk
+
+    --
+    -- Ser/deser (dangerous)
+    --
+    rawSerialiseSignKeyDSIGNM sk = do
+      seed <- getSeedDSIGNM (Proxy @Ed25519DSIGNM) sk
+      -- need to copy the seed into unsafe memory and finalize the MLSB, in
+      -- order to avoid leaking mlocked memory
+      raw <- evaluate . (BS.copy $!) . mlsbToByteString $ seed
+      mlsbFinalize seed
+      return raw
+
+    rawDeserialiseSignKeyDSIGNM raw = do
+      mseed <- mlsbFromByteStringCheck raw
+      case mseed of
+        Nothing -> return Nothing
+        Just seed -> do
+          sk <- Just <$> genKeyDSIGNM seed
+          mlsbFinalize seed
+          return sk
+
+
+instance ToCBOR (VerKeyDSIGNM Ed25519DSIGNM) where
+  toCBOR = encodeVerKeyDSIGNM
+  encodedSizeExpr _ = encodedVerKeyDSIGNMSizeExpr
+
+instance FromCBOR (VerKeyDSIGNM Ed25519DSIGNM) where
+  fromCBOR = decodeVerKeyDSIGNM
+
+-- instance ToCBOR (SignKeyDSIGNM Ed25519DSIGNM) where
+--   toCBOR = encodeSignKeyDSIGNM
+--   encodedSizeExpr _ = encodedSignKeyDESIGNSizeExpr
+--
+-- instance FromCBOR (SignKeyDSIGNM Ed25519DSIGNM) where
+--   fromCBOR = decodeSignKeyDSIGNM
+
+instance ToCBOR (SigDSIGNM Ed25519DSIGNM) where
+  toCBOR = encodeSigDSIGNM
+  encodedSizeExpr _ = encodedSigDSIGNMSizeExpr
+
+instance FromCBOR (SigDSIGNM Ed25519DSIGNM) where
+  fromCBOR = decodeSigDSIGNM

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed25519ML.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed25519ML.hs
@@ -173,7 +173,7 @@ instance DSIGNMAlgorithm IO Ed25519DSIGNM where
         seed <- mlsbNew
         mlsbUseAsSizedPtr sk $ \skPtr ->
           mlsbUseAsSizedPtr seed $ \seedPtr ->
-            cOrError "rawSerialiseSignKeyDSIGNM @Ed25519DSIGNM" "c_crypto_sign_ed25519_sk_to_seed"
+            cOrError "getSeedDSIGNM @Ed25519DSIGNM" "c_crypto_sign_ed25519_sk_to_seed"
               $ c_crypto_sign_ed25519_sk_to_seed seedPtr skPtr
         return seed
 

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed448.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed448.hs
@@ -115,7 +115,7 @@ instance FromCBOR (VerKeyDSIGN Ed448DSIGN) where
 
 instance ToCBOR (SignKeyDSIGN Ed448DSIGN) where
   toCBOR = encodeSignKeyDSIGN
-  encodedSizeExpr _ = encodedSignKeyDESIGNSizeExpr
+  encodedSizeExpr _ = encodedSignKeyDSIGNSizeExpr
 
 instance FromCBOR (SignKeyDSIGN Ed448DSIGN) where
   fromCBOR = decodeSignKeyDSIGN

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Mock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Mock.hs
@@ -138,7 +138,7 @@ instance FromCBOR (VerKeyDSIGN MockDSIGN) where
 
 instance ToCBOR (SignKeyDSIGN MockDSIGN) where
   toCBOR = encodeSignKeyDSIGN
-  encodedSizeExpr _ = encodedSignKeyDESIGNSizeExpr
+  encodedSizeExpr _ = encodedSignKeyDSIGNSizeExpr
 
 instance FromCBOR (SignKeyDSIGN MockDSIGN) where
   fromCBOR = decodeSignKeyDSIGN

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/SchnorrSecp256k1.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/SchnorrSecp256k1.hs
@@ -72,7 +72,7 @@ import Cardano.Crypto.DSIGN.Class (
   encodedVerKeyDSIGNSizeExpr,
   decodeVerKeyDSIGN,
   encodeSignKeyDSIGN,
-  encodedSignKeyDESIGNSizeExpr,
+  encodedSignKeyDSIGNSizeExpr,
   decodeSignKeyDSIGN,
   encodeSigDSIGN,
   encodedSigDSIGNSizeExpr,
@@ -180,7 +180,7 @@ instance FromCBOR (VerKeyDSIGN SchnorrSecp256k1DSIGN) where
 
 instance ToCBOR (SignKeyDSIGN SchnorrSecp256k1DSIGN) where
   toCBOR = encodeSignKeyDSIGN
-  encodedSizeExpr _ = encodedSignKeyDESIGNSizeExpr
+  encodedSizeExpr _ = encodedSignKeyDSIGNSizeExpr
 
 instance FromCBOR (SignKeyDSIGN SchnorrSecp256k1DSIGN) where
   fromCBOR = decodeSignKeyDSIGN

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGNM/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGNM/Class.hs
@@ -1,0 +1,339 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE LambdaCase #-}
+
+-- | Abstract digital signatures.
+module Cardano.Crypto.DSIGNM.Class
+  (
+    -- * DSIGNMM algorithm class
+    DSIGNMAlgorithmBase (..)
+  , DSIGNMAlgorithm (..)
+  , MLockedSeed
+  , seedSizeDSIGNM
+  , sizeVerKeyDSIGNM
+  , sizeSignKeyDSIGNM
+  , sizeSigDSIGNM
+
+    -- * 'SignedDSIGNM' wrapper
+  , SignedDSIGNM (..)
+  , signedDSIGNM
+  , verifySignedDSIGNM
+
+    -- * CBOR encoding and decoding
+  , encodeVerKeyDSIGNM
+  , decodeVerKeyDSIGNM
+  , encodeSigDSIGNM
+  , decodeSigDSIGNM
+  , encodeSignKeyDSIGNM
+  , decodeSignKeyDSIGNM
+  , encodeSignedDSIGNM
+  , decodeSignedDSIGNM
+
+    -- * Encoded 'Size' expresssions
+  , encodedVerKeyDSIGNMSizeExpr
+  , encodedSignKeyDSIGNMSizeExpr
+  , encodedSigDSIGNMSizeExpr
+  )
+where
+
+import qualified Data.ByteString as BS
+import Data.ByteString (ByteString)
+import Data.Kind (Type)
+import Data.Proxy (Proxy(..))
+import Data.Typeable (Typeable)
+import GHC.Exts (Constraint)
+import GHC.Generics (Generic)
+import GHC.Stack
+import GHC.TypeLits (KnownNat, Nat, natVal, TypeError, ErrorMessage (..))
+import NoThunks.Class (NoThunks)
+-- import Control.DeepSeq (NFData)
+
+import Cardano.Binary (Decoder, decodeBytes, Encoding, encodeBytes, Size, withWordSize)
+
+import Cardano.Crypto.Util (Empty)
+import Cardano.Crypto.Libsodium.MLockedBytes
+import Cardano.Crypto.Hash.Class (HashAlgorithm, Hash, hashWith)
+
+-- deriving instance NFData (VerKeyDSIGNM d)
+-- deriving instance NFData (SignKeyDSIGNM d)
+-- deriving instance NFData (SigDSIGNM d)
+
+-- | A seed of size @n@, stored in mlocked memory. This is required to prevent
+-- the seed from leaking to disk via swapping and reclaiming or scanning memory
+-- after its content has been moved.
+type MLockedSeed n = MLockedSizedBytes n
+
+
+class ( Typeable v
+      , Show (VerKeyDSIGNM v)
+      , Eq (VerKeyDSIGNM v)
+      , Show (SignKeyDSIGNM v)
+      , Show (SigDSIGNM v)
+      , Eq (SigDSIGNM v)
+      , NoThunks (SigDSIGNM v)
+      , NoThunks (SignKeyDSIGNM v)
+      , NoThunks (VerKeyDSIGNM v)
+      , KnownNat (SeedSizeDSIGNM v)
+      , KnownNat (SizeVerKeyDSIGNM v)
+      , KnownNat (SizeSignKeyDSIGNM v)
+      , KnownNat (SizeSigDSIGNM v)
+      )
+      => DSIGNMAlgorithmBase v where
+
+  type SeedSizeDSIGNM    v :: Nat
+  type SizeVerKeyDSIGNM  v :: Nat
+  type SizeSignKeyDSIGNM v :: Nat
+  type SizeSigDSIGNM     v :: Nat
+
+  --
+  -- Key and signature types
+  --
+
+  data VerKeyDSIGNM  v :: Type
+  data SignKeyDSIGNM v :: Type
+  data SigDSIGNM     v :: Type
+
+  --
+  -- Metadata and basic key operations
+  --
+
+  algorithmNameDSIGNM :: proxy v -> String
+
+  hashVerKeyDSIGNM :: HashAlgorithm h => VerKeyDSIGNM v -> Hash h (VerKeyDSIGNM v)
+  hashVerKeyDSIGNM = hashWith rawSerialiseVerKeyDSIGNM
+
+  --
+  -- Core algorithm operations
+  --
+
+  -- | Context required to run the DSIGNM algorithm
+  --
+  -- Unit by default (no context required)
+  type ContextDSIGNM v :: Type
+  type ContextDSIGNM v = ()
+
+  type SignableM v :: Type -> Constraint
+  type SignableM v = Empty
+
+  verifyDSIGNM
+    :: (SignableM v a, HasCallStack)
+    => ContextDSIGNM v
+    -> VerKeyDSIGNM v
+    -> a
+    -> SigDSIGNM v
+    -> Either String ()
+
+  --
+  -- Serialisation/(de)serialisation in fixed-size raw format
+  --
+
+  rawSerialiseVerKeyDSIGNM    :: VerKeyDSIGNM v -> ByteString
+  rawSerialiseSigDSIGNM       :: SigDSIGNM v -> ByteString
+
+  rawDeserialiseVerKeyDSIGNM  :: ByteString -> Maybe (VerKeyDSIGNM v)
+  rawDeserialiseSigDSIGNM     :: ByteString -> Maybe (SigDSIGNM v)
+
+class ( DSIGNMAlgorithmBase v
+      , Monad m
+      )
+      => DSIGNMAlgorithm m v where
+
+  --
+  -- Metadata and basic key operations
+  --
+
+  deriveVerKeyDSIGNM :: SignKeyDSIGNM v -> m (VerKeyDSIGNM v)
+
+  --
+  -- Core algorithm operations
+  --
+
+  signDSIGNM
+    :: (SignableM v a, HasCallStack)
+    => ContextDSIGNM v
+    -> a
+    -> SignKeyDSIGNM v
+    -> m (SigDSIGNM v)
+
+  --
+  -- Key generation
+  --
+
+  genKeyDSIGNM :: MLockedSeed (SeedSizeDSIGNM v) -> m (SignKeyDSIGNM v)
+
+  getSeedDSIGNM :: Proxy v -> SignKeyDSIGNM v -> m (MLockedSeed (SeedSizeDSIGNM v))
+
+  --
+  -- Secure forgetting
+  --
+
+  forgetSignKeyDSIGNM :: SignKeyDSIGNM v -> m ()
+
+  --
+  -- Serialisation/(de)serialisation in fixed-size raw format
+  --
+
+  rawSerialiseSignKeyDSIGNM   :: SignKeyDSIGNM v -> m ByteString
+
+  rawDeserialiseSignKeyDSIGNM :: ByteString -> m (Maybe (SignKeyDSIGNM v))
+
+--
+-- Do not provide Ord instances for keys, see #38
+--
+
+instance ( TypeError ('Text "Ord not supported for signing keys, use the hash instead")
+         , Eq (SignKeyDSIGNM v)
+         )
+      => Ord (SignKeyDSIGNM v) where
+    compare = error "unsupported"
+
+instance ( TypeError ('Text "Ord not supported for verification keys, use the hash instead")
+         , Eq (VerKeyDSIGNM v)
+         )
+      => Ord (VerKeyDSIGNM v) where
+    compare = error "unsupported"
+
+-- | The upper bound on the seed size needed by 'genKeyDSIGNM'
+seedSizeDSIGNM :: forall v proxy. DSIGNMAlgorithmBase v => proxy v -> Word
+seedSizeDSIGNM _ = fromInteger (natVal (Proxy @(SeedSizeDSIGNM v)))
+
+sizeVerKeyDSIGNM    :: forall v proxy. DSIGNMAlgorithmBase v => proxy v -> Word
+sizeVerKeyDSIGNM  _ = fromInteger (natVal (Proxy @(SizeVerKeyDSIGNM v)))
+sizeSignKeyDSIGNM   :: forall v proxy. DSIGNMAlgorithmBase v => proxy v -> Word
+sizeSignKeyDSIGNM _ = fromInteger (natVal (Proxy @(SizeSignKeyDSIGNM v)))
+sizeSigDSIGNM       :: forall v proxy. DSIGNMAlgorithmBase v => proxy v -> Word
+sizeSigDSIGNM     _ = fromInteger (natVal (Proxy @(SizeSigDSIGNM v)))
+
+--
+-- Convenient CBOR encoding/decoding
+--
+-- Implementations in terms of the raw (de)serialise
+--
+
+encodeVerKeyDSIGNM :: DSIGNMAlgorithmBase v => VerKeyDSIGNM v -> Encoding
+encodeVerKeyDSIGNM = encodeBytes . rawSerialiseVerKeyDSIGNM
+
+encodeSignKeyDSIGNM :: DSIGNMAlgorithm m v => SignKeyDSIGNM v -> m Encoding
+encodeSignKeyDSIGNM = fmap encodeBytes . rawSerialiseSignKeyDSIGNM
+
+encodeSigDSIGNM :: DSIGNMAlgorithmBase v => SigDSIGNM v -> Encoding
+encodeSigDSIGNM = encodeBytes . rawSerialiseSigDSIGNM
+
+decodeVerKeyDSIGNM :: forall v s. DSIGNMAlgorithmBase v => Decoder s (VerKeyDSIGNM v)
+decodeVerKeyDSIGNM = do
+    bs <- decodeBytes
+    case rawDeserialiseVerKeyDSIGNM bs of
+      Just vk -> return vk
+      Nothing
+        | actual /= expected
+                    -> fail ("decodeVerKeyDSIGNM: wrong length, expected " ++
+                             show expected ++ " bytes but got " ++ show actual)
+        | otherwise -> fail "decodeVerKeyDSIGNM: cannot decode key"
+        where
+          expected = fromIntegral (sizeVerKeyDSIGNM (Proxy :: Proxy v))
+          actual   = BS.length bs
+
+decodeSignKeyDSIGNM :: forall m v s. DSIGNMAlgorithm m v => Decoder s (m (SignKeyDSIGNM v))
+decodeSignKeyDSIGNM = do
+    bs <- decodeBytes
+    return $ rawDeserialiseSignKeyDSIGNM bs >>= \case
+      Just vk -> return vk
+      Nothing
+        | actual /= expected
+                    -> error ("decodeSignKeyDSIGNM: wrong length, expected " ++
+                             show expected ++ " bytes but got " ++ show actual)
+        | otherwise -> error "decodeSignKeyDSIGNM: cannot decode key"
+        where
+          expected = fromIntegral (sizeSignKeyDSIGNM (Proxy :: Proxy v))
+          actual   = BS.length bs
+
+decodeSigDSIGNM :: forall v s. DSIGNMAlgorithmBase v => Decoder s (SigDSIGNM v)
+decodeSigDSIGNM = do
+    bs <- decodeBytes
+    case rawDeserialiseSigDSIGNM bs of
+      Just sig -> return sig
+      Nothing
+        | actual /= expected
+                    -> fail ("decodeSigDSIGNM: wrong length, expected " ++
+                             show expected ++ " bytes but got " ++ show actual)
+        | otherwise -> fail "decodeSigDSIGNM: cannot decode signature"
+        where
+          expected = fromIntegral (sizeSigDSIGNM (Proxy :: Proxy v))
+          actual   = BS.length bs
+
+
+newtype SignedDSIGNM v a = SignedDSIGNM (SigDSIGNM v)
+  deriving Generic
+
+deriving instance DSIGNMAlgorithmBase v => Show (SignedDSIGNM v a)
+deriving instance DSIGNMAlgorithmBase v => Eq   (SignedDSIGNM v a)
+
+instance DSIGNMAlgorithmBase v => NoThunks (SignedDSIGNM v a)
+  -- use generic instance
+
+signedDSIGNM
+  :: (DSIGNMAlgorithm m v, SignableM v a)
+  => ContextDSIGNM v
+  -> a
+  -> SignKeyDSIGNM v
+  -> m (SignedDSIGNM v a)
+signedDSIGNM ctxt a key = SignedDSIGNM <$> signDSIGNM ctxt a key
+
+verifySignedDSIGNM
+  :: (DSIGNMAlgorithmBase v, SignableM v a, HasCallStack)
+  => ContextDSIGNM v
+  -> VerKeyDSIGNM v
+  -> a
+  -> SignedDSIGNM v a
+  -> Either String ()
+verifySignedDSIGNM ctxt key a (SignedDSIGNM s) = verifyDSIGNM ctxt key a s
+
+encodeSignedDSIGNM :: DSIGNMAlgorithmBase v => SignedDSIGNM v a -> Encoding
+encodeSignedDSIGNM (SignedDSIGNM s) = encodeSigDSIGNM s
+
+decodeSignedDSIGNM :: DSIGNMAlgorithmBase v => Decoder s (SignedDSIGNM v a)
+decodeSignedDSIGNM = SignedDSIGNM <$> decodeSigDSIGNM
+
+--
+-- Encoded 'Size' expressions for 'ToCBOR' instances
+--
+
+-- | 'Size' expression for 'VerKeyDSIGNM' which is using 'sizeVerKeyDSIGNM'
+-- encoded as 'Size'.
+--
+encodedVerKeyDSIGNMSizeExpr :: forall v. DSIGNMAlgorithmBase v => Proxy (VerKeyDSIGNM v) -> Size
+encodedVerKeyDSIGNMSizeExpr _proxy =
+      -- 'encodeBytes' envelope
+      fromIntegral ((withWordSize :: Word -> Integer) (sizeVerKeyDSIGNM (Proxy :: Proxy v)))
+      -- payload
+    + fromIntegral (sizeVerKeyDSIGNM (Proxy :: Proxy v))
+
+-- | 'Size' expression for 'SignKeyDSIGNM' which is using 'sizeSignKeyDSIGNM'
+-- encoded as 'Size'.
+--
+encodedSignKeyDSIGNMSizeExpr :: forall v. DSIGNMAlgorithmBase v => Proxy (SignKeyDSIGNM v) -> Size
+encodedSignKeyDSIGNMSizeExpr _proxy =
+      -- 'encodeBytes' envelope
+      fromIntegral ((withWordSize :: Word -> Integer) (sizeSignKeyDSIGNM (Proxy :: Proxy v)))
+      -- payload
+    + fromIntegral (sizeSignKeyDSIGNM (Proxy :: Proxy v))
+
+-- | 'Size' expression for 'SigDSIGNM' which is using 'sizeSigDSIGNM' encoded as
+-- 'Size'.
+--
+encodedSigDSIGNMSizeExpr :: forall v. DSIGNMAlgorithmBase v => Proxy (SigDSIGNM v) -> Size
+encodedSigDSIGNMSizeExpr _proxy =
+      -- 'encodeBytes' envelope
+      fromIntegral ((withWordSize :: Word -> Integer) (sizeSigDSIGNM (Proxy :: Proxy v)))
+      -- payload
+    + fromIntegral (sizeSigDSIGNM (Proxy :: Proxy v))

--- a/cardano-crypto-class/src/Cardano/Crypto/Hash/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Hash/Class.hs
@@ -224,7 +224,7 @@ hashFromStringAsHex = hashFromTextAsHex . Text.pack
 -- | Convert the hash to hex encoding, as 'Text'.
 --
 hashToTextAsHex :: Hash h a -> Text
-hashToTextAsHex = Text.decodeUtf8 . hashToBytesAsHex
+hashToTextAsHex = Text.decodeLatin1 . hashToBytesAsHex
 
 -- | Make a hash from hex-encoded 'Text' representation.
 --
@@ -262,13 +262,13 @@ instance HashAlgorithm h => IsString (Hash h a) where
       Nothing -> error ("fromString: cannot decode hash " ++ show str)
 
 instance HashAlgorithm h => ToJSONKey (Hash h a) where
-  toJSONKey = Aeson.toJSONKeyText hashToText
+  toJSONKey = Aeson.toJSONKeyText hashToTextAsHex
 
 instance HashAlgorithm h => FromJSONKey (Hash h a) where
   fromJSONKey = Aeson.FromJSONKeyTextParser parseHash
 
 instance HashAlgorithm h => ToJSON (Hash h a) where
-  toJSON = toJSON . hashToText
+  toJSON = toJSON . hashToTextAsHex
 
 instance HashAlgorithm h => FromJSON (Hash h a) where
   parseJSON = Aeson.withText "hash" parseHash
@@ -278,10 +278,6 @@ instance HeapWords (Hash h a) where
   heapWords (UnsafeHashRep (PackedBytes28 _ _ _ _)) = 1 + 4
   heapWords (UnsafeHashRep (PackedBytes32 _ _ _ _)) = 1 + 4
   heapWords (UnsafeHashRep (PackedBytes# ba#)) = heapWords (SBSI.SBS ba#)
-
--- utils used in the instances above
-hashToText :: Hash h a -> Text
-hashToText = Text.decodeLatin1 . hashToBytesAsHex
 
 parseHash :: HashAlgorithm crypto => Text -> Aeson.Parser (Hash crypto a)
 parseHash t =

--- a/cardano-crypto-class/src/Cardano/Crypto/Hash/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Hash/Class.hs
@@ -164,7 +164,7 @@ hashFromBytes ::
   -> Maybe (Hash h a)
 hashFromBytes bytes
   | BS.length bytes == fromIntegral (sizeHash (Proxy :: Proxy h))
-  = Just $! UnsafeHashRep (packPinnedBytes bytes)
+  = Just $ UnsafeHashRep (packPinnedBytes bytes)
 
   | otherwise
   = Nothing

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Class.hs
@@ -81,6 +81,9 @@ class ( Typeable v
       , NoThunks (SignKeyKES v)
       , NoThunks (VerKeyKES v)
       , KnownNat (SeedSizeKES v)
+      , KnownNat (SizeVerKeyKES v)
+      , KnownNat (SizeSignKeyKES v)
+      , KnownNat (SizeSigKES v)
       )
       => KESAlgorithm v where
   --
@@ -88,8 +91,12 @@ class ( Typeable v
   --
   data VerKeyKES  v :: Type
   data SigKES     v :: Type
-  type SeedSizeKES v :: Nat
   data SignKeyKES v :: Type
+
+  type SeedSizeKES    v :: Nat
+  type SizeVerKeyKES  v :: Nat
+  type SizeSignKeyKES v :: Nat
+  type SizeSigKES     v :: Nat
 
   --
   -- Metadata and basic key operations
@@ -144,8 +151,13 @@ class ( Typeable v
   --
 
   sizeVerKeyKES  :: proxy v -> Word
+  sizeVerKeyKES _ = fromInteger (natVal (Proxy @(SizeVerKeyKES v)))
+
   sizeSigKES     :: proxy v -> Word
+  sizeSigKES _ = fromInteger (natVal (Proxy @(SizeSigKES v)))
+
   sizeSignKeyKES :: proxy v -> Word
+  sizeSignKeyKES _ = fromInteger (natVal (Proxy @(SizeSignKeyKES v)))
 
   rawSerialiseVerKeyKES    :: VerKeyKES  v -> ByteString
   rawSerialiseSigKES       :: SigKES     v -> ByteString

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/CompactSingle.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/CompactSingle.hs
@@ -179,7 +179,7 @@ instance ( DSIGNMAlgorithm m d -- needed for secure forgetting
     genKeyKES seed = SignKeyCompactSingleKES <$> genKeyDSIGNM seed
 
     rawSerialiseSignKeyKES (SignKeyCompactSingleKES sk) = rawSerialiseSignKeyDSIGNM sk
-    rawDeserialiseSignKeyKES bs = fmap SignKeyCompactSingleKES <$> rawDeserialiseSignKeyDSIGNM bs
+    rawDeserialiseSignKeyKES mlsb offset = fmap SignKeyCompactSingleKES <$> rawDeserialiseSignKeyDSIGNM mlsb offset
 
     --
     -- forgetting

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/CompactSum.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/CompactSum.hs
@@ -6,7 +6,9 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 
 -- | A key evolving signatures implementation.
 --
@@ -78,17 +80,19 @@ import           Data.Typeable (Typeable)
 import           GHC.Generics (Generic)
 import qualified Data.ByteString as BS
 import           Control.Monad (guard)
+import           Control.Monad.Trans (lift)
+import           Control.Monad.Trans.Maybe (MaybeT (..), runMaybeT)
+import           Control.DeepSeq (NFData)
 import           NoThunks.Class (NoThunks)
 
 import           Cardano.Binary (FromCBOR (..), ToCBOR (..))
 
-import           Cardano.Crypto.Seed
-import           Cardano.Crypto.Util
 import           Cardano.Crypto.Hash.Class
 import           Cardano.Crypto.KES.Class
 import           Cardano.Crypto.KES.CompactSingle (CompactSingleKES)
-import           Control.DeepSeq (NFData)
+import qualified Cardano.Crypto.MonadSodium as NaCl
 
+import           Cardano.Crypto.Util
 
 -- | A 2^0 period KES
 type CompactSum0KES d   = CompactSingleKES d
@@ -131,7 +135,12 @@ instance (NFData (SigKES d), NFData (VerKeyKES d)) =>
 instance (NFData (SignKeyKES d), NFData (VerKeyKES d)) =>
   NFData (SignKeyKES (CompactSumKES h d)) where
 
-instance (OptimizedKESAlgorithm d, HashAlgorithm h, Typeable d)
+instance ( OptimizedKESAlgorithm d
+         , NaCl.SodiumHashAlgorithm h
+         , Typeable d
+         , SizeHash h ~ SeedSizeKES d -- can be relaxed
+         , NoThunks (VerKeyKES (CompactSumKES h d))
+         )
       => KESAlgorithm (CompactSumKES h d) where
 
     type SeedSizeKES (CompactSumKES h d) = SeedSizeKES d
@@ -154,7 +163,7 @@ instance (OptimizedKESAlgorithm d, HashAlgorithm h, Typeable d)
     --
     data SignKeyKES (CompactSumKES h d) =
            SignKeyCompactSumKES !(SignKeyKES d)
-                         !Seed
+                         !(NaCl.SafePinned (NaCl.MLockedSizedBytes (SeedSizeKES d)))
                          !(VerKeyKES d)
                          !(VerKeyKES d)
         deriving Generic
@@ -166,7 +175,7 @@ instance (OptimizedKESAlgorithm d, HashAlgorithm h, Typeable d)
     --
     data SigKES (CompactSumKES h d) =
            SigCompactSumKES !(SigKES d) -- includes VerKeys for the Merkle subpath
-                     !(VerKeyKES d)
+                            !(VerKeyKES d)
         deriving Generic
 
 
@@ -175,9 +184,6 @@ instance (OptimizedKESAlgorithm d, HashAlgorithm h, Typeable d)
     --
 
     algorithmNameKES _ = mungeName (algorithmNameKES (Proxy :: Proxy d))
-
-    deriveVerKeyKES (SignKeyCompactSumKES _ _ vk_0 vk_1) =
-        VerKeyCompactSumKES (hashPairOfVKeys (vk_0, vk_1))
 
     -- The verification key in this scheme is actually a hash already
     -- however the type of hashVerKeyKES says the caller gets to choose
@@ -194,27 +200,7 @@ instance (OptimizedKESAlgorithm d, HashAlgorithm h, Typeable d)
     type Signable   (CompactSumKES h d) = Signable   d
     type ContextKES (CompactSumKES h d) = ContextKES d
 
-    signKES ctxt t a (SignKeyCompactSumKES sk _r_1 vk_0 vk_1) =
-        SigCompactSumKES sigma vk_other
-      where
-        (sigma, vk_other)
-          | t < _T    = (signKES ctxt  t       a sk, vk_1)
-          | otherwise = (signKES ctxt (t - _T) a sk, vk_0)
-
-        _T = totalPeriodsKES (Proxy :: Proxy d)
-
     verifyKES = verifyOptimizedKES
-
-    updateKES ctx (SignKeyCompactSumKES sk r_1 vk_0 vk_1) t
-      | t+1 <  _T = do sk' <- updateKES ctx sk t
-                       return $ SignKeyCompactSumKES sk' r_1 vk_0 vk_1
-      | t+1 == _T = do let sk' = genKeyKES r_1
-                       return $ SignKeyCompactSumKES sk' zero vk_0 vk_1
-      | otherwise = do sk' <- updateKES ctx sk (t - _T)
-                       return $ SignKeyCompactSumKES sk' r_1 vk_0 vk_1
-      where
-        _T = totalPeriodsKES (Proxy :: Proxy d)
-        zero = zeroSeed (Proxy :: Proxy d)
 
     totalPeriodsKES  _ = 2 * totalPeriodsKES (Proxy :: Proxy d)
 
@@ -224,16 +210,6 @@ instance (OptimizedKESAlgorithm d, HashAlgorithm h, Typeable d)
     --
 
     seedSizeKES _ = seedSizeKES (Proxy :: Proxy d)
-    genKeyKES r = SignKeyCompactSumKES sk_0 r1 vk_0 vk_1
-      where
-        (r0, r1) = expandSeed (Proxy :: Proxy h) r
-
-        sk_0 = genKeyKES r0
-        vk_0 = deriveVerKeyKES sk_0
-
-        sk_1 = genKeyKES r1
-        vk_1 = deriveVerKeyKES sk_1
-
 
     --
     -- raw serialise/deserialise
@@ -248,14 +224,6 @@ instance (OptimizedKESAlgorithm d, HashAlgorithm h, Typeable d)
 
     rawSerialiseVerKeyKES  (VerKeyCompactSumKES  vk) = hashToBytes vk
 
-    rawSerialiseSignKeyKES (SignKeyCompactSumKES sk r_1 vk_0 vk_1) =
-      mconcat
-        [ rawSerialiseSignKeyKES sk
-        , getSeedBytes r_1
-        , rawSerialiseVerKeyKES vk_0
-        , rawSerialiseVerKeyKES vk_1
-        ]
-
     rawSerialiseSigKES (SigCompactSumKES sigma vk_other) =
       mconcat
         [ rawSerialiseSigKES sigma
@@ -263,29 +231,6 @@ instance (OptimizedKESAlgorithm d, HashAlgorithm h, Typeable d)
         ]
 
     rawDeserialiseVerKeyKES = fmap VerKeyCompactSumKES  . hashFromBytes
-
-    rawDeserialiseSignKeyKES b = do
-        guard (BS.length b == fromIntegral size_total)
-        sk   <- rawDeserialiseSignKeyKES b_sk
-        let r = mkSeedFromBytes          b_r
-        vk_0 <- rawDeserialiseVerKeyKES  b_vk0
-        vk_1 <- rawDeserialiseVerKeyKES  b_vk1
-        return (SignKeyCompactSumKES sk r vk_0 vk_1)
-      where
-        b_sk  = slice off_sk  size_sk b
-        b_r   = slice off_r   size_r  b
-        b_vk0 = slice off_vk0 size_vk b
-        b_vk1 = slice off_vk1 size_vk b
-
-        size_sk    = sizeSignKeyKES (Proxy :: Proxy d)
-        size_r     = seedSizeKES    (Proxy :: Proxy d)
-        size_vk    = sizeVerKeyKES  (Proxy :: Proxy d)
-        size_total = sizeSignKeyKES (Proxy :: Proxy (CompactSumKES h d))
-
-        off_sk     = 0 :: Word
-        off_r      = size_sk
-        off_vk0    = off_r + size_r
-        off_vk1    = off_vk0 + size_vk
 
     rawDeserialiseSigKES b = do
         guard (BS.length b == fromIntegral size_total)
@@ -303,7 +248,114 @@ instance (OptimizedKESAlgorithm d, HashAlgorithm h, Typeable d)
         off_sig    = 0 :: Word
         off_vk     = size_sig
 
-instance (KESAlgorithm (CompactSumKES h d), OptimizedKESAlgorithm d, HashAlgorithm h) => OptimizedKESAlgorithm (CompactSumKES h d) where
+instance ( OptimizedKESAlgorithm d
+         , KESSignAlgorithm m d
+         , NaCl.SodiumHashAlgorithm h -- needed for secure forgetting
+         , Typeable d
+         , SizeHash h ~ SeedSizeKES d -- can be relaxed
+         , NaCl.MonadSodium m
+         , NoThunks (VerKeyKES (CompactSumKES h d))
+         )
+      => KESSignAlgorithm m (CompactSumKES h d) where
+
+    deriveVerKeyKES (SignKeyCompactSumKES _ _ vk_0 vk_1) =
+        return $ VerKeyCompactSumKES (hashPairOfVKeys (vk_0, vk_1))
+
+    signKES ctxt t a (SignKeyCompactSumKES sk _r_1 vk_0 vk_1) = do
+        sigma <- getSigma
+        return $ SigCompactSumKES sigma vk_other
+      where
+        (getSigma, vk_other)
+          | t < _T    = (signKES ctxt  t       a sk, vk_1)
+          | otherwise = (signKES ctxt (t - _T) a sk, vk_0)
+
+        _T = totalPeriodsKES (Proxy :: Proxy d)
+
+    updateKES ctx (SignKeyCompactSumKES sk r_1 vk_0 vk_1) t
+      | t+1 <  _T = runMaybeT $
+                      do
+                        sk' <- MaybeT $ updateKES ctx sk t
+                        r_1' <- lift $ NaCl.mapSafePinned NaCl.mlsbCopy r_1
+                        return $ SignKeyCompactSumKES sk' r_1' vk_0 vk_1
+
+      | t+1 == _T = do
+                        sk' <- NaCl.interactSafePinned r_1 genKeyKES
+                        zero <- NaCl.makeSafePinned =<< NaCl.mlsbNew
+                        return . Just $ SignKeyCompactSumKES sk' zero vk_0 vk_1
+      | otherwise = runMaybeT $
+                      do
+                        sk' <- MaybeT $ updateKES ctx sk (t - _T)
+                        r_1' <- lift $ NaCl.mapSafePinned NaCl.mlsbCopy r_1
+                        return $ SignKeyCompactSumKES sk' r_1' vk_0 vk_1
+      where
+        _T = totalPeriodsKES (Proxy :: Proxy d)
+
+    --
+    -- Key generation
+    --
+
+    genKeyKES r = do
+      let (rr0, rr1) = NaCl.expandHash (Proxy :: Proxy h) r
+      r0 <- NaCl.makeSafePinned rr0
+      r1 <- NaCl.makeSafePinned rr1
+      sk_0 <- NaCl.interactSafePinned r0 genKeyKES
+      vk_0 <- deriveVerKeyKES sk_0
+      sk_1 <- NaCl.interactSafePinned r1 genKeyKES
+      vk_1 <- deriveVerKeyKES @m @d sk_1
+      forgetSignKeyKES sk_1
+      NaCl.releaseSafePinned r0
+      return $ SignKeyCompactSumKES sk_0 r1 vk_0 vk_1
+
+    --
+    -- forgetting
+    --
+    forgetSignKeyKES (SignKeyCompactSumKES sk_0 r1 _ _) = do
+        forgetSignKeyKES sk_0
+        NaCl.releaseSafePinned r1
+
+    --
+    -- raw serialise/deserialise
+    --
+
+    rawSerialiseSignKeyKES (SignKeyCompactSumKES sk r_1 vk_0 vk_1) = do
+      ssk <- rawSerialiseSignKeyKES sk
+      rr1 <- NaCl.interactSafePinned r_1 return
+      return $ mconcat
+                  [ ssk
+                  , NaCl.mlsbToByteString rr1
+                  , rawSerialiseVerKeyKES vk_0
+                  , rawSerialiseVerKeyKES vk_1
+                  ]
+
+    rawDeserialiseSignKeyKES b = runMaybeT $ do
+        guard (BS.length b == fromIntegral size_total)
+        sk   <- MaybeT $ rawDeserialiseSignKeyKES b_sk
+        rr <- MaybeT $ NaCl.mlsbFromByteStringCheck b_r
+        r <- MaybeT . fmap Just $ NaCl.makeSafePinned rr
+        vk_0 <- MaybeT . return $ rawDeserialiseVerKeyKES  b_vk0
+        vk_1 <- MaybeT . return $ rawDeserialiseVerKeyKES  b_vk1
+        return (SignKeyCompactSumKES sk r vk_0 vk_1)
+      where
+        b_sk  = slice off_sk  size_sk b
+        b_r   = slice off_r   size_r  b
+        b_vk0 = slice off_vk0 size_vk b
+        b_vk1 = slice off_vk1 size_vk b
+
+        size_sk    = sizeSignKeyKES (Proxy :: Proxy d)
+        size_r     = seedSizeKES    (Proxy :: Proxy d)
+        size_vk    = sizeVerKeyKES  (Proxy :: Proxy d)
+        size_total = sizeSignKeyKES (Proxy :: Proxy (CompactSumKES h d))
+
+        off_sk     = 0 :: Word
+        off_r      = size_sk
+        off_vk0    = off_r + size_r
+        off_vk1    = off_vk0 + size_vk
+
+
+
+instance (KESAlgorithm (CompactSumKES h d), OptimizedKESAlgorithm d, HashAlgorithm h) =>
+         OptimizedKESAlgorithm (CompactSumKES h d) where
+
     verifySigKES ctxt t a (SigCompactSumKES sigma _) =
       verifySigKES ctxt t' a sigma
       where
@@ -327,35 +379,43 @@ instance (KESAlgorithm (CompactSumKES h d), OptimizedKESAlgorithm d, HashAlgorit
 deriving instance HashAlgorithm h => Show (VerKeyKES (CompactSumKES h d))
 deriving instance Eq   (VerKeyKES (CompactSumKES h d))
 
-instance (KESAlgorithm d) => NoThunks (SignKeyKES (CompactSumKES h d))
-
-instance (OptimizedKESAlgorithm d, HashAlgorithm h, Typeable d)
+instance ( OptimizedKESAlgorithm d
+         , NaCl.SodiumHashAlgorithm h
+         , Typeable d
+         , SizeHash h ~ SeedSizeKES d
+         , NoThunks (VerKeyKES (CompactSumKES h d))
+         )
       => ToCBOR (VerKeyKES (CompactSumKES h d)) where
   toCBOR = encodeVerKeyKES
   encodedSizeExpr _size = encodedVerKeyKESSizeExpr
 
-instance (OptimizedKESAlgorithm d, HashAlgorithm h, Typeable d)
+instance ( OptimizedKESAlgorithm d
+         , NaCl.SodiumHashAlgorithm h
+         , Typeable d
+         , SizeHash h ~ SeedSizeKES d
+         , NoThunks (VerKeyKES (CompactSumKES h d))
+         )
       => FromCBOR (VerKeyKES (CompactSumKES h d)) where
   fromCBOR = decodeVerKeyKES
 
+instance (OptimizedKESAlgorithm d) => NoThunks (VerKeyKES  (CompactSumKES h d))
 
 --
 -- SignKey instances
 --
 
-deriving instance KESAlgorithm d => Show (SignKeyKES (CompactSumKES h d))
+instance (KESAlgorithm d) => NoThunks (SignKeyKES (CompactSumKES h d))
 
-instance (OptimizedKESAlgorithm d) => NoThunks (VerKeyKES  (CompactSumKES h d))
-
-instance (OptimizedKESAlgorithm d, HashAlgorithm h, Typeable d)
-      => ToCBOR (SignKeyKES (CompactSumKES h d)) where
-  toCBOR = encodeSignKeyKES
-  encodedSizeExpr _size = encodedSignKeyKESSizeExpr
-
-instance (OptimizedKESAlgorithm d, HashAlgorithm h, Typeable d)
-      => FromCBOR (SignKeyKES (CompactSumKES h d)) where
-  fromCBOR = decodeSignKeyKES
-
+-- deriving instance KESAlgorithm d => Show (SignKeyKES (CompactSumKES h d))
+--
+-- instance (OptimizedKESAlgorithm d, HashAlgorithm h, Typeable d)
+--       => ToCBOR (SignKeyKES (CompactSumKES h d)) where
+--   toCBOR = encodeSignKeyKES
+--   encodedSizeExpr _size = encodedSignKeyKESSizeExpr
+--
+-- instance (OptimizedKESAlgorithm d, HashAlgorithm h, Typeable d)
+--       => FromCBOR (SignKeyKES (CompactSumKES h d)) where
+--   fromCBOR = decodeSignKeyKES
 
 --
 -- Sig instances
@@ -366,11 +426,21 @@ deriving instance KESAlgorithm d => Eq   (SigKES (CompactSumKES h d))
 
 instance KESAlgorithm d => NoThunks (SigKES (CompactSumKES h d))
 
-instance (OptimizedKESAlgorithm d, HashAlgorithm h, Typeable d)
+instance ( OptimizedKESAlgorithm d
+         , NaCl.SodiumHashAlgorithm h
+         , Typeable d
+         , SizeHash h ~ SeedSizeKES d
+         , NoThunks (VerKeyKES (CompactSumKES h d))
+         )
       => ToCBOR (SigKES (CompactSumKES h d)) where
   toCBOR = encodeSigKES
   encodedSizeExpr _size = encodedSigKESSizeExpr
 
-instance (OptimizedKESAlgorithm d, HashAlgorithm h, Typeable d)
+instance ( OptimizedKESAlgorithm d
+         , NaCl.SodiumHashAlgorithm h
+         , Typeable d
+         , SizeHash h ~ SeedSizeKES d
+         , NoThunks (VerKeyKES (CompactSumKES h d))
+         )
       => FromCBOR (SigKES (CompactSumKES h d)) where
   fromCBOR = decodeSigKES

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/CompactSum.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/CompactSum.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -7,8 +8,10 @@
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NoStarIsType #-}
 
 -- | A key evolving signatures implementation.
 --
@@ -78,6 +81,7 @@ module Cardano.Crypto.KES.CompactSum (
 import           Data.Proxy (Proxy(..))
 import           Data.Typeable (Typeable)
 import           GHC.Generics (Generic)
+import           GHC.TypeLits (KnownNat, type (+), type (*))
 import qualified Data.ByteString as BS
 import           Control.Monad (guard)
 import           Control.Monad.Trans (lift)
@@ -140,6 +144,9 @@ instance ( OptimizedKESAlgorithm d
          , Typeable d
          , SizeHash h ~ SeedSizeKES d -- can be relaxed
          , NoThunks (VerKeyKES (CompactSumKES h d))
+         , KnownNat (SizeVerKeyKES (CompactSumKES h d))
+         , KnownNat (SizeSignKeyKES (CompactSumKES h d))
+         , KnownNat (SizeSigKES (CompactSumKES h d))
          )
       => KESAlgorithm (CompactSumKES h d) where
 
@@ -215,12 +222,12 @@ instance ( OptimizedKESAlgorithm d
     -- raw serialise/deserialise
     --
 
-    sizeVerKeyKES  _ = sizeHash       (Proxy :: Proxy h)
-    sizeSignKeyKES _ = sizeSignKeyKES (Proxy :: Proxy d)
-                     + seedSizeKES    (Proxy :: Proxy d)
-                     + sizeVerKeyKES  (Proxy :: Proxy d) * 2
-    sizeSigKES     _ = sizeSigKES     (Proxy :: Proxy d)
-                     + sizeVerKeyKES  (Proxy :: Proxy d)
+    type SizeVerKeyKES  _ = SizeHash       h
+    type SizeSignKeyKES _ = SizeSignKeyKES d
+                          + SeedSizeKES    d
+                          + SizeVerKeyKES  d * 2
+    type SizeSigKES     _ = SizeSigKES     d
+                          + SizeVerKeyKES  d
 
     rawSerialiseVerKeyKES  (VerKeyCompactSumKES  vk) = hashToBytes vk
 
@@ -255,6 +262,9 @@ instance ( OptimizedKESAlgorithm d
          , SizeHash h ~ SeedSizeKES d -- can be relaxed
          , NaCl.MonadSodium m
          , NoThunks (VerKeyKES (CompactSumKES h d))
+         , KnownNat (SizeVerKeyKES (CompactSumKES h d))
+         , KnownNat (SizeSignKeyKES (CompactSumKES h d))
+         , KnownNat (SizeSigKES (CompactSumKES h d))
          )
       => KESSignAlgorithm m (CompactSumKES h d) where
 
@@ -384,6 +394,9 @@ instance ( OptimizedKESAlgorithm d
          , Typeable d
          , SizeHash h ~ SeedSizeKES d
          , NoThunks (VerKeyKES (CompactSumKES h d))
+         , KnownNat (SizeVerKeyKES (CompactSumKES h d))
+         , KnownNat (SizeSignKeyKES (CompactSumKES h d))
+         , KnownNat (SizeSigKES (CompactSumKES h d))
          )
       => ToCBOR (VerKeyKES (CompactSumKES h d)) where
   toCBOR = encodeVerKeyKES
@@ -394,6 +407,9 @@ instance ( OptimizedKESAlgorithm d
          , Typeable d
          , SizeHash h ~ SeedSizeKES d
          , NoThunks (VerKeyKES (CompactSumKES h d))
+         , KnownNat (SizeVerKeyKES (CompactSumKES h d))
+         , KnownNat (SizeSignKeyKES (CompactSumKES h d))
+         , KnownNat (SizeSigKES (CompactSumKES h d))
          )
       => FromCBOR (VerKeyKES (CompactSumKES h d)) where
   fromCBOR = decodeVerKeyKES
@@ -431,6 +447,9 @@ instance ( OptimizedKESAlgorithm d
          , Typeable d
          , SizeHash h ~ SeedSizeKES d
          , NoThunks (VerKeyKES (CompactSumKES h d))
+         , KnownNat (SizeVerKeyKES (CompactSumKES h d))
+         , KnownNat (SizeSignKeyKES (CompactSumKES h d))
+         , KnownNat (SizeSigKES (CompactSumKES h d))
          )
       => ToCBOR (SigKES (CompactSumKES h d)) where
   toCBOR = encodeSigKES
@@ -441,6 +460,9 @@ instance ( OptimizedKESAlgorithm d
          , Typeable d
          , SizeHash h ~ SeedSizeKES d
          , NoThunks (VerKeyKES (CompactSumKES h d))
+         , KnownNat (SizeVerKeyKES (CompactSumKES h d))
+         , KnownNat (SizeSignKeyKES (CompactSumKES h d))
+         , KnownNat (SizeSigKES (CompactSumKES h d))
          )
       => FromCBOR (SigKES (CompactSumKES h d)) where
   fromCBOR = decodeSigKES

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/CompactSum.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/CompactSum.hs
@@ -305,7 +305,7 @@ instance ( OptimizedKESAlgorithm d
     --
 
     genKeyKES r = do
-      let (rr0, rr1) = NaCl.expandHash (Proxy :: Proxy h) r
+      (rr0, rr1) <- NaCl.expandHash (Proxy :: Proxy h) r
       r0 <- NaCl.makeSafePinned rr0
       r1 <- NaCl.makeSafePinned rr1
       sk_0 <- NaCl.interactSafePinned r0 genKeyKES

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/ForgetMock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/ForgetMock.hs
@@ -1,0 +1,132 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+
+-- | Mock key evolving signatures.
+module Cardano.Crypto.KES.ForgetMock
+  ( ForgetMockKES
+  , VerKeyKES (..)
+  , SignKeyKES (..)
+  , SigKES (..)
+  )
+where
+
+import Data.Proxy (Proxy(..))
+import GHC.Generics (Generic)
+
+import Cardano.Prelude (lift, MonadIO, liftIO, ReaderT (..), ask)
+
+import Cardano.Crypto.KES.Class
+import NoThunks.Class (NoThunks)
+import System.Random (randomRIO)
+
+-- | A wrapper for a KES implementation that adds logging functionality, for
+-- the purpose of verifying that invocations of 'genKeyKES' and
+-- 'forgetSignKeyKES' pair up properly in a given host application.
+--
+-- The wrapped KES behaves exactly like its unwrapped payload, except that
+-- invocations of 'genKeyKES', 'updateKES' and 'forgetSignKeyKES' are logged
+-- to the eventlog (via 'traceEvent'), prefixed with @"PRE: "@, @"UPD: "@,
+-- or @"DEL: "@, respectively.
+data ForgetMockKES k
+
+type Logger = String -> IO ()
+
+instance
+  ( KESAlgorithm k
+  )
+  => KESAlgorithm (ForgetMockKES k) where
+    type SeedSizeKES (ForgetMockKES k) = SeedSizeKES k
+    type Signable (ForgetMockKES k) = Signable k
+
+    newtype VerKeyKES (ForgetMockKES k) = VerKeyForgetMockKES (VerKeyKES k)
+      deriving (Generic)
+    data SignKeyKES (ForgetMockKES k) = SignKeyForgetMockKES !Word !(SignKeyKES k)
+      deriving (Generic)
+    newtype SigKES (ForgetMockKES k) = SigForgetMockKES (SigKES k)
+      deriving (Generic)
+
+    type ContextKES (ForgetMockKES k) = ContextKES k
+
+    algorithmNameKES _ = algorithmNameKES (Proxy @k)
+
+    verifyKES ctx (VerKeyForgetMockKES vk) p msg (SigForgetMockKES sig) =
+        verifyKES ctx vk p msg sig
+
+    totalPeriodsKES _ = totalPeriodsKES (Proxy @k)
+
+    sizeVerKeyKES _ = sizeVerKeyKES (Proxy @k)
+    sizeSignKeyKES _ = sizeSignKeyKES (Proxy @k)
+    sizeSigKES _ = sizeSigKES (Proxy @k)
+
+    rawSerialiseVerKeyKES (VerKeyForgetMockKES k) = rawSerialiseVerKeyKES k
+    rawSerialiseSigKES (SigForgetMockKES k) = rawSerialiseSigKES k
+
+    rawDeserialiseVerKeyKES = fmap VerKeyForgetMockKES . rawDeserialiseVerKeyKES
+    rawDeserialiseSigKES = fmap SigForgetMockKES . rawDeserialiseSigKES
+
+
+instance
+  ( KESSignAlgorithm m k
+  , MonadIO m
+  )
+  => KESSignAlgorithm (ReaderT Logger m) (ForgetMockKES k) where
+    genKeyKES seed = do
+      sk <- lift (genKeyKES seed)
+      nonce <- liftIO $ randomRIO (10000000, 99999999)
+      writeLog <- ask
+      liftIO $ writeLog ("GEN: " ++ show nonce)
+      return (SignKeyForgetMockKES nonce sk)
+
+    forgetSignKeyKES (SignKeyForgetMockKES nonce _) = do
+      writeLog <- ask
+      liftIO $ writeLog ("DEL: " ++ show nonce)
+      return ()
+
+    deriveVerKeyKES (SignKeyForgetMockKES _ k) =
+      VerKeyForgetMockKES <$> lift (deriveVerKeyKES k)
+
+    signKES ctx p msg (SignKeyForgetMockKES _ sk) =
+        SigForgetMockKES <$> lift (signKES ctx p msg sk)
+
+    updateKES ctx (SignKeyForgetMockKES nonce sk) p = do
+      writeLog <- ask
+      nonce' <- liftIO $ randomRIO (10000000, 99999999)
+      lift (updateKES ctx sk p) >>= \case
+        Just sk' -> do
+          liftIO $ writeLog ("UPD: " ++ show nonce ++ "->" ++ show nonce')
+          return $ Just $ SignKeyForgetMockKES nonce' sk'
+        Nothing -> do
+          liftIO $ writeLog ("UPD: ---")
+          return Nothing
+
+    rawSerialiseSignKeyKES (SignKeyForgetMockKES _ k) = lift $ rawSerialiseSignKeyKES k
+
+    rawDeserialiseSignKeyKES bs = do
+      msk <- lift $ rawDeserialiseSignKeyKES bs
+      nonce :: Word <- liftIO $ randomRIO (10000000, 99999999)
+      return $ fmap (SignKeyForgetMockKES nonce) msk
+
+
+deriving instance Show (VerKeyKES k) => Show (VerKeyKES (ForgetMockKES k))
+deriving instance Eq (VerKeyKES k) => Eq (VerKeyKES (ForgetMockKES k))
+deriving instance Ord (VerKeyKES k) => Ord (VerKeyKES (ForgetMockKES k))
+deriving instance NoThunks (VerKeyKES k) => NoThunks (VerKeyKES (ForgetMockKES k))
+
+deriving instance Eq (SignKeyKES k) => Eq (SignKeyKES (ForgetMockKES k))
+instance NoThunks (SignKeyKES k) => NoThunks (SignKeyKES (ForgetMockKES k)) where
+
+deriving instance Show (SigKES k) => Show (SigKES (ForgetMockKES k))
+deriving instance Eq (SigKES k) => Eq (SigKES (ForgetMockKES k))
+deriving instance Ord (SigKES k) => Ord (SigKES (ForgetMockKES k))
+deriving instance NoThunks (SigKES k) => NoThunks (SigKES (ForgetMockKES k))

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/ForgetMock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/ForgetMock.hs
@@ -65,9 +65,9 @@ instance
 
     totalPeriodsKES _ = totalPeriodsKES (Proxy @k)
 
-    sizeVerKeyKES _ = sizeVerKeyKES (Proxy @k)
-    sizeSignKeyKES _ = sizeSignKeyKES (Proxy @k)
-    sizeSigKES _ = sizeSigKES (Proxy @k)
+    type SizeVerKeyKES (ForgetMockKES k) = SizeVerKeyKES k
+    type SizeSignKeyKES (ForgetMockKES k) = SizeSignKeyKES k
+    type SizeSigKES (ForgetMockKES k) = SizeSigKES k
 
     rawSerialiseVerKeyKES (VerKeyForgetMockKES k) = rawSerialiseVerKeyKES k
     rawSerialiseSigKES (SigForgetMockKES k) = rawSerialiseSigKES k

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/ForgetMock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/ForgetMock.hs
@@ -110,10 +110,11 @@ instance
           liftIO $ writeLog ("UPD: ---")
           return Nothing
 
-    rawSerialiseSignKeyKES (SignKeyForgetMockKES _ k) = lift $ rawSerialiseSignKeyKES k
+    rawSerialiseSignKeyKES (SignKeyForgetMockKES _ sk) target offset =
+      lift $ rawSerialiseSignKeyKES sk target offset
 
-    rawDeserialiseSignKeyKES bs = do
-      msk <- lift $ rawDeserialiseSignKeyKES bs
+    rawDeserialiseSignKeyKES src offset = do
+      msk <- lift $ rawDeserialiseSignKeyKES src offset
       nonce :: Word <- liftIO $ randomRIO (10000000, 99999999)
       return $ fmap (SignKeyForgetMockKES nonce) msk
 

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Mock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Mock.hs
@@ -74,9 +74,9 @@ instance KnownNat t => KESAlgorithm (MockKES t) where
 
     algorithmNameKES proxy = "mock_" ++ show (totalPeriodsKES proxy)
 
-    sizeVerKeyKES  _ = 8
-    sizeSignKeyKES _ = 16
-    sizeSigKES     _ = 24
+    type SizeVerKeyKES  (MockKES t) = 8
+    type SizeSignKeyKES (MockKES t) = 16
+    type SizeSigKES     (MockKES t) = 24
 
 
     --

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Mock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Mock.hs
@@ -148,7 +148,7 @@ instance (Monad m, KnownNat t) => KESSignAlgorithm m (MockKES t) where
 
     genKeyKES seed = do
         let vk = VerKeyMockKES (runMonadRandomWithSeed (mkSeedFromBytes $ mlsbToByteString seed) getRandomWord64)
-        return $ SignKeyMockKES vk 0
+        return $! SignKeyMockKES vk 0
 
     rawSerialiseSignKeyKES sk =
       return $ rawSerialiseSignKeyMockKES sk

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/NeverUsed.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/NeverUsed.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 module Cardano.Crypto.KES.NeverUsed
   ( NeverKES
   , VerKeyKES (..)
@@ -37,25 +38,27 @@ instance KESAlgorithm NeverKES where
 
   algorithmNameKES _ = "never"
 
-  deriveVerKeyKES _ = NeverUsedVerKeyKES
-
-  signKES   = error "KES not available"
   verifyKES = error "KES not available"
-  updateKES = error "KES not available"
 
   totalPeriodsKES _ = 0
-
-  genKeyKES       _ = NeverUsedSignKeyKES
 
   sizeVerKeyKES  _ = 0
   sizeSignKeyKES _ = 0
   sizeSigKES     _ = 0
 
   rawSerialiseVerKeyKES  _ = mempty
-  rawSerialiseSignKeyKES _ = mempty
   rawSerialiseSigKES     _ = mempty
 
   rawDeserialiseVerKeyKES  _ = Just NeverUsedVerKeyKES
-  rawDeserialiseSignKeyKES _ = Just NeverUsedSignKeyKES
   rawDeserialiseSigKES     _ = Just NeverUsedSigKES
 
+instance Monad m => KESSignAlgorithm m NeverKES where
+  deriveVerKeyKES _ = return NeverUsedVerKeyKES
+
+  signKES   = error "KES not available"
+  updateKES = error "KES not available"
+
+  genKeyKES       _ = return NeverUsedSignKeyKES
+
+  rawSerialiseSignKeyKES _ = return mempty
+  rawDeserialiseSignKeyKES _ = return $ Just NeverUsedSignKeyKES

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/NeverUsed.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/NeverUsed.hs
@@ -42,9 +42,9 @@ instance KESAlgorithm NeverKES where
 
   totalPeriodsKES _ = 0
 
-  sizeVerKeyKES  _ = 0
-  sizeSignKeyKES _ = 0
-  sizeSigKES     _ = 0
+  type SizeVerKeyKES  NeverKES = 0
+  type SizeSignKeyKES NeverKES = 0
+  type SizeSigKES     NeverKES = 0
 
   rawSerialiseVerKeyKES  _ = mempty
   rawSerialiseSigKES     _ = mempty

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/NeverUsed.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/NeverUsed.hs
@@ -60,5 +60,5 @@ instance Monad m => KESSignAlgorithm m NeverKES where
 
   genKeyKES       _ = return NeverUsedSignKeyKES
 
-  rawSerialiseSignKeyKES _ = return mempty
-  rawDeserialiseSignKeyKES _ = return $ Just NeverUsedSignKeyKES
+  rawSerialiseSignKeyKES _ _ = error "KES not available"
+  rawDeserialiseSignKeyKES _ _ = return $ Just NeverUsedSignKeyKES

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Simple.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Simple.hs
@@ -159,7 +159,7 @@ instance ( KESAlgorithm (SimpleKES d t)
          KESSignAlgorithm m (SimpleKES d t) where
 
     deriveVerKeyKES (SignKeySimpleKES sks) =
-        return $ VerKeySimpleKES (Vec.map deriveVerKeyDSIGN sks)
+        return $! VerKeySimpleKES (Vec.map deriveVerKeyDSIGN sks)
 
 
     signKES ctxt j a (SignKeySimpleKES sks) =
@@ -184,7 +184,7 @@ instance ( KESAlgorithm (SimpleKES d t)
                      . map mkSeedFromBytes
                      $ unfoldr (getBytesFromSeed seedSize) seed
             sks      = map genKeyDSIGN seeds
-         in return $ SignKeySimpleKES (Vec.fromList sks)
+         in return $! SignKeySimpleKES (Vec.fromList sks)
 
 
     --

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Simple.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Simple.hs
@@ -66,8 +66,14 @@ pattern SignKeySimpleKES v <- ThunkySignKeySimpleKES v
 
 {-# COMPLETE SignKeySimpleKES #-}
 
-instance (DSIGNAlgorithm d, Typeable d, KnownNat t, KnownNat (SeedSizeDSIGN d * t)) =>
-         KESAlgorithm (SimpleKES d t) where
+instance ( DSIGNAlgorithm d
+         , Typeable d
+         , KnownNat t
+         , KnownNat (SeedSizeDSIGN d * t)
+         , KnownNat (SizeVerKeyDSIGN d * t)
+         , KnownNat (SizeSignKeyDSIGN d * t)
+         )
+         => KESAlgorithm (SimpleKES d t) where
 
     type SeedSizeKES (SimpleKES d t) = SeedSizeDSIGN d * t
 
@@ -121,15 +127,9 @@ instance (DSIGNAlgorithm d, Typeable d, KnownNat t, KnownNat (SeedSizeDSIGN d * 
     -- raw serialise/deserialise
     --
 
-    sizeVerKeyKES  _ = sizeVerKeyDSIGN  (Proxy :: Proxy d) * duration
-      where
-        duration = fromIntegral (natVal (Proxy @t))
-
-    sizeSignKeyKES _ = sizeSignKeyDSIGN (Proxy :: Proxy d) * duration
-      where
-        duration = fromIntegral (natVal (Proxy @t))
-
-    sizeSigKES     _ = sizeSigDSIGN     (Proxy :: Proxy d)
+    type SizeVerKeyKES  (SimpleKES d t) = SizeVerKeyDSIGN d * t
+    type SizeSignKeyKES (SimpleKES d t) = SizeSignKeyDSIGN d * t
+    type SizeSigKES     (SimpleKES d t) = SizeSigDSIGN d
 
     rawSerialiseVerKeyKES (VerKeySimpleKES vks) =
         BS.concat [ rawSerialiseVerKeyDSIGN vk | vk <- Vec.toList vks ]
@@ -153,7 +153,12 @@ instance (DSIGNAlgorithm d, Typeable d, KnownNat t, KnownNat (SeedSizeDSIGN d * 
 
 
 instance ( KESAlgorithm (SimpleKES d t)
-         , DSIGNAlgorithm d, Typeable d, KnownNat t, KnownNat (SeedSizeDSIGN d * t)
+         , DSIGNAlgorithm d
+         , Typeable d
+         , KnownNat t
+         , KnownNat (SeedSizeDSIGN d * t)
+         , KnownNat (SizeVerKeyDSIGN d * t)
+         , KnownNat (SizeSignKeyDSIGN d * t)
          , Monad m
          ) =>
          KESSignAlgorithm m (SimpleKES d t) where
@@ -218,21 +223,45 @@ instance DSIGNAlgorithm d => NoThunks (SigKES     (SimpleKES d t))
 instance DSIGNAlgorithm d => NoThunks (SignKeyKES (SimpleKES d t))
 instance DSIGNAlgorithm d => NoThunks (VerKeyKES  (SimpleKES d t))
 
-instance (DSIGNAlgorithm d, Typeable d, KnownNat t, KnownNat (SeedSizeDSIGN d * t))
+instance ( DSIGNAlgorithm d
+         , Typeable d
+         , KnownNat t
+         , KnownNat (SeedSizeDSIGN d * t)
+         , KnownNat (SizeVerKeyDSIGN d * t)
+         , KnownNat (SizeSignKeyDSIGN d * t)
+         )
       => ToCBOR (VerKeyKES (SimpleKES d t)) where
   toCBOR = encodeVerKeyKES
   encodedSizeExpr _size = encodedVerKeyKESSizeExpr
 
-instance (DSIGNAlgorithm d, Typeable d, KnownNat t, KnownNat (SeedSizeDSIGN d * t))
+instance ( DSIGNAlgorithm d
+         , Typeable d
+         , KnownNat t
+         , KnownNat (SeedSizeDSIGN d * t)
+         , KnownNat (SizeVerKeyDSIGN d * t)
+         , KnownNat (SizeSignKeyDSIGN d * t)
+         )
       => FromCBOR (VerKeyKES (SimpleKES d t)) where
   fromCBOR = decodeVerKeyKES
 
-instance (DSIGNAlgorithm d, Typeable d, KnownNat t, KnownNat (SeedSizeDSIGN d * t))
+instance ( DSIGNAlgorithm d
+         , Typeable d
+         , KnownNat t
+         , KnownNat (SeedSizeDSIGN d * t)
+         , KnownNat (SizeVerKeyDSIGN d * t)
+         , KnownNat (SizeSignKeyDSIGN d * t)
+         )
       => ToCBOR (SigKES (SimpleKES d t)) where
   toCBOR = encodeSigKES
   encodedSizeExpr _size = encodedSigKESSizeExpr
 
-instance (DSIGNAlgorithm d, Typeable d, KnownNat t, KnownNat (SeedSizeDSIGN d * t))
+instance (DSIGNAlgorithm d
+         , Typeable d
+         , KnownNat t
+         , KnownNat (SeedSizeDSIGN d * t)
+         , KnownNat (SizeVerKeyDSIGN d * t)
+         , KnownNat (SizeSignKeyDSIGN d * t)
+         )
       => FromCBOR (SigKES (SimpleKES d t)) where
   fromCBOR = decodeSigKES
 

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Single.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Single.hs
@@ -143,8 +143,8 @@ instance ( DSIGNMAlgorithm m d -- needed for secure forgetting
     rawSerialiseSignKeyKES (SignKeySingleKES sk) =
       rawSerialiseSignKeyDSIGNM sk
 
-    rawDeserialiseSignKeyKES bs =
-      fmap SignKeySingleKES <$> rawDeserialiseSignKeyDSIGNM bs
+    rawDeserialiseSignKeyKES mlsb p =
+      fmap SignKeySingleKES <$> rawDeserialiseSignKeyDSIGNM mlsb p
 
 --
 -- VerKey instances

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Single.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Single.hs
@@ -98,9 +98,9 @@ instance (DSIGNMAlgorithmBase d, Typeable d) => KESAlgorithm (SingleKES d) where
     -- raw serialise/deserialise
     --
 
-    sizeVerKeyKES  _ = sizeVerKeyDSIGNM  (Proxy :: Proxy d)
-    sizeSignKeyKES _ = sizeSignKeyDSIGNM (Proxy :: Proxy d)
-    sizeSigKES     _ = sizeSigDSIGNM     (Proxy :: Proxy d)
+    type SizeVerKeyKES (SingleKES d) = SizeVerKeyDSIGNM d
+    type SizeSignKeyKES (SingleKES d) = SizeSignKeyDSIGNM d
+    type SizeSigKES (SingleKES d) = SizeSigDSIGNM d
 
     hashVerKeyKES (VerKeySingleKES vk) =
         castHash (hashVerKeyDSIGNM vk)

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Single.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Single.hs
@@ -4,8 +4,10 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
 
@@ -25,7 +27,7 @@
 -- > as forward-seure signature schemes with one time period, namely T = 1.
 --
 -- So this module simply provides a wrapper 'SingleKES' that turns any
--- 'DSIGNAlgorithm' into an instance of 'KESAlgorithm' with a single period.
+-- 'DSIGNMAlgorithm' into an instance of 'KESAlgorithm' with a single period.
 --
 -- See "Cardano.Crypto.KES.Sum" for the composition case.
 --
@@ -42,14 +44,13 @@ import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks)
 
 import Control.Exception (assert)
+import Control.DeepSeq (NFData)
 
 import Cardano.Binary (FromCBOR (..), ToCBOR (..))
 
 import Cardano.Crypto.Hash.Class
-import Cardano.Crypto.DSIGN.Class
-import qualified Cardano.Crypto.DSIGN as DSIGN
+import Cardano.Crypto.DSIGNM.Class as DSIGNM
 import Cardano.Crypto.KES.Class
-import Control.DeepSeq (NFData)
 
 
 -- | A standard signature scheme is a forward-secure signature scheme with a
@@ -57,129 +58,131 @@ import Control.DeepSeq (NFData)
 --
 data SingleKES d
 
-deriving instance NFData (VerKeyDSIGN d) => NFData (VerKeyKES (SingleKES d))
-deriving instance NFData (SignKeyDSIGN d) => NFData (SignKeyKES (SingleKES d))
-deriving instance NFData (SigDSIGN d) => NFData (SigKES (SingleKES d))
+deriving instance NFData (VerKeyDSIGNM d) => NFData (VerKeyKES (SingleKES d))
+deriving instance NFData (SignKeyDSIGNM d) => NFData (SignKeyKES (SingleKES d))
+deriving instance NFData (SigDSIGNM d) => NFData (SigKES (SingleKES d))
 
-instance (DSIGNAlgorithm d, Typeable d) => KESAlgorithm (SingleKES d) where
-    type SeedSizeKES (SingleKES d) = SeedSizeDSIGN d
+instance (DSIGNMAlgorithmBase d, Typeable d) => KESAlgorithm (SingleKES d) where
+    type SeedSizeKES (SingleKES d) = SeedSizeDSIGNM d
 
     --
     -- Key and signature types
     --
 
-    newtype VerKeyKES (SingleKES d) = VerKeySingleKES (VerKeyDSIGN d)
+    newtype VerKeyKES (SingleKES d) = VerKeySingleKES (VerKeyDSIGNM d)
         deriving Generic
 
-    newtype SignKeyKES (SingleKES d) = SignKeySingleKES (SignKeyDSIGN d)
+    newtype SignKeyKES (SingleKES d) = SignKeySingleKES (SignKeyDSIGNM d)
         deriving Generic
 
-    newtype SigKES (SingleKES d) = SigSingleKES (SigDSIGN d)
+    newtype SigKES (SingleKES d) = SigSingleKES (SigDSIGNM d)
         deriving Generic
+
+    type ContextKES (SingleKES d) = ContextDSIGNM d
+    type Signable   (SingleKES d) = DSIGNM.SignableM     d
 
 
     --
     -- Metadata and basic key operations
     --
 
-    algorithmNameKES _ = algorithmNameDSIGN (Proxy :: Proxy d) ++ "_kes_2^0"
-
-    deriveVerKeyKES (SignKeySingleKES sk) =
-        VerKeySingleKES (deriveVerKeyDSIGN sk)
-
-    hashVerKeyKES (VerKeySingleKES vk) =
-        castHash (hashVerKeyDSIGN vk)
-
-
-    --
-    -- Core algorithm operations
-    --
-
-    type ContextKES (SingleKES d) = DSIGN.ContextDSIGN d
-    type Signable   (SingleKES d) = DSIGN.Signable     d
-
-    signKES ctxt t a (SignKeySingleKES sk) =
-        assert (t == 0) $
-        SigSingleKES (signDSIGN ctxt a sk)
-
-    verifyKES ctxt (VerKeySingleKES vk) t a (SigSingleKES sig) =
-        assert (t == 0) $
-        verifyDSIGN ctxt vk a sig
-
-    updateKES _ctx (SignKeySingleKES _sk) _to = Nothing
+    algorithmNameKES _ = algorithmNameDSIGNM (Proxy :: Proxy d) ++ "_kes_2^0"
 
     totalPeriodsKES  _ = 1
 
-    --
-    -- Key generation
-    --
-
-    seedSizeKES _ = seedSizeDSIGN (Proxy :: Proxy d)
-    genKeyKES seed = SignKeySingleKES (genKeyDSIGN seed)
-
+    verifyKES ctxt (VerKeySingleKES vk) t a (SigSingleKES sig) =
+        assert (t == 0) $
+        verifyDSIGNM ctxt vk a sig
 
     --
     -- raw serialise/deserialise
     --
 
-    sizeVerKeyKES  _ = sizeVerKeyDSIGN  (Proxy :: Proxy d)
-    sizeSignKeyKES _ = sizeSignKeyDSIGN (Proxy :: Proxy d)
-    sizeSigKES     _ = sizeSigDSIGN     (Proxy :: Proxy d)
+    sizeVerKeyKES  _ = sizeVerKeyDSIGNM  (Proxy :: Proxy d)
+    sizeSignKeyKES _ = sizeSignKeyDSIGNM (Proxy :: Proxy d)
+    sizeSigKES     _ = sizeSigDSIGNM     (Proxy :: Proxy d)
 
-    rawSerialiseVerKeyKES  (VerKeySingleKES  vk) = rawSerialiseVerKeyDSIGN vk
-    rawSerialiseSignKeyKES (SignKeySingleKES sk) = rawSerialiseSignKeyDSIGN sk
-    rawSerialiseSigKES     (SigSingleKES    sig) = rawSerialiseSigDSIGN sig
+    hashVerKeyKES (VerKeySingleKES vk) =
+        castHash (hashVerKeyDSIGNM vk)
 
-    rawDeserialiseVerKeyKES  = fmap VerKeySingleKES  . rawDeserialiseVerKeyDSIGN
-    rawDeserialiseSignKeyKES = fmap SignKeySingleKES . rawDeserialiseSignKeyDSIGN
-    rawDeserialiseSigKES     = fmap SigSingleKES     . rawDeserialiseSigDSIGN
+    rawSerialiseVerKeyKES  (VerKeySingleKES  vk) = rawSerialiseVerKeyDSIGNM vk
+    rawSerialiseSigKES     (SigSingleKES    sig) = rawSerialiseSigDSIGNM sig
 
+    rawDeserialiseVerKeyKES  = fmap VerKeySingleKES  . rawDeserialiseVerKeyDSIGNM
+    rawDeserialiseSigKES     = fmap SigSingleKES     . rawDeserialiseSigDSIGNM
+
+
+instance ( DSIGNMAlgorithm m d -- needed for secure forgetting
+         , Monad m
+         , Typeable d) => KESSignAlgorithm m (SingleKES d) where
+    deriveVerKeyKES (SignKeySingleKES v) =
+      VerKeySingleKES <$> deriveVerKeyDSIGNM v
+
+    --
+    -- Core algorithm operations
+    --
+
+    signKES ctxt t a (SignKeySingleKES sk) =
+        assert (t == 0) $
+        SigSingleKES <$> signDSIGNM ctxt a sk
+
+    updateKES _ctx (SignKeySingleKES _sk) _to = return Nothing
+
+    --
+    -- Key generation
+    --
+
+    genKeyKES seed = SignKeySingleKES <$> genKeyDSIGNM seed
+
+    --
+    -- forgetting
+    --
+    forgetSignKeyKES (SignKeySingleKES v) =
+      forgetSignKeyDSIGNM v
+
+    rawSerialiseSignKeyKES (SignKeySingleKES sk) =
+      rawSerialiseSignKeyDSIGNM sk
+
+    rawDeserialiseSignKeyKES bs =
+      fmap SignKeySingleKES <$> rawDeserialiseSignKeyDSIGNM bs
 
 --
 -- VerKey instances
 --
 
-deriving instance DSIGNAlgorithm d => Show (VerKeyKES (SingleKES d))
-deriving instance DSIGNAlgorithm d => Eq   (VerKeyKES (SingleKES d))
+deriving instance DSIGNMAlgorithmBase d => Show (VerKeyKES (SingleKES d))
+deriving instance DSIGNMAlgorithmBase d => Eq   (VerKeyKES (SingleKES d))
 
-instance DSIGNAlgorithm d => NoThunks (SignKeyKES (SingleKES d))
-
-instance DSIGNAlgorithm d => ToCBOR (VerKeyKES (SingleKES d)) where
+instance DSIGNMAlgorithmBase d => ToCBOR (VerKeyKES (SingleKES d)) where
   toCBOR = encodeVerKeyKES
   encodedSizeExpr _size = encodedVerKeyKESSizeExpr
 
-instance DSIGNAlgorithm d => FromCBOR (VerKeyKES (SingleKES d)) where
+instance DSIGNMAlgorithmBase d => FromCBOR (VerKeyKES (SingleKES d)) where
   fromCBOR = decodeVerKeyKES
+
+instance DSIGNMAlgorithmBase d => NoThunks (VerKeyKES  (SingleKES d))
 
 
 --
 -- SignKey instances
 --
 
-deriving instance DSIGNAlgorithm d => Show (SignKeyKES (SingleKES d))
+instance DSIGNMAlgorithmBase d => NoThunks (SignKeyKES (SingleKES d))
 
-instance DSIGNAlgorithm d => NoThunks (VerKeyKES  (SingleKES d))
-
-instance DSIGNAlgorithm d => ToCBOR (SignKeyKES (SingleKES d)) where
-  toCBOR = encodeSignKeyKES
-  encodedSizeExpr _size = encodedSignKeyKESSizeExpr
-
-instance DSIGNAlgorithm d => FromCBOR (SignKeyKES (SingleKES d)) where
-  fromCBOR = decodeSignKeyKES
-
+-- deriving instance DSIGNMAlgorithmBase d => Show (SignKeyKES (SingleKES d))
 
 --
 -- Sig instances
 --
 
-deriving instance DSIGNAlgorithm d => Show (SigKES (SingleKES d))
-deriving instance DSIGNAlgorithm d => Eq   (SigKES (SingleKES d))
+deriving instance DSIGNMAlgorithmBase d => Show (SigKES (SingleKES d))
+deriving instance DSIGNMAlgorithmBase d => Eq   (SigKES (SingleKES d))
 
-instance DSIGNAlgorithm d => NoThunks (SigKES (SingleKES d))
+instance DSIGNMAlgorithmBase d => NoThunks (SigKES (SingleKES d))
 
-instance DSIGNAlgorithm d => ToCBOR (SigKES (SingleKES d)) where
+instance DSIGNMAlgorithmBase d => ToCBOR (SigKES (SingleKES d)) where
   toCBOR = encodeSigKES
   encodedSizeExpr _size = encodedSigKESSizeExpr
 
-instance DSIGNAlgorithm d => FromCBOR (SigKES (SingleKES d)) where
+instance DSIGNMAlgorithmBase d => FromCBOR (SigKES (SingleKES d)) where
   fromCBOR = decodeSigKES

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Sum.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Sum.hs
@@ -267,7 +267,7 @@ instance ( KESSignAlgorithm m d
     --
 
     genKeyKES r = do
-      let (rr0, rr1) = NaCl.expandHash (Proxy :: Proxy h) r
+      (rr0, rr1) <- NaCl.expandHash (Proxy :: Proxy h) r
       r0 <- NaCl.makeSafePinned rr0
       r1 <- NaCl.makeSafePinned rr1
       sk_0 <- NaCl.interactSafePinned r0 genKeyKES

--- a/cardano-crypto-class/src/Cardano/Crypto/Libsodium.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Libsodium.hs
@@ -9,11 +9,11 @@ module Cardano.Crypto.Libsodium (
   traceMLockedForeignPtr,
   -- * MLocked bytes
   MLockedSizedBytes,
-  mlsbZero,
   mlsbFromByteString,
   mlsbFromByteStringCheck,
   mlsbToByteString,
   mlsbFinalize,
+  mlsbCopy,
   -- * Hashing
   SodiumHashAlgorithm (..),
   digestMLockedStorable,

--- a/cardano-crypto-class/src/Cardano/Crypto/Libsodium.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Libsodium.hs
@@ -12,6 +12,7 @@ module Cardano.Crypto.Libsodium (
   mlsbFromByteString,
   mlsbFromByteStringCheck,
   mlsbToByteString,
+  mlsbAsByteString,
   mlsbFinalize,
   mlsbCopy,
   -- * Hashing

--- a/cardano-crypto-class/src/Cardano/Crypto/Libsodium/C.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Libsodium/C.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE CApiFFI             #-}
 {-# LANGUAGE DerivingStrategies  #-}
-
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Cardano.Crypto.Libsodium.C (
     -- * Initialization
     c_sodium_init,

--- a/cardano-crypto-class/src/Cardano/Crypto/Libsodium/C.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Libsodium/C.hs
@@ -13,6 +13,10 @@ module Cardano.Crypto.Libsodium.C (
     c_mlocked_pool_malloc,
     c_mlocked_pool_free,
 
+    -- * Mlocked direct fd I/O
+    c_mlocked_fd_read,
+    c_mlocked_fd_write,
+
     -- * Hashing
     -- ** SHA256
     c_crypto_hash_sha256,
@@ -93,6 +97,13 @@ foreign import ccall unsafe "mlocked_pool_malloc" c_mlocked_pool_malloc :: CSize
 
 -- | @void mlocked_pool_free(void *ptr);@
 foreign import ccall unsafe "mlocked_pool_free" c_mlocked_pool_free :: (Ptr a) -> IO ()
+
+-------------------------------------------------------------------------------
+-- Direct FD-based mlocked I/O
+-------------------------------------------------------------------------------
+
+foreign import capi unsafe "unistd.h read" c_mlocked_fd_read :: CInt -> Ptr a -> CSize -> IO CInt
+foreign import capi unsafe "unistd.h write" c_mlocked_fd_write :: CInt -> Ptr a -> CSize -> IO CInt
 
 -------------------------------------------------------------------------------
 -- Hashing: SHA256

--- a/cardano-crypto-class/src/Cardano/Crypto/Libsodium/C.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Libsodium/C.hs
@@ -9,6 +9,10 @@ module Cardano.Crypto.Libsodium.C (
     c_sodium_malloc,
     c_sodium_free,
     c_sodium_free_funptr,
+
+    c_mlocked_pool_malloc,
+    c_mlocked_pool_free,
+
     -- * Hashing
     -- ** SHA256
     c_crypto_hash_sha256,
@@ -79,6 +83,16 @@ foreign import capi unsafe "sodium.h sodium_free" c_sodium_free :: Ptr a -> IO (
 --
 -- <https://libsodium.gitbook.io/doc/memory_management>
 foreign import capi unsafe "sodium.h &sodium_free" c_sodium_free_funptr :: FunPtr (Ptr a -> IO ())
+
+-------------------------------------------------------------------------------
+-- MLocked Pooled Memory management
+-------------------------------------------------------------------------------
+
+-- | @void *mlocked_pool_malloc(size_t size);@
+foreign import ccall unsafe "mlocked_pool_malloc" c_mlocked_pool_malloc :: CSize -> IO (Ptr a)
+
+-- | @void mlocked_pool_free(void *ptr);@
+foreign import ccall unsafe "mlocked_pool_free" c_mlocked_pool_free :: (Ptr a) -> IO ()
 
 -------------------------------------------------------------------------------
 -- Hashing: SHA256

--- a/cardano-crypto-class/src/Cardano/Crypto/Libsodium/Hash.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Libsodium/Hash.hs
@@ -54,7 +54,7 @@ digestMLockedStorable
     :: forall h a proxy. (SodiumHashAlgorithm h, Storable a)
     => proxy h -> Ptr a -> MLockedSizedBytes (SizeHash h)
 digestMLockedStorable p ptr = unsafeDupablePerformIO $
-    naclDigestPtr p ptr (sizeOf (undefined :: a))
+    naclDigestPtr p ptr ((sizeOf (undefined :: a)))
 
 digestMLockedBS
     :: forall h proxy. (SodiumHashAlgorithm h)
@@ -70,7 +70,7 @@ digestMLockedBS p bs = unsafeDupablePerformIO $
 expandHash
     :: forall h proxy. SodiumHashAlgorithm h
     => proxy h
-    -> MLockedSizedBytes (SizeHash h)
+    -> (MLockedSizedBytes (SizeHash h))
     -> (MLockedSizedBytes (SizeHash h), MLockedSizedBytes (SizeHash h))
 expandHash h (MLSB sfptr) = unsafeDupablePerformIO $ do
     withMLockedForeignPtr sfptr $ \ptr -> do

--- a/cardano-crypto-class/src/Cardano/Crypto/Libsodium/MLockedBytes.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Libsodium/MLockedBytes.hs
@@ -1,12 +1,13 @@
 module Cardano.Crypto.Libsodium.MLockedBytes (
     MLockedSizedBytes,
-    mlsbZero,
+    mlsbNew,
     mlsbFromByteString,
     mlsbFromByteStringCheck,
     mlsbToByteString,
     mlsbUseAsCPtr,
     mlsbUseAsSizedPtr,
     mlsbFinalize,
+    mlsbCopy,
 ) where
 
 import Cardano.Crypto.Libsodium.MLockedBytes.Internal

--- a/cardano-crypto-class/src/Cardano/Crypto/Libsodium/MLockedBytes.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Libsodium/MLockedBytes.hs
@@ -9,7 +9,11 @@ module Cardano.Crypto.Libsodium.MLockedBytes (
     mlsbUseAsSizedPtr,
     mlsbFinalize,
     mlsbCopy,
-    mlsbMemcpy
+    mlsbMemcpy,
+
+    mlsbReadFd,
+    mlsbReadFromFd,
+    mlsbWriteFd,
 ) where
 
 import Cardano.Crypto.Libsodium.MLockedBytes.Internal

--- a/cardano-crypto-class/src/Cardano/Crypto/Libsodium/MLockedBytes.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Libsodium/MLockedBytes.hs
@@ -4,10 +4,12 @@ module Cardano.Crypto.Libsodium.MLockedBytes (
     mlsbFromByteString,
     mlsbFromByteStringCheck,
     mlsbToByteString,
+    mlsbAsByteString,
     mlsbUseAsCPtr,
     mlsbUseAsSizedPtr,
     mlsbFinalize,
     mlsbCopy,
+    mlsbMemcpy
 ) where
 
 import Cardano.Crypto.Libsodium.MLockedBytes.Internal

--- a/cardano-crypto-class/src/Cardano/Crypto/Libsodium/Memory.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Libsodium/Memory.hs
@@ -5,6 +5,10 @@ module Cardano.Crypto.Libsodium.Memory (
   allocMLockedForeignPtr,
   finalizeMLockedForeignPtr,
   traceMLockedForeignPtr,
+  -- * Debugging / testing instrumentation
+  AllocEvent (..),
+  pushAllocLogEvent,
+  popAllocLogEvent,
 ) where
 
 import Cardano.Crypto.Libsodium.Memory.Internal

--- a/cardano-crypto-class/src/Cardano/Crypto/Libsodium/Memory/Internal.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Libsodium/Memory/Internal.hs
@@ -115,13 +115,11 @@ sodiumMalloc size = do
     when (ptr == nullPtr) $ do
         errno <- getErrno
         ioException $ errnoToIOError "c_sodium_malloc" errno Nothing Nothing
-    -- putStrLn $ "sodiumMalloc " <> show ptr
     pushAllocLogEvent $ AllocEv (ptrToWordPtr ptr)
     return ptr
 
 sodiumFree :: Ptr a -> IO ()
 sodiumFree ptr = do
-  -- putStrLn $ "sodiumFree " <> show ptr
   pushAllocLogEvent $ FreeEv (ptrToWordPtr ptr)
   c_sodium_free ptr
 

--- a/cardano-crypto-class/src/Cardano/Crypto/MonadSodium.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/MonadSodium.hs
@@ -1,0 +1,89 @@
+{-# LANGUAGE RankNTypes #-}
+
+-- We need this so that we can forward the deprecated traceMLockedForeignPtr
+{-# OPTIONS_GHC -Wno-deprecations #-}
+
+-- | The Libsodium API generalized to fit arbitrary-ish Monads.
+--
+-- The purpose of this module is to provide a drop-in replacement for the plain
+-- 'Cardano.Crypto.Libsodium' module, but such that the Monad in which some
+-- essential actions run can be mocked, rather than forcing it to be 'IO'.
+--
+-- It may also be used to provide Libsodium functionality in monad stacks that
+-- have IO at the bottom, but decorate certain Libsodium operations with
+-- additional effects, e.g. logging mlocked memory access.
+module Cardano.Crypto.MonadSodium
+(
+  MonadSodium (..),
+  -- * Re-exports from plain Libsodium module
+  NaCl.sodiumInit,
+  NaCl.MLockedForeignPtr,
+  NaCl.MLockedSizedBytes,
+  NaCl.mlsbToByteString,
+  NaCl.SodiumHashAlgorithm (..),
+  NaCl.digestMLockedStorable,
+  NaCl.digestMLockedBS,
+  NaCl.expandHash,
+
+  -- * SafePinned
+  SP.SafePinned,
+  mapSafePinned
+)
+where
+
+import Cardano.Crypto.Libsodium
+  ( MLockedForeignPtr
+  )
+import qualified Cardano.Crypto.Libsodium as NaCl
+import qualified Cardano.Crypto.SafePinned as SP
+import Cardano.Crypto.Libsodium.MLockedBytes as NaCl
+import Cardano.Foreign (SizedPtr)
+
+import GHC.TypeLits (KnownNat)
+import Foreign.Ptr (Ptr)
+import Foreign.Storable (Storable)
+import Data.Word (Word8)
+import qualified Data.ByteString as BS
+
+{-#DEPRECATED traceMLockedForeignPtr "Do not use traceMLockedForeignPtr in production" #-}
+
+class Monad m => MonadSodium m where
+  -- * MLocked memory management
+  withMLockedForeignPtr :: forall a b. MLockedForeignPtr a -> (Ptr a -> m b) -> m b
+  finalizeMLockedForeignPtr :: forall a. MLockedForeignPtr a -> m ()
+  allocMLockedForeignPtr :: Storable a => m (MLockedForeignPtr a)
+  traceMLockedForeignPtr :: (Storable a, Show a) => MLockedForeignPtr a -> m ()
+
+  -- * MLocked bytes
+  mlsbNew :: forall n. KnownNat n => m (MLockedSizedBytes n)
+  mlsbFinalize :: MLockedSizedBytes n -> m ()
+  mlsbCopy :: forall n. KnownNat n => MLockedSizedBytes n -> m (MLockedSizedBytes n)
+  mlsbUseAsSizedPtr :: forall n r. KnownNat n => MLockedSizedBytes n -> (SizedPtr n -> m r) -> m r
+  mlsbUseAsCPtr :: forall n r. KnownNat n => MLockedSizedBytes n -> (Ptr Word8 -> m r) -> m r
+  mlsbFromByteString :: forall n. KnownNat n => BS.ByteString -> m (MLockedSizedBytes n)
+  mlsbFromByteStringCheck :: forall n. KnownNat n => BS.ByteString -> m (Maybe (MLockedSizedBytes n))
+
+  -- * SafePinned
+  makeSafePinned :: a -> m (SP.SafePinned a)
+  releaseSafePinned :: forall a. SP.Release a => SP.SafePinned a -> m ()
+  interactSafePinned :: SP.SafePinned a -> (a -> m b) -> m b
+
+instance MonadSodium IO where
+  withMLockedForeignPtr = NaCl.withMLockedForeignPtr
+  finalizeMLockedForeignPtr = NaCl.finalizeMLockedForeignPtr
+  allocMLockedForeignPtr = NaCl.allocMLockedForeignPtr
+  traceMLockedForeignPtr = NaCl.traceMLockedForeignPtr
+  mlsbNew = NaCl.mlsbNew
+  mlsbFinalize = NaCl.mlsbFinalize
+  mlsbCopy = NaCl.mlsbCopy
+  mlsbUseAsSizedPtr = NaCl.mlsbUseAsSizedPtr
+  mlsbUseAsCPtr = NaCl.mlsbUseAsCPtr
+  makeSafePinned = SP.makeSafePinned
+  releaseSafePinned = SP.releaseSafePinned
+  interactSafePinned = SP.interactSafePinned
+  mlsbFromByteString = NaCl.mlsbFromByteString
+  mlsbFromByteStringCheck = NaCl.mlsbFromByteStringCheck
+
+mapSafePinned :: MonadSodium m => (a -> m b) -> SP.SafePinned a -> m (SP.SafePinned b)
+mapSafePinned f p =
+  interactSafePinned p f >>= makeSafePinned

--- a/cardano-crypto-class/src/Cardano/Crypto/PackedBytes.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/PackedBytes.hs
@@ -219,7 +219,7 @@ packBytesMaybe bs offset = do
       size = fromInteger (natVal' (proxy# @n))
   guard (offset >= 0)
   guard (size <= bufferSize - offset)
-  Just $! packBytes bs offset
+  Just $ packBytes bs offset
 
 
 packPinnedBytes8 :: ByteString -> PackedBytes 8

--- a/cardano-crypto-class/src/Cardano/Crypto/SafePinned.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/SafePinned.hs
@@ -1,0 +1,61 @@
+{-#LANGUAGE DerivingVia #-}
+{-#LANGUAGE GeneralizedNewtypeDeriving #-}
+module Cardano.Crypto.SafePinned
+( SafePinned
+, makeSafePinned
+, releaseSafePinned
+, interactSafePinned
+, mapSafePinned
+, Release (..)
+)
+where
+
+import Control.Concurrent.MVar
+import Control.Exception (Exception, throw)
+import Control.DeepSeq (NFData (..))
+import NoThunks.Class (NoThunks, OnlyCheckWhnf (..))
+import Control.Monad.IO.Class (MonadIO, liftIO)
+import Cardano.Crypto.Libsodium.MLockedBytes
+
+data SafePinnedFinalizedError = SafePinnedFinalizedError
+  deriving (Show)
+
+instance Exception SafePinnedFinalizedError
+
+class Release a where
+  release :: a -> IO ()
+
+instance Release (MLockedSizedBytes a) where
+  release = mlsbFinalize
+
+newtype SafePinned a =
+  SafePinned { safePinnedMVar :: MVar a }
+  deriving NoThunks via OnlyCheckWhnf (MVar a)
+
+makeSafePinned :: MonadIO m => a -> m (SafePinned a)
+makeSafePinned val = SafePinned <$> liftIO (newMVar val)
+
+mapSafePinned :: MonadIO m => (a -> m b) -> SafePinned a -> m (SafePinned b)
+mapSafePinned f p =
+  interactSafePinned p f >>= makeSafePinned
+
+releaseSafePinned :: (MonadIO m, Release a) => SafePinned a -> m ()
+releaseSafePinned sp = do
+  mval <- liftIO $ tryTakeMVar (safePinnedMVar sp)
+  maybe (return ()) (liftIO . release) mval
+
+interactSafePinned :: MonadIO m => SafePinned a -> (a -> m b) -> m b
+interactSafePinned (SafePinned var) action = do
+  mval <- liftIO (tryTakeMVar var)
+  case mval of
+    Just val -> do
+      result <- action val
+      result `seq` liftIO (putMVar var val)
+      return result
+    Nothing -> do
+      throw SafePinnedFinalizedError
+
+-- If it's fine by Kmett & Marlow, ...
+-- https://github.com/haskell/deepseq/issues/6
+instance NFData (SafePinned a) where
+  rnf x = x `seq` ()

--- a/cardano-crypto-praos/cardano-crypto-praos.cabal
+++ b/cardano-crypto-praos/cardano-crypto-praos.cabal
@@ -20,13 +20,13 @@ extra-source-files:    cbits/crypto_vrf.h
                        cbits/vrf03/crypto_vrf_ietfdraft03.h
                        cbits/vrf03/vrf_ietfdraft03.h
 
-                       cbits/vrf10_batchcompat/crypto_vrf_ietfdraft10.h
-                       cbits/vrf10_batchcompat/vrf_ietfdraft10.h
+                       -- cbits/vrf10_batchcompat/crypto_vrf_ietfdraft10.h
+                       -- cbits/vrf10_batchcompat/vrf_ietfdraft10.h
 
                        cbits/private/common.h
                        cbits/private/quirks.h
                        cbits/private/ed25519_ref10.h
-                       cbits/private/hash_to_curve.h
+                       --cbits/private/hash_to_curve.h
                        cbits/private/ed25519_ref10_fe_25_5.h
                        cbits/private/ed25519_ref10_fe_51.h
 
@@ -71,7 +71,8 @@ library
   import:               base, project-config
   hs-source-dirs:       src
   exposed-modules:      Cardano.Crypto.VRF.Praos
-                 ,      Cardano.Crypto.VRF.PraosBatchCompat
+                 -- Disabled until the full audit is complete:
+                 -- ,      Cardano.Crypto.VRF.PraosBatchCompat
                  ,      Cardano.Crypto.RandomBytes
 
   build-depends:        base
@@ -91,11 +92,11 @@ library
                         cbits/vrf03/verify.c
                         cbits/vrf03/vrf.c
 
-                        cbits/vrf10_batchcompat/convert.c
-                        cbits/vrf10_batchcompat/verify.c
-                        cbits/vrf10_batchcompat/keypair.c
-                        cbits/vrf10_batchcompat/prove.c
-                        cbits/vrf10_batchcompat/vrf.c
+                        -- cbits/vrf10_batchcompat/convert.c
+                        -- cbits/vrf10_batchcompat/verify.c
+                        -- cbits/vrf10_batchcompat/keypair.c
+                        -- cbits/vrf10_batchcompat/prove.c
+                        -- cbits/vrf10_batchcompat/vrf.c
 
-                        cbits/private/hash_to_curve.c
+                        -- cbits/private/hash_to_curve.c
                         cbits/private/ed25519_ref10.c

--- a/cardano-crypto-tests/cardano-crypto-tests.cabal
+++ b/cardano-crypto-tests/cardano-crypto-tests.cabal
@@ -57,7 +57,7 @@ library
                         Bench.Crypto.KES
 
   build-depends:        base
-                      , bytestring >=0.10.12.0
+                      , bytestring >=0.10
                       , cardano-binary
                       , cardano-crypto-class
                       , cardano-crypto-praos

--- a/cardano-crypto-tests/cardano-crypto-tests.cabal
+++ b/cardano-crypto-tests/cardano-crypto-tests.cabal
@@ -73,6 +73,7 @@ library
                       , quickcheck-instances
                       , tasty
                       , tasty-quickcheck
+                      , unix
                       , criterion
                       , tasty-hunit
                       , HUnit

--- a/cardano-crypto-tests/cardano-crypto-tests.cabal
+++ b/cardano-crypto-tests/cardano-crypto-tests.cabal
@@ -48,6 +48,7 @@ library
 
   exposed-modules:      Test.Crypto.DSIGN
                         Test.Crypto.Hash
+                        Test.Crypto.RunIO
                         Test.Crypto.KES
                         Test.Crypto.Util
                         Test.Crypto.VRF
@@ -56,14 +57,16 @@ library
                         Bench.Crypto.KES
 
   build-depends:        base
-                      , bytestring
+                      , bytestring >=0.10.12.0
                       , cardano-binary
                       , cardano-crypto-class
                       , cardano-crypto-praos
                       , cardano-prelude
                       , cborg
+                      , containers
                       , cryptonite
                       , formatting
+                      , mtl
                       , nothunks
                       , pretty-show
                       , QuickCheck
@@ -71,6 +74,8 @@ library
                       , tasty
                       , tasty-quickcheck
                       , criterion
+                      , tasty-hunit
+                      , HUnit
 
   if flag(secp256k1-support)
     build-depends: secp256k1-haskell

--- a/cardano-crypto-tests/src/Test/Crypto/DSIGN.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/DSIGN.hs
@@ -29,7 +29,6 @@ import Text.Show.Pretty (ppShow)
 import Data.ByteString (ByteString)
 import Control.Monad (replicateM)
 import qualified Crypto.Secp256k1 as SECP
-import qualified GHC.Exts as GHC
 #endif
 
 import qualified Test.QuickCheck.Gen as Gen
@@ -152,7 +151,7 @@ genSECPMsg :: Gen SECP.Msg
 genSECPMsg = Gen.suchThatMap go SECP.msg
   where
     go :: Gen ByteString
-    go = GHC.fromListN 32 <$> replicateM 32 arbitrary
+    go = BS.pack <$> replicateM 32 arbitrary
 #endif
 
 defaultVerKeyGen :: forall (a :: Type) . 

--- a/cardano-crypto-tests/src/Test/Crypto/Hash.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/Hash.hs
@@ -76,7 +76,6 @@ testSodiumHashAlgorithm p =
     ]
     where n = hashAlgorithmName p
 
-
 testPackedBytesN :: forall n. KnownNat n => TestHash n -> TestTree
 testPackedBytesN h = do
   testGroup
@@ -124,7 +123,6 @@ testPackedBytes =
     , testPackedBytesN (TestHash :: TestHash 31)
     , testPackedBytesN (TestHash :: TestHash 32)
     ]
-
 
 prop_hash_cbor :: HashAlgorithm h => Hash h Int -> Property
 prop_hash_cbor = prop_cbor

--- a/cardano-crypto-tests/src/Test/Crypto/Hash.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/Hash.hs
@@ -155,11 +155,12 @@ prop_hash_hashFromStringAsHex_hashToStringFromHash h = fromJust (hashFromStringA
 prop_libsodium_model
   :: forall h. NaCl.SodiumHashAlgorithm h
   => Proxy h -> BS.ByteString -> Property
-prop_libsodium_model p bs = expected === actual
-  where
-    mlsb = NaCl.digestMLockedBS p bs
-    actual = NaCl.mlsbToByteString mlsb
-    expected = digest p bs
+prop_libsodium_model p bs = ioProperty $ do
+    mlsb <- NaCl.digestMLockedBS p bs
+    actual <- NaCl.mlsbToByteString mlsb
+    NaCl.mlsbFinalize mlsb
+    let expected = digest p bs
+    return $ expected === actual
 
 
 --

--- a/cardano-crypto-tests/src/Test/Crypto/Instances.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/Instances.hs
@@ -1,21 +1,40 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
-module Test.Crypto.Instances () where
+module Test.Crypto.Instances
+( withMLSBFromPSB
+) where
 
 import Data.Proxy (Proxy (..))
 import GHC.TypeLits (KnownNat, natVal)
 import Test.QuickCheck (Arbitrary (..), vectorOf)
-import qualified Data.ByteString as BS
 
 import qualified Cardano.Crypto.Libsodium as NaCl
 import Cardano.Crypto.PinnedSizedBytes
-import System.IO.Unsafe (unsafePerformIO)
+import Test.Crypto.RunIO (RunIO (..))
+import Control.Monad.IO.Class (MonadIO (..))
+import Control.Exception (bracket)
 
-instance KnownNat n => Arbitrary (NaCl.MLockedSizedBytes n) where
-    arbitrary = unsafePerformIO . NaCl.mlsbFromByteString . BS.pack <$> vectorOf size arbitrary
-      where
-        size :: Int
-        size = fromInteger (natVal (Proxy :: Proxy n))
+-- We cannot allow this instance, because it doesn't guarantee timely
+-- forgetting of the MLocked memory.
+-- Instead, use 'arbitrary' to generate a suitably sized PinnedSizedBytes
+-- value, and then mlsbFromPSB or withMLSBFromPSB to convert it to an
+-- MLockedSizedBytes value.
+--
+-- instance KnownNat n => Arbitrary (NaCl.MLockedSizedBytes n) where
+--     arbitrary = unsafePerformIO . NaCl.mlsbFromByteString . BS.pack <$> vectorOf size arbitrary
+--       where
+--         size :: Int
+--         size = fromInteger (natVal (Proxy :: Proxy n))
+
+mlsbFromPSB :: (KnownNat n) => PinnedSizedBytes n -> IO (NaCl.MLockedSizedBytes n)
+mlsbFromPSB = NaCl.mlsbFromByteString . psbToByteString
+
+withMLSBFromPSB :: (KnownNat n, MonadIO m, RunIO m) => PinnedSizedBytes n -> (NaCl.MLockedSizedBytes n -> m a) -> m a
+withMLSBFromPSB psb action = liftIO $ do
+  bracket
+    (mlsbFromPSB psb)
+    NaCl.mlsbFinalize
+    (io . action)
 
 instance KnownNat n => Arbitrary (PinnedSizedBytes n) where
     arbitrary = psbFromBytes <$> vectorOf size arbitrary

--- a/cardano-crypto-tests/src/Test/Crypto/Instances.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/Instances.hs
@@ -9,9 +9,10 @@ import qualified Data.ByteString as BS
 
 import qualified Cardano.Crypto.Libsodium as NaCl
 import Cardano.Crypto.PinnedSizedBytes
+import System.IO.Unsafe (unsafePerformIO)
 
 instance KnownNat n => Arbitrary (NaCl.MLockedSizedBytes n) where
-    arbitrary = NaCl.mlsbFromByteString . BS.pack <$> vectorOf size arbitrary
+    arbitrary = unsafePerformIO . NaCl.mlsbFromByteString . BS.pack <$> vectorOf size arbitrary
       where
         size :: Int
         size = fromInteger (natVal (Proxy :: Proxy n))

--- a/cardano-crypto-tests/src/Test/Crypto/KES.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/KES.hs
@@ -390,7 +390,8 @@ prop_onlyGenSignKeyKES
       KESSignAlgorithm IO v
   => Lock -> Proxy v -> PinnedSizedBytes (SeedSizeKES v) -> Property
 prop_onlyGenSignKeyKES lock _ seedPSB = ioProperty . withLock lock . withMLSBFromPSB seedPSB $ \seed -> do
-  _ <- genKeyKES @IO @v seed
+  sk <- genKeyKES @IO @v seed
+  forgetSignKeyKES sk
   return True
 
 prop_onlyGenVerKeyKES
@@ -400,6 +401,7 @@ prop_onlyGenVerKeyKES
 prop_onlyGenVerKeyKES lock _ seedPSB = ioProperty . withLock lock . withMLSBFromPSB seedPSB $ \seed -> do
   sk <- genKeyKES @IO @v seed
   _ <- deriveVerKeyKES sk
+  forgetSignKeyKES sk
   return True
 
 prop_oneUpdateSignKeyKES 

--- a/cardano-crypto-tests/src/Test/Crypto/KES.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/KES.hs
@@ -27,7 +27,6 @@ import qualified Data.Set as Set
 import Foreign.Ptr (WordPtr)
 import System.IO.Unsafe (unsafePerformIO)
 import Data.IORef
-import Data.Maybe (fromJust)
 import Text.Printf
 
 import Control.Concurrent (threadDelay)
@@ -239,7 +238,6 @@ testKESAlgorithm
      , FromCBOR (SigKES v)
      , Signable v ~ SignableRepresentation
      , ContextKES v ~ ()
-     , RunIO m
      , KESSignAlgorithm m v
      , KESSignAlgorithm IO v
      )
@@ -377,13 +375,6 @@ testKESAlgorithm lock _pm _pv n =
       bracket
         (NaCl.mlsbFromByteString =<< generate (arbitrarySeedBytesOfSize (seedSizeKES (Proxy :: Proxy v))))
         NaCl.mlsbFinalize
-        action
-
-    withTestSK :: forall a. (SignKeyKES v -> IO a) -> NaCl.MLockedSizedBytes (SeedSizeKES v) -> IO a
-    withTestSK action seed =
-      bracket
-        (genKeyKES seed)
-        forgetSignKeyKES
         action
 
     withNewTestSK :: forall a. (SignKeyKES v -> IO a) -> IO a

--- a/cardano-crypto-tests/src/Test/Crypto/KES.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/KES.hs
@@ -1,11 +1,16 @@
 {-# LANGUAGE DataKinds            #-}
+{-# LANGUAGE DeriveAnyClass       #-}
+{-# LANGUAGE KindSignatures       #-}
 {-# LANGUAGE FlexibleContexts     #-}
 {-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE LambdaCase           #-}
 {-# LANGUAGE ScopedTypeVariables  #-}
 {-# LANGUAGE StandaloneDeriving   #-}
-{-# LANGUAGE TypeFamilies         #-}
 {-# LANGUAGE TypeApplications     #-}
+{-# LANGUAGE TypeFamilies         #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE RankNTypes #-}
 
 {-# OPTIONS_GHC -Wno-orphans #-}
 
@@ -15,92 +20,267 @@ module Test.Crypto.KES
 where
 
 import Data.Proxy (Proxy(..))
-import Data.List (unfoldr)
+import Data.List (isPrefixOf, foldl')
+import qualified Data.ByteString as BS
+import Data.Set (Set)
+import qualified Data.Set as Set
+import Foreign.Ptr (WordPtr)
+import System.IO.Unsafe (unsafePerformIO)
+import Data.IORef
+import Data.Maybe (fromJust)
+import Text.Printf
+
+import Control.Concurrent (threadDelay)
+import Control.Monad (void)
 
 import Cardano.Crypto.DSIGN hiding (Signable)
 import Cardano.Crypto.Hash
 import Cardano.Crypto.KES
+import Cardano.Crypto.KES.ForgetMock
 import Cardano.Crypto.Util (SignableRepresentation(..))
+import qualified Cardano.Crypto.Libsodium as NaCl
+import qualified Cardano.Crypto.Libsodium.Memory as NaCl
+import Cardano.Prelude (ReaderT, runReaderT)
+import Cardano.Crypto.SafePinned
 
 import Test.QuickCheck
 import Test.Tasty (TestTree, testGroup, adjustOption)
 import Test.Tasty.QuickCheck (testProperty, QuickCheckMaxSize(..))
+import Test.Tasty.HUnit (testCase)
+import Test.HUnit
+-- import Debug.Trace (traceShow)
 
 import Test.Crypto.Util hiding (label)
+import Test.Crypto.RunIO (RunIO (..))
 import Test.Crypto.Instances ()
-
-{- HLINT ignore "Reduce duplication" -}
 
 --
 -- The list of all tests
 --
-tests :: TestTree
-tests =
+tests :: Lock -> TestTree
+tests lock =
   testGroup "Crypto.KES"
-  [ testKESAlgorithm (Proxy :: Proxy (MockKES 7))               "MockKES"
-  , testKESAlgorithm (Proxy :: Proxy (SimpleKES Ed448DSIGN 7))  "SimpleKES"
-  , testKESAlgorithm (Proxy :: Proxy (SingleKES Ed25519DSIGN))  "SingleKES"
-  , testKESAlgorithm (Proxy :: Proxy (Sum1KES Ed25519DSIGN Blake2b_256)) "Sum1KES"
-  , testKESAlgorithm (Proxy :: Proxy (Sum2KES Ed25519DSIGN Blake2b_256)) "Sum2KES"
-  , testKESAlgorithm (Proxy :: Proxy (Sum5KES Ed25519DSIGN Blake2b_256)) "Sum5KES"
-  , testKESAlgorithm (Proxy :: Proxy (CompactSingleKES Ed25519DSIGN))  "CompactSingleKES"
-  , testKESAlgorithm (Proxy :: Proxy (CompactSum1KES Ed25519DSIGN Blake2b_256)) "CompactSum1KES"
-  , testKESAlgorithm (Proxy :: Proxy (CompactSum2KES Ed25519DSIGN Blake2b_256)) "CompactSum2KES"
-  , testKESAlgorithm (Proxy :: Proxy (CompactSum5KES Ed25519DSIGN Blake2b_256)) "CompactSum5KES"
+  [ testKESAlloc lock (Proxy :: Proxy (SingleKES Ed25519DSIGNM)) "SingleKES"
+  , testKESAlloc lock (Proxy :: Proxy (Sum1KES Ed25519DSIGNM Blake2b_256)) "Sum1KES"
+  , testKESAlloc lock (Proxy :: Proxy (Sum2KES Ed25519DSIGNM Blake2b_256)) "Sum2KES"
+  , testKESAlgorithm lock (Proxy :: Proxy IO) (Proxy :: Proxy (MockKES 7))               "MockKES"
+  , testKESAlgorithm lock (Proxy :: Proxy IO) (Proxy :: Proxy (SimpleKES Ed448DSIGN 7))  "SimpleKES"
+  , testKESAlgorithm lock (Proxy :: Proxy IO) (Proxy :: Proxy (SingleKES Ed25519DSIGNM))  "SingleKES"
+  , testKESAlgorithm lock (Proxy :: Proxy IO) (Proxy :: Proxy (Sum1KES Ed25519DSIGNM Blake2b_256)) "Sum1KES"
+  , testKESAlgorithm lock (Proxy :: Proxy IO) (Proxy :: Proxy (Sum2KES Ed25519DSIGNM Blake2b_256)) "Sum2KES"
+  , testKESAlgorithm lock (Proxy :: Proxy IO) (Proxy :: Proxy (Sum5KES Ed25519DSIGNM Blake2b_256)) "Sum5KES"
+  , testKESAlgorithm lock (Proxy :: Proxy IO) (Proxy :: Proxy (CompactSum1KES Ed25519DSIGNM Blake2b_256)) "CompactSum1KES"
+  , testKESAlgorithm lock (Proxy :: Proxy IO) (Proxy :: Proxy (CompactSum2KES Ed25519DSIGNM Blake2b_256)) "CompactSum2KES"
+  , testKESAlgorithm lock (Proxy :: Proxy IO) (Proxy :: Proxy (CompactSum5KES Ed25519DSIGNM Blake2b_256)) "CompactSum5KES"
   ]
 
 -- We normally ensure that we avoid naively comparing signing keys by not
 -- providing instances, but for tests it is fine, so we provide the orphan
 -- instances here.
+
+instance Eq a => Eq (SafePinned a) where
+  ap == bp = unsafePerformIO $ do
+    interactSafePinned ap $ \a ->
+      interactSafePinned bp $ \b ->
+        return (a == b)
+
+instance Show (SignKeyKES (SingleKES Ed25519DSIGNM)) where
+  show (SignKeySingleKES (SignKeyEd25519DSIGNM mlsb)) =
+    let bytes = BS.unpack $ NaCl.mlsbToByteString mlsb
+        hexstr = concatMap (printf "%02x") bytes
+    in "SignKeySingleKES (SignKeyEd25519DSIGNM " ++ hexstr ++ ")"
+
+instance Show (SignKeyKES (SumKES h d)) where
+  show _ = "<SignKeySumKES>"
+
+instance Show (SignKeyKES (CompactSingleKES Ed25519DSIGNM)) where
+  show (SignKeyCompactSingleKES (SignKeyEd25519DSIGNM mlsb)) =
+    let bytes = BS.unpack $ NaCl.mlsbToByteString mlsb
+        hexstr = concatMap (printf "%02x") bytes
+    in "SignKeyCompactSingleKES (SignKeyEd25519DSIGNM " ++ hexstr ++ ")"
+
+instance Show (SignKeyKES (CompactSumKES h d)) where
+  show _ = "<SignKeyCompactSumKES>"
+
 deriving instance Eq (SignKeyDSIGN d) => Eq (SignKeyKES (SimpleKES d t))
 
-deriving instance Eq (SignKeyDSIGN d)
+deriving instance Eq (SignKeyDSIGNM d)
                => Eq (SignKeyKES (SingleKES d))
-deriving instance (KESAlgorithm d, Eq (SignKeyKES d))
+deriving instance (KESAlgorithm d, NaCl.SodiumHashAlgorithm h, Eq (SignKeyKES d))
                => Eq (SignKeyKES (SumKES h d))
-deriving instance Eq (SignKeyDSIGN d)
+deriving instance Eq (SignKeyDSIGNM d)
                => Eq (SignKeyKES (CompactSingleKES d))
 deriving instance (KESAlgorithm d, Eq (SignKeyKES d))
                => Eq (SignKeyKES (CompactSumKES h d))
 
+testKESAlloc
+  :: forall v.
+     ( KESSignAlgorithm IO v
+     , ContextKES v ~ ()
+     )
+  => Lock
+  -> Proxy v
+  -> String
+  -> TestTree
+testKESAlloc lock _p n =
+  testGroup n
+    [ testGroup "Forget mock"
+      [ testCase "genKey" $ testForgetGenKeyKES lock _p
+      , testCase "updateKey" $ testForgetUpdateKeyKES lock _p
+      ]
+    , testGroup "Low-level mlocked allocations"
+      [ testCase "genKey" $ testMLockGenKeyKES lock _p
+      -- , testCase "updateKey" $ testMLockUpdateKeyKES lock _p
+      ]
+    ]
+
+testForgetGenKeyKES
+  :: forall v.
+     ( KESSignAlgorithm IO v
+     )
+  => Lock
+  -> Proxy v
+  -> Assertion
+testForgetGenKeyKES lock _p = withLock lock $ do
+  seed <- NaCl.mlsbFromByteString (BS.replicate 1024 23)
+  logVar <- newIORef []
+  let logger str = modifyIORef logVar (++ [str])
+  sk <- flip runReaderT logger $ genKeyKES @(ReaderT _ _) @(ForgetMockKES v) seed
+  NaCl.mlsbFinalize seed
+  flip runReaderT logger $ do
+    forgetSignKeyKES sk
+  result <- readIORef logVar
+  assertEqual "number of log entries" 2 (length result)
+  assertBool "first entry is GEN" ("GEN" `isPrefixOf` (result !! 0))
+  assertBool "second entry is DEL" ("DEL" `isPrefixOf` (result !! 1))
+  return ()
+
+testForgetUpdateKeyKES
+  :: forall v.
+     ( KESAlgorithm v
+     , KESSignAlgorithm IO v
+     , ContextKES v ~ ()
+     )
+  => Lock
+  -> Proxy v
+  -> Assertion
+testForgetUpdateKeyKES lock _p = withLock lock $ do
+  seed <- NaCl.mlsbFromByteString (BS.replicate 1024 23)
+  logVar <- newIORef []
+  let logger str = modifyIORef logVar (++ [str])
+  sk <- flip runReaderT logger $ genKeyKES @(ReaderT _ _) @(ForgetMockKES v) seed
+  NaCl.mlsbFinalize seed
+  msk' <- flip runReaderT logger $ updateKES () sk 0
+  case msk' of
+    Just sk' -> flip runReaderT logger $ forgetSignKeyKES sk'
+    Nothing -> return ()
+  threadDelay 1000000
+  result <- readIORef logVar
+  -- assertEqual "number of log entries" 3 (length result)
+  assertBool "first entry is GEN" ("GEN" `isPrefixOf` (result !! 0))
+  -- assertBool "second entry is UPD" ("UPD" `isPrefixOf` (result !! 1))
+  -- assertBool "third entry is DEL" ("DEL" `isPrefixOf` (result !! 2))
+
+
+drainAllocLog :: IO [NaCl.AllocEvent]
+drainAllocLog =
+  reverse <$> go []
+  where
+    go xs = do
+      NaCl.popAllocLogEvent >>= \case
+        Nothing ->
+          return xs
+        Just x ->
+          go (x:xs)
+
+matchAllocLog :: [NaCl.AllocEvent] -> Set WordPtr
+matchAllocLog evs = foldl' (flip go) Set.empty evs
+  where
+    go (NaCl.AllocEv ptr) = Set.insert ptr
+    go (NaCl.FreeEv ptr) = Set.delete ptr
+    go (NaCl.MarkerEv _) = id
+
+testMLockGenKeyKES
+  :: forall v.
+     ( KESAlgorithm v
+     , KESSignAlgorithm IO v
+     )
+  => Lock
+  -> Proxy v
+  -> Assertion
+testMLockGenKeyKES lock _p = withLock lock $ do
+  _ <- drainAllocLog
+
+  NaCl.pushAllocLogEvent $ NaCl.MarkerEv "gen seed"
+  (seed :: NaCl.MLockedSizedBytes (SeedSizeKES v)) <- NaCl.mlsbFromByteString (BS.replicate 1024 23)
+  NaCl.pushAllocLogEvent $ NaCl.MarkerEv "gen key"
+  sk <- genKeyKES @IO @v seed
+  NaCl.pushAllocLogEvent $ NaCl.MarkerEv "forget key"
+  forgetSignKeyKES sk
+  NaCl.pushAllocLogEvent $ NaCl.MarkerEv "forget seed"
+  NaCl.mlsbFinalize seed
+  NaCl.pushAllocLogEvent $ NaCl.MarkerEv "done"
+  after <- drainAllocLog
+  let evset = matchAllocLog after
+  putStrLn ""
+  mapM_ print after
+  assertEqual "all allocations deallocated" Set.empty evset
+
 testKESAlgorithm
-  :: forall v proxy.
+  :: forall m v.
      ( KESAlgorithm v
      , ToCBOR (VerKeyKES v)
      , FromCBOR (VerKeyKES v)
-     , ToCBOR (SignKeyKES v)
-     , FromCBOR (SignKeyKES v)
      , Eq (SignKeyKES v)   -- no Eq for signing keys normally
+     , Show (SignKeyKES v) -- fake instance defined locally
      , ToCBOR (SigKES v)
      , FromCBOR (SigKES v)
      , Signable v ~ SignableRepresentation
      , ContextKES v ~ ()
+     , RunIO m
+     , KESSignAlgorithm m v
+     , KESSignAlgorithm IO v
      )
-  => proxy v
+  => Lock
+  -> Proxy m
+  -> Proxy v
   -> String
   -> TestTree
-testKESAlgorithm _p n =
+testKESAlgorithm lock _pm _pv n =
   testGroup n
-    [ testGroup "serialisation"
-      [ testGroup "raw"
+    [ testProperty "only gen signkey" $ prop_onlyGenSignKeyKES @v lock Proxy
+    , testProperty "only gen verkey" $ prop_onlyGenVerKeyKES @v lock Proxy
+    , testProperty "one update signkey" $ prop_oneUpdateSignKeyKES lock (Proxy @IO) (Proxy @v)
+    , testProperty "all updates signkey" $ prop_allUpdatesSignKeyKES lock (Proxy @IO) (Proxy @v)
+    , testProperty "total periods" $ prop_totalPeriodsKES lock (Proxy @IO) (Proxy @v)
+    , testProperty "same VerKey "  $ prop_deriveVerKeyKES lock (Proxy @IO) (Proxy @v)
+    , testGroup "serialisation"
+
+      [ testGroup "raw ser only"
+        [ testProperty "VerKey"  $ prop_raw_serialise_only @(VerKeyKES v)
+                                                           rawSerialiseVerKeyKES
+        , testProperty "Sig"     $ prop_raw_serialise_only @(SigKES v)
+                                                           rawSerialiseSigKES
+        , testProperty "SignKey" $ prop_raw_serialise_only @(SignKeyKES v)
+                                                           (unsafePerformIO . io . rawSerialiseSignKeyKES @m @v)
+        ]
+      , testGroup "raw"
         [ testProperty "VerKey"  $ prop_raw_serialise @(VerKeyKES v)
                                                       rawSerialiseVerKeyKES
                                                       rawDeserialiseVerKeyKES
-        , testProperty "SignKey" $ prop_raw_serialise @(SignKeyKES v)
-                                                      rawSerialiseSignKeyKES
-                                                      rawDeserialiseSignKeyKES
         , testProperty "Sig"     $ prop_raw_serialise @(SigKES v)
                                                       rawSerialiseSigKES
                                                       rawDeserialiseSigKES
+        , testProperty "SignKey" $ prop_raw_serialise_IO_from @(SignKeyKES v)
+                                                      (io . rawSerialiseSignKeyKES @m @v)
+                                                      (io . rawDeserialiseSignKeyKES @m @v)
+                                                      (io . genKeyKES @m @v)
         ]
 
       , testGroup "size"
         [ testProperty "VerKey"  $ prop_size_serialise @(VerKeyKES v)
                                                        rawSerialiseVerKeyKES
                                                        (sizeVerKeyKES (Proxy @ v))
-        , testProperty "SignKey" $ prop_size_serialise @(SignKeyKES v)
-                                                       rawSerialiseSignKeyKES
-                                                       (sizeSignKeyKES (Proxy @ v))
         , testProperty "Sig"     $ prop_size_serialise @(SigKES v)
                                                        rawSerialiseSigKES
                                                        (sizeSigKES (Proxy @ v))
@@ -110,50 +290,42 @@ testKESAlgorithm _p n =
         [ testProperty "VerKey"  $ prop_cbor_with @(VerKeyKES v)
                                                   encodeVerKeyKES
                                                   decodeVerKeyKES
-        , testProperty "SignKey" $ prop_cbor_with @(SignKeyKES v)
-                                                  encodeSignKeyKES
-                                                  decodeSignKeyKES
         , testProperty "Sig"     $ prop_cbor_with @(SigKES v)
                                                   encodeSigKES
                                                   decodeSigKES
+        , testProperty "SignKey" $ prop_cbor_with @(SignKeyKES v)
+                                                  (unsafePerformIO . io @m . encodeSignKeyKES @v)
+                                                  (fromJust . unsafePerformIO . io @m <$> decodeSignKeyKES @v)
         ]
 
       , testGroup "To/FromCBOR class"
         [ testProperty "VerKey"  $ prop_cbor @(VerKeyKES v)
-        , testProperty "SignKey" $ prop_cbor @(SignKeyKES v)
         , testProperty "Sig"     $ prop_cbor @(SigKES v)
         ]
       , testGroup "ToCBOR size"
         [ testProperty "VerKey"  $ prop_cbor_size @(VerKeyKES v)
-        , testProperty "SignKey" $ prop_cbor_size @(SignKeyKES v)
         , testProperty "Sig"     $ prop_cbor_size @(SigKES v)
         ]
 
       , testGroup "direct matches class"
         [ testProperty "VerKey"  $ prop_cbor_direct_vs_class @(VerKeyKES v)
                                                              encodeVerKeyKES
-        , testProperty "SignKey" $ prop_cbor_direct_vs_class @(SignKeyKES v)
-                                                             encodeSignKeyKES
         , testProperty "Sig"     $ prop_cbor_direct_vs_class @(SigKES v)
                                                              encodeSigKES
         ]
       ]
 
-    , testProperty "total periods" $ prop_totalPeriodsKES @v
-    , testProperty "same VerKey "  $ prop_deriveVerKeyKES @v
-
     , testGroup "verify"
-      [ testProperty "positive"           $ prop_verifyKES_positive         @v
-      , testProperty "negative (key)"     $ prop_verifyKES_negative_key     @v
-      , testProperty "negative (message)" $ prop_verifyKES_negative_message @v
+      [ testProperty "positive"           $ prop_verifyKES_positive         @IO @v lock Proxy Proxy
+      , testProperty "negative (key)"     $ prop_verifyKES_negative_key     @IO @v lock Proxy Proxy
+      , testProperty "negative (message)" $ prop_verifyKES_negative_message @IO @v lock Proxy Proxy
       , adjustOption (\(QuickCheckMaxSize sz) -> QuickCheckMaxSize (min sz 50)) $
-        testProperty "negative (period)"  $ prop_verifyKES_negative_period  @v
+        testProperty "negative (period)"  $ prop_verifyKES_negative_period  @IO @v lock Proxy Proxy
       ]
 
     , testGroup "serialisation of all KES evolutions"
-      [ testProperty "VerKey"  $ prop_serialise_VerKeyKES  @v
-      , testProperty "SignKey" $ prop_serialise_SignKeyKES @v
-      , testProperty "Sig"     $ prop_serialise_SigKES     @v
+      [ testProperty "VerKey"  $ prop_serialise_VerKeyKES  @IO @v lock Proxy Proxy
+      , testProperty "Sig"     $ prop_serialise_SigKES     @IO @v lock Proxy Proxy
       ]
 
     , testGroup "NoThunks"
@@ -164,43 +336,94 @@ testKESAlgorithm _p n =
     ]
 
 
+prop_onlyGenSignKeyKES
+  :: forall v.
+      KESSignAlgorithm IO v
+  => Lock -> Proxy v -> NaCl.MLockedSizedBytes (SeedSizeKES v) -> Property
+prop_onlyGenSignKeyKES lock _ seed = ioProperty . withLock lock $ do
+  _ <- genKeyKES @IO @v seed
+  return True
+
+prop_onlyGenVerKeyKES
+  :: forall v.
+      KESSignAlgorithm IO v
+  => Lock -> Proxy v -> NaCl.MLockedSizedBytes (SeedSizeKES v) -> Property
+prop_onlyGenVerKeyKES lock _ seed = ioProperty . withLock lock $ do
+  sk <- genKeyKES @IO @v seed
+  _ <- deriveVerKeyKES sk
+  return True
+
+prop_oneUpdateSignKeyKES 
+  :: forall m v.
+        ( ContextKES v ~ ()
+        , RunIO m
+        , MonadFail m
+        , KESSignAlgorithm m v
+        )
+  => Lock -> Proxy m -> Proxy v -> NaCl.MLockedSizedBytes (SeedSizeKES v) -> Property
+prop_oneUpdateSignKeyKES lock _ _ seed = ioProperty . withLock lock . io $ do
+  sk <- genKeyKES @m @v seed
+  msk' <- updateKES @m () sk 0
+  forgetSignKeyKES sk
+  maybe (return ()) forgetSignKeyKES msk'
+  return True
+
+prop_allUpdatesSignKeyKES 
+  :: forall m v.
+        ( ContextKES v ~ ()
+        , RunIO m
+        , KESSignAlgorithm m v
+        )
+  => Lock -> Proxy m -> Proxy v -> NaCl.MLockedSizedBytes (SeedSizeKES v) -> Property
+prop_allUpdatesSignKeyKES lock _ _ seed = ioProperty . withLock lock . io $ do
+  void $ withAllUpdatesKES_ @m @v seed $ const (return ())
+
 -- | If we start with a signing key, we can evolve it a number of times so that
 -- the total number of signing keys (including the initial one) equals the
 -- total number of periods for this algorithm.
 --
 prop_totalPeriodsKES
-  :: forall v. (KESAlgorithm v, ContextKES v ~ ())
-  => SignKeyKES v -> Property
-prop_totalPeriodsKES sk_0 =
-    totalPeriods > 0 ==>
-    counterexample (show totalPeriods) $
-    counterexample (show sks) $
-      length sks === totalPeriods
+  :: forall m v.
+        ( ContextKES v ~ ()
+        , RunIO m
+        , KESSignAlgorithm m v
+        )
+  => Lock -> Proxy m -> Proxy v -> NaCl.MLockedSizedBytes (SeedSizeKES v) -> Property
+prop_totalPeriodsKES lock _ _ seed =
+    ioProperty . withLock lock $ do
+        sks <- io $ withAllUpdatesKES_ @m @v seed (const . return $ ())
+        return $
+          totalPeriods > 0 ==>
+          counterexample (show totalPeriods) $
+          counterexample (show $ length sks) $
+          length sks === totalPeriods
   where
     totalPeriods :: Int
     totalPeriods = fromIntegral (totalPeriodsKES (Proxy :: Proxy v))
-
-    sks :: [SignKeyKES v]
-    sks = allUpdatesKES sk_0
 
 
 -- | If we start with a signing key, and all its evolutions, the verification
 -- keys we derive from each one are the same.
 --
 prop_deriveVerKeyKES
-  :: forall v. (KESAlgorithm v, ContextKES v ~ ())
-  => SignKeyKES v -> Property
-prop_deriveVerKeyKES sk_0 =
-    counterexample (show vks) $
-      conjoin [ vk === vk_0 | vk <- vks ]
-  where
-    sks :: [SignKeyKES v]
-    sks = allUpdatesKES sk_0
+  :: forall m v.
+      ( ContextKES v ~ ()
+      , RunIO m
+      , KESSignAlgorithm m v
+      )
+  => Lock -> Proxy m -> Proxy v -> NaCl.MLockedSizedBytes (SeedSizeKES v) -> Property
+prop_deriveVerKeyKES lock _ _ seed =
+    ioProperty . withLock lock $ do
+        vk_0 <- io $ do
+          sk_0 <- genKeyKES @m @v seed
+          vk_0 <- deriveVerKeyKES @m sk_0
+          forgetSignKeyKES sk_0
+          return vk_0
 
-    vk_0 = deriveVerKeyKES sk_0
-
-    vks :: [VerKeyKES v]
-    vks = map deriveVerKeyKES sks
+        vks <- io $ withAllUpdatesKES_ seed $ deriveVerKeyKES @m
+        return $
+          counterexample (show vks) $
+          conjoin (map (vk_0 ===) vks)
 
 
 -- | If we take an initial signing key, a sequence of messages to sign, and
@@ -208,17 +431,29 @@ prop_deriveVerKeyKES sk_0 =
 -- corresponding period.
 --
 prop_verifyKES_positive
-  :: forall v.
-     (KESAlgorithm v, ContextKES v ~ (), Signable v ~ SignableRepresentation)
-  => SignKeyKES v -> [Message] -> Property
-prop_verifyKES_positive sk_0 xs =
-    cover 1 (length xs >= totalPeriods) "covers total periods" $
-    conjoin [ counterexample ("period " ++ show t) $
-              verifyKES () vk t x sig === Right ()
-            | let vk = deriveVerKeyKES sk_0
-            , (t, x, sk) <- zip3 [0..] xs (allUpdatesKES sk_0)
-            , let sig = signKES () t x sk
-            ]
+  :: forall m v.
+     ( ContextKES v ~ ()
+     , Signable v ~ SignableRepresentation
+     , RunIO m
+     , KESSignAlgorithm m v
+     )
+  => Lock -> Proxy m -> Proxy v -> NaCl.MLockedSizedBytes (SeedSizeKES v) -> Gen Property
+prop_verifyKES_positive lock _ _ seed = do
+    xs :: [Message] <- vectorOf totalPeriods arbitrary
+    return $ checkCoverage $
+      cover 1 (length xs >= totalPeriods) "Message count covers total periods" $
+      (length xs > 0) ==>
+      ioProperty $ fmap conjoin $ withLock lock $ io $ do
+        sk_0 <- genKeyKES @m @v seed
+        vk <- deriveVerKeyKES @m sk_0
+        forgetSignKeyKES sk_0
+        withAllUpdatesKES seed $ \t sk -> do
+          let x = (cycle xs) !! (fromIntegral t)
+          sig <- signKES () t x sk
+          let verResult = verifyKES () vk t x sig
+          return $
+            counterexample ("period " ++ show t ++ "/" ++ show totalPeriods) $
+            verResult === Right ()
   where
     totalPeriods :: Int
     totalPeriods = fromIntegral (totalPeriodsKES (Proxy :: Proxy v))
@@ -229,37 +464,54 @@ prop_verifyKES_positive sk_0 xs =
 -- corresponding to a different signing key, then the verification fails.
 --
 prop_verifyKES_negative_key
-  :: forall v.
-     (KESAlgorithm v, ContextKES v ~ (),
-      Signable v ~ SignableRepresentation, Eq (SignKeyKES v))
-  => SignKeyKES v -> SignKeyKES v -> Message -> Property
-prop_verifyKES_negative_key sk_0 sk'_0 x =
-    sk_0 /= sk'_0 ==>
-    conjoin [ counterexample ("period " ++ show t) $
-              verifyKES () vk' t x sig =/= Right ()
-            | let sks = allUpdatesKES sk_0
-                  vk' = deriveVerKeyKES sk'_0
-            , (t, sk) <- zip [0..] sks
-            , let sig = signKES () t x sk
-            ]
+  :: forall m v.
+     ( ContextKES v ~ ()
+     , Signable v ~ SignableRepresentation
+     , RunIO m
+     , KESSignAlgorithm m v
+     )
+  => Lock -> Proxy m -> Proxy v
+  -> NaCl.MLockedSizedBytes (SeedSizeKES v) -> NaCl.MLockedSizedBytes (SeedSizeKES v)
+  -> Message
+  -> Property
+prop_verifyKES_negative_key lock _ _ seed seed' x =
+    seed /= seed' ==> ioProperty $ fmap conjoin $ withLock lock $ io $ do
+        sk_0' <- genKeyKES @m @v seed'
+        vk' <- deriveVerKeyKES sk_0'
+        forgetSignKeyKES sk_0'
+        withAllUpdatesKES seed $ \t sk -> do
+          sig <- signKES () t x sk
+          let verResult = verifyKES () vk' t x sig
+          return $
+            counterexample ("period " ++ show t) $
+            verResult =/= Right ()
 
 -- | If we sign a message @a@ with one list of signing key evolutions, if we
 -- try to verify the signature with a message other than @a@, then the
 -- verification fails.
 --
 prop_verifyKES_negative_message
-  :: forall v.
-     (KESAlgorithm v, ContextKES v ~ (), Signable v ~ SignableRepresentation)
-  => SignKeyKES v -> Message -> Message -> Property
-prop_verifyKES_negative_message sk_0 x x' =
-    x /= x' ==>
-    conjoin [ counterexample ("period " ++ show t) $
-              verifyKES () vk t x' sig =/= Right ()
-            | let sks = allUpdatesKES sk_0
-                  vk  = deriveVerKeyKES sk_0
-            , (t, sk) <- zip [0..] sks
-            , let sig = signKES () t x sk
-            ]
+  :: forall m v.
+     ( ContextKES v ~ ()
+     , Signable v ~ SignableRepresentation
+     , RunIO m
+     , KESSignAlgorithm m v
+     )
+  => Lock -> Proxy m -> Proxy v
+  -> NaCl.MLockedSizedBytes (SeedSizeKES v)
+  -> Message -> Message
+  -> Property
+prop_verifyKES_negative_message lock _ _ seed x x' =
+    x /= x' ==> ioProperty $ fmap conjoin $ withLock lock $ io $ do
+        sk_0 <- genKeyKES @m @v seed
+        vk <- deriveVerKeyKES @m sk_0
+        forgetSignKeyKES sk_0
+        withAllUpdatesKES seed $ \t sk -> do
+          sig <- signKES () t x sk
+          let verResult = verifyKES () vk t x' sig
+          return $
+            counterexample ("period " ++ show t) $
+            verResult =/= Right ()
 
 -- | If we sign a message @a@ with one list of signing key evolutions, if we
 -- try to verify the signature (and message @a@) using the right verification
@@ -267,120 +519,145 @@ prop_verifyKES_negative_message sk_0 x x' =
 -- verification fails.
 --
 prop_verifyKES_negative_period
-  :: forall v.
-     (KESAlgorithm v, ContextKES v ~ (), Signable v ~ SignableRepresentation)
-  => SignKeyKES v -> Message -> Property
-prop_verifyKES_negative_period sk_0 x =
-    conjoin [ counterexample ("periods " ++ show (t, t')) $
-              verifyKES () vk t' x sig =/= Right ()
-            | let sks = allUpdatesKES sk_0
-                  vk  = deriveVerKeyKES sk_0
-            , (t, sk) <- zip [0..] sks
-            , let sig = signKES () t x sk
-            , (t', _) <- zip [0..] sks
-            , t /= t'
-            ]
+  :: forall m v.
+     ( ContextKES v ~ ()
+     , Signable v ~ SignableRepresentation
+     , RunIO m
+     , KESSignAlgorithm m v
+     )
+  => Lock -> Proxy m -> Proxy v
+  -> NaCl.MLockedSizedBytes (SeedSizeKES v)
+  -> Message
+  -> Property
+prop_verifyKES_negative_period lock _ _ seed x =
+    ioProperty $ fmap conjoin $ withLock lock $ io $ do
+        sk_0 <- genKeyKES @m @v seed
+        vk <- deriveVerKeyKES @m sk_0
+        forgetSignKeyKES sk_0
+        withAllUpdatesKES seed $ \t sk -> do
+            sig <- signKES () t x sk
+            return $
+              conjoin [ counterexample ("periods " ++ show (t, t')) $
+                        verifyKES () vk t' x sig =/= Right ()
+                      | t' <- [0..totalPeriods-1]
+                      , t /= t'
+                      ]
+  where
+    totalPeriods :: Word
+    totalPeriods = fromIntegral (totalPeriodsKES (Proxy :: Proxy v))
 
 
 -- | Check 'prop_raw_serialise', 'prop_cbor_with' and 'prop_size_serialise'
 -- for 'VerKeyKES' on /all/ the KES key evolutions.
 --
 prop_serialise_VerKeyKES
-  :: forall v.
-     (KESAlgorithm v, ContextKES v ~ ())
-  => SignKeyKES v -> Property
-prop_serialise_VerKeyKES sk_0 =
-    conjoin
-      [ counterexample ("period " ++ show (t :: Int)) $
-        counterexample ("vkey " ++ show vk) $
-           prop_raw_serialise rawSerialiseVerKeyKES
-                              rawDeserialiseVerKeyKES vk
-       .&. prop_cbor_with encodeVerKeyKES
-                          decodeVerKeyKES vk
-       .&. prop_size_serialise rawSerialiseVerKeyKES
-                               (sizeVerKeyKES (Proxy @ v)) vk
-      | (t, vk) <- zip [0..] (map deriveVerKeyKES (allUpdatesKES sk_0)) ]
-
-
--- | Check 'prop_raw_serialise', 'prop_cbor_with' and 'prop_size_serialise'
--- for 'SignKeyKES' on /all/ the KES key evolutions.
---
-prop_serialise_SignKeyKES
-  :: forall v.
-     (KESAlgorithm v, ContextKES v ~ (), Eq (SignKeyKES v))
-  => SignKeyKES v -> Property
-prop_serialise_SignKeyKES sk_0 =
-    conjoin
-      [ counterexample ("period " ++ show (t :: Int)) $
-        counterexample ("skey " ++ show sk) $
-           prop_raw_serialise rawSerialiseSignKeyKES
-                              rawDeserialiseSignKeyKES sk
-       .&. prop_cbor_with encodeSignKeyKES
-                          decodeSignKeyKES sk
-       .&. prop_size_serialise rawSerialiseSignKeyKES
-                               (sizeSignKeyKES (Proxy @ v)) sk
-      | (t, sk) <- zip [0..] (allUpdatesKES sk_0) ]
-
+  :: forall m v.
+     ( ContextKES v ~ ()
+     , RunIO m
+     , KESSignAlgorithm m v
+     )
+  => Lock -> Proxy m -> Proxy v -> NaCl.MLockedSizedBytes (SeedSizeKES v) -> Property
+prop_serialise_VerKeyKES lock _ _ seed =
+    ioProperty $ fmap conjoin $ withLock lock $ io $ do
+        withAllUpdatesKES @m @v seed $ \t sk -> do
+          vk <- deriveVerKeyKES @m sk
+          return $
+                 counterexample ("period " ++ show t) $
+                 counterexample ("vkey " ++ show vk) $
+                    prop_raw_serialise rawSerialiseVerKeyKES
+                                       rawDeserialiseVerKeyKES vk
+                .&. prop_cbor_with encodeVerKeyKES
+                                   decodeVerKeyKES vk
+                .&. prop_size_serialise rawSerialiseVerKeyKES
+                                        (sizeVerKeyKES (Proxy @ v)) vk
 
 -- | Check 'prop_raw_serialise', 'prop_cbor_with' and 'prop_size_serialise'
 -- for 'SigKES' on /all/ the KES key evolutions.
 --
 prop_serialise_SigKES
-  :: forall v.
-     (KESAlgorithm v, ContextKES v ~ (), Signable v ~ SignableRepresentation)
-  => SignKeyKES v -> Message -> Property
-prop_serialise_SigKES sk_0 x =
-    conjoin
-      [ counterexample ("period " ++ show t) $
-        counterexample ("vkey "   ++ show sk) $
-        counterexample ("sig "    ++ show sig) $
-           prop_raw_serialise rawSerialiseSigKES
-                              rawDeserialiseSigKES sig
-       .&. prop_cbor_with encodeSigKES
-                          decodeSigKES sig
-       .&. prop_size_serialise rawSerialiseSigKES
-                               (sizeSigKES (Proxy @ v)) sig
-      | (t, sk) <- zip [0..] (allUpdatesKES sk_0)
-      , let sig = signKES () t x sk
-      ]
-
+  :: forall m v.
+     ( ContextKES v ~ ()
+     , Signable v ~ SignableRepresentation
+     , Show (SignKeyKES v)
+     , RunIO m
+     , KESSignAlgorithm m v
+     )
+  => Lock -> Proxy m -> Proxy v -> NaCl.MLockedSizedBytes (SeedSizeKES v) -> Message -> Property
+prop_serialise_SigKES lock _ _ seed x =
+    ioProperty $ fmap conjoin $ withLock lock $ io $ do
+        withAllUpdatesKES @m @v seed $ \t sk -> do
+            sig <- signKES () t x sk
+            return $
+              counterexample ("period " ++ show t) $
+              counterexample ("vkey "   ++ show sk) $
+              counterexample ("sig "    ++ show sig) $
+                  prop_raw_serialise rawSerialiseSigKES
+                                     rawDeserialiseSigKES sig
+              .&. prop_cbor_with encodeSigKES
+                                 decodeSigKES sig
+              .&. prop_size_serialise rawSerialiseSigKES
+                                      (sizeSigKES (Proxy @ v)) sig
 
 --
 -- KES test utils
 --
 
-allUpdatesKES :: forall v. (KESAlgorithm v, ContextKES v ~ ())
-              => SignKeyKES v -> [SignKeyKES v]
-allUpdatesKES sk_0 =
-    sk_0 : unfoldr update (sk_0, 0)
-  where
-    update :: (SignKeyKES v, Period)
-           -> Maybe (SignKeyKES v, (SignKeyKES v, Period))
-    update (sk, t) =
-      case updateKES () sk t of
-        Nothing  -> Nothing
-        Just sk' -> Just (sk', (sk', t+1))
+withAllUpdatesKES_ :: forall m v a.
+                  ( KESSignAlgorithm m v
+                  , ContextKES v ~ ()
+                  )
+              => NaCl.MLockedSizedBytes (SeedSizeKES v)
+              -> (SignKeyKES v -> m a)
+              -> m [a]
+withAllUpdatesKES_ seed f = do
+  withAllUpdatesKES seed (const f)
 
+withAllUpdatesKES :: forall m v a.
+                  ( KESSignAlgorithm m v
+                  , ContextKES v ~ ()
+                  )
+              => NaCl.MLockedSizedBytes (SeedSizeKES v)
+              -> (Word -> SignKeyKES v -> m a)
+              -> m [a]
+withAllUpdatesKES seed f = do
+  sk_0 <- genKeyKES seed
+  go sk_0 0
+  where
+    go :: SignKeyKES v -> Word -> m [a]
+    go sk t = do
+      x <- f t sk
+      msk' <- updateKES () sk t
+      case msk' of
+        Nothing -> do
+          forgetSignKeyKES sk
+          return [x]
+        Just sk' -> do
+          forgetSignKeyKES sk
+          xs <- go sk' (t + 1)
+          return $ x:xs
 
 --
 -- Arbitrary instances
 --
 
-instance KESAlgorithm v => Arbitrary (VerKeyKES v) where
-  arbitrary = deriveVerKeyKES <$> arbitrary
+instance (KESSignAlgorithm IO v) => Arbitrary (SignKeyKES v) where
+  arbitrary = unsafePerformIO . genKeyKES <$> arbitrary
   shrink = const []
 
-instance KESAlgorithm v => Arbitrary (SignKeyKES v) where
-  arbitrary = genKeyKES <$> arbitrarySeedOfSize seedSize
-    where
-      seedSize = seedSizeKES (Proxy :: Proxy v)
+instance (KESSignAlgorithm IO v) => Arbitrary (VerKeyKES v) where
+  arbitrary = unsafePerformIO . deriveVerKeyKES <$> arbitrary
   shrink = const []
 
-instance (KESAlgorithm v, ContextKES v ~ (), Signable v ~ SignableRepresentation)
+instance ( KESSignAlgorithm IO v
+         , ContextKES v ~ ()
+         , Signable v ~ SignableRepresentation
+         )
       => Arbitrary (SigKES v) where
   arbitrary = do
     a <- arbitrary :: Gen Message
     sk <- arbitrary
-    let sig = signKES () 0 a sk
+    let sig = unsafePerformIO $ signKES () 0 a sk
     return sig
   shrink = const []
+
+-- MLockedSizedBytes

--- a/cardano-crypto-tests/src/Test/Crypto/RunIO.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/RunIO.hs
@@ -1,0 +1,13 @@
+module Test.Crypto.RunIO
+where
+
+import Control.Monad.Identity
+
+class RunIO m where
+  io :: m a -> IO a
+
+instance RunIO IO where
+  io = id
+
+instance RunIO Identity where
+  io = return . runIdentity

--- a/cardano-crypto-tests/src/Test/Crypto/Util.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/Util.hs
@@ -4,22 +4,39 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE LambdaCase #-}
 
 module Test.Crypto.Util
   ( -- * CBOR
     FromCBOR (..)
   , ToCBOR (..)
   , prop_cbor
+  , prop_cbor_IO_from
+  , prop_cbor_IO_with
   , prop_cbor_size
+  , prop_cbor_size_IO_from
+  , prop_cbor_size_IO_with
   , prop_cbor_with
+  , prop_cbor_with_IO_from
+  , prop_cbor_with_IO_with
   , prop_cbor_valid
   , prop_cbor_roundtrip
   , prop_raw_serialise
+  , prop_raw_serialise_IO_from
+  , prop_raw_serialise_IO_with
+  , prop_raw_serialise_only
   , prop_size_serialise
+  , prop_size_serialise_IO
+  , prop_size_serialise_IO_from
+  , prop_size_serialise_IO_with
   , prop_cbor_direct_vs_class
+  , prop_cbor_direct_vs_class_IO_from 
+  , prop_cbor_direct_vs_class_IO_with
 
     -- * NoThunks
   , prop_no_thunks
+  , prop_no_thunks_IO_from 
+  , prop_no_thunks_IO_with 
 
     -- * Test Seed
   , TestSeed (..)
@@ -29,9 +46,15 @@ module Test.Crypto.Util
 
     -- * Seeds
   , arbitrarySeedOfSize
+  , arbitrarySeedBytesOfSize
 
    -- * test messages for signings
   , Message(..)
+
+   -- * Locking
+  , Lock
+  , withLock
+  , newLock
   )
 where
 
@@ -65,8 +88,20 @@ import Test.QuickCheck
   , property
   , shrink
   , vector
+  , ioProperty
+  , generate
   )
 import Formatting.Buildable (Buildable (..))
+import Control.Monad (join)
+import Control.Concurrent.MVar (withMVar, MVar, newMVar)
+
+type Lock = MVar ()
+
+withLock :: Lock -> IO a -> IO a
+withLock lock = withMVar lock . const
+
+newLock :: IO Lock
+newLock = newMVar ()
 
 --------------------------------------------------------------------------------
 -- Connecting MonadRandom to Gen
@@ -100,7 +135,12 @@ instance Arbitrary TestSeed where
 --------------------------------------------------------------------------------
 
 arbitrarySeedOfSize :: Word -> Gen Seed
-arbitrarySeedOfSize sz = mkSeedFromBytes . BS.pack <$> vector (fromIntegral sz)
+arbitrarySeedOfSize sz =
+  mkSeedFromBytes <$> arbitrarySeedBytesOfSize sz
+
+arbitrarySeedBytesOfSize :: Word -> Gen ByteString
+arbitrarySeedBytesOfSize sz =
+  BS.pack <$> vector (fromIntegral sz)
 
 --------------------------------------------------------------------------------
 -- Messages to sign
@@ -122,6 +162,14 @@ prop_cbor :: (ToCBOR a, FromCBOR a, Eq a, Show a)
           => a -> Property
 prop_cbor = prop_cbor_with toCBOR fromCBOR
 
+prop_cbor_IO_from :: (ToCBOR a, FromCBOR a, Eq a, Show a)
+          => Lock -> (b -> IO a) -> b -> Property
+prop_cbor_IO_from lock = prop_cbor_with_IO_from lock toCBOR fromCBOR
+
+prop_cbor_IO_with :: (ToCBOR a, FromCBOR a, Eq a, Show a)
+          => Lock -> (Gen (IO a)) -> Property
+prop_cbor_IO_with lock = prop_cbor_with_IO_with lock toCBOR fromCBOR
+
 prop_cbor_size :: forall a. ToCBOR a => a -> Property
 prop_cbor_size a = counterexample (show lo ++ " ≰ " ++ show len) (lo <= len)
               .&&. counterexample (show len ++ " ≰ " ++ show hi) (len <= hi)
@@ -133,14 +181,49 @@ prop_cbor_size a = counterexample (show lo ++ " ≰ " ++ show len) (lo <= len)
         Right x -> x
         Left err -> error . show . build $ err
 
+prop_cbor_size_IO_from :: forall a b. ToCBOR a => (b -> IO a) -> b -> Property
+prop_cbor_size_IO_from mkX y = ioProperty $ do
+  x <- mkX y
+  return $ prop_cbor_size x
+
+prop_cbor_size_IO_with :: forall a. ToCBOR a => (Gen (IO a)) -> Property
+prop_cbor_size_IO_with mkX = ioProperty $ do
+  x <- join (generate mkX)
+  return $ prop_cbor_size x
+
 
 prop_cbor_with :: (Eq a, Show a)
                => (a -> Encoding)
                -> (forall s. Decoder s a)
-               -> a -> Property
+               -> a
+               -> Property
 prop_cbor_with encoder decoder x =
       prop_cbor_valid     encoder         x
  .&&. prop_cbor_roundtrip encoder decoder x
+
+prop_cbor_with_IO_from :: (Eq a, Show a)
+               => Lock
+               -> (a -> Encoding)
+               -> (forall s. Decoder s a)
+               -> (b -> IO a)
+               -> b
+               -> Property
+prop_cbor_with_IO_from lock encoder decoder mkX y =
+  ioProperty $
+  withLock lock $ do
+    x <- mkX y
+    return $ prop_cbor_with encoder decoder x
+
+prop_cbor_with_IO_with :: (Eq a, Show a)
+               => Lock
+               -> (a -> Encoding)
+               -> (forall s. Decoder s a)
+               -> (Gen (IO a))
+               -> Property
+prop_cbor_with_IO_with lock encoder decoder mkX =
+  ioProperty $ withLock lock $ do
+    x <- join (generate mkX)
+    return $ prop_cbor_with encoder decoder x
 
 
 prop_cbor_valid :: (a -> Encoding) -> a -> Property
@@ -168,11 +251,43 @@ prop_cbor_roundtrip encoder decoder x =
 prop_raw_serialise :: (Eq a, Show a)
                    => (a -> ByteString)
                    -> (ByteString -> Maybe a)
-                   -> a -> Property
+                   -> a
+                   -> Property
 prop_raw_serialise serialise deserialise x =
     case deserialise (serialise x) of
       Just y  -> y === x
       Nothing -> property False
+
+prop_raw_serialise_IO_with :: forall a. (Eq a, Show a)
+                   => (a -> IO ByteString)
+                   -> (ByteString -> IO (Maybe a))
+                   -> Gen (IO a)
+                   -> Property
+prop_raw_serialise_IO_with serialise deserialise mkX =
+  ioProperty $ do
+    x <- join (generate mkX)
+    serialise x >>= deserialise >>= \case
+      Just y  -> return (y === x)
+      Nothing -> return (property False)
+
+prop_raw_serialise_IO_from :: forall a b. (Eq a, Show a)
+                   => (a -> IO ByteString)
+                   -> (ByteString -> IO (Maybe a))
+                   -> (b -> IO a)
+                   -> b
+                   -> Property
+prop_raw_serialise_IO_from serialise deserialise mkX seed = do
+  ioProperty $ do
+    x <- mkX seed
+    serialise x >>= deserialise >>= \case
+      Just y  -> return (y === x)
+      Nothing -> return (property False)
+
+prop_raw_serialise_only :: (a -> ByteString)
+                        -> a -> Bool
+prop_raw_serialise_only serialise x =
+    let y = serialise x
+    in y `seq` True
 
 -- | The crypto algorithm classes have direct encoding functions, and the key
 -- types are also typically a member of the 'ToCBOR' class. Where a 'ToCBOR'
@@ -184,10 +299,43 @@ prop_cbor_direct_vs_class :: ToCBOR a
 prop_cbor_direct_vs_class encoder x =
   toFlatTerm (encoder x) === toFlatTerm (toCBOR x)
 
+prop_cbor_direct_vs_class_IO_from :: ToCBOR a
+                          => (a -> Encoding)
+                          -> (b -> IO a)
+                          -> b
+                          -> Property
+prop_cbor_direct_vs_class_IO_from encoder mkX y =
+  ioProperty $ do
+    x <- mkX y
+    return $ prop_cbor_direct_vs_class encoder x
+
+prop_cbor_direct_vs_class_IO_with :: ToCBOR a
+                          => (a -> Encoding)
+                          -> (Gen (IO a))
+                          -> Property
+prop_cbor_direct_vs_class_IO_with encoder mkX =
+  ioProperty $ do
+    x <- join (generate mkX)
+    return $ prop_cbor_direct_vs_class encoder x
 
 prop_size_serialise :: (a -> ByteString) -> Word -> a -> Property
 prop_size_serialise serialise size x =
     BS.length (serialise x) === fromIntegral size
+
+prop_size_serialise_IO :: (a -> IO ByteString) -> Word -> a -> Property
+prop_size_serialise_IO serialise size = prop_size_serialise_IO_from serialise size return
+
+prop_size_serialise_IO_from :: (a -> IO ByteString) -> Word -> (b -> IO a) -> b -> Property
+prop_size_serialise_IO_from serialise size mkX y = ioProperty $ do
+    x <- mkX y
+    actual <- BS.length <$> serialise x
+    return $ actual === fromIntegral size
+
+prop_size_serialise_IO_with :: (a -> IO ByteString) -> Word -> (Gen (IO a)) -> Property
+prop_size_serialise_IO_with serialise size mkX = ioProperty $ do
+    x <- join (generate mkX)
+    actual <- BS.length <$> serialise x
+    return $ actual === fromIntegral size
 
 --------------------------------------------------------------------------------
 -- NoThunks
@@ -198,3 +346,13 @@ prop_no_thunks :: NoThunks a => a -> Property
 prop_no_thunks !a = case unsafeNoThunks a of
     Nothing  -> property True
     Just msg -> counterexample (show msg) (property False)
+
+prop_no_thunks_IO_from :: NoThunks a => Lock -> (b -> IO a) -> b -> Property
+prop_no_thunks_IO_from lock mkX y = ioProperty . withLock lock $ do
+  x <- mkX y
+  return $ prop_no_thunks x
+
+prop_no_thunks_IO_with :: NoThunks a => Lock -> (Gen (IO a)) -> Property
+prop_no_thunks_IO_with lock mkX = ioProperty . withLock lock $ do
+  x <- join (generate mkX)
+  return $ prop_no_thunks x

--- a/cardano-crypto-tests/src/Test/Crypto/VRF.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/VRF.hs
@@ -13,7 +13,8 @@ where
 
 import Cardano.Crypto.VRF
 import Cardano.Crypto.VRF.Praos
-import Cardano.Crypto.VRF.PraosBatchCompat
+-- TODO: re-enable once the audit is complete:
+-- import Cardano.Crypto.VRF.PraosBatchCompat
 import Cardano.Crypto.Util
 
 import qualified Data.ByteString as BS
@@ -38,7 +39,8 @@ tests =
     [ testVRFAlgorithm (Proxy :: Proxy MockVRF) "MockVRF"
     , testVRFAlgorithm (Proxy :: Proxy SimpleVRF) "SimpleVRF"
     , testVRFAlgorithm (Proxy :: Proxy PraosVRF) "PraosVRF"
-    , testVRFAlgorithm (Proxy :: Proxy PraosBatchCompatVRF) "PraosBatchCompatVRF"
+    -- Disabled until VRF10 audit is copmplete:
+    -- , testVRFAlgorithm (Proxy :: Proxy PraosBatchCompatVRF) "PraosBatchCompatVRF"
 
     , testGroup "OutputVRF"
       [ testProperty "bytesToNatural" prop_bytesToNatural

--- a/cardano-crypto-tests/test/Main.hs
+++ b/cardano-crypto-tests/test/Main.hs
@@ -7,20 +7,22 @@ import qualified Test.Crypto.VRF (tests)
 import Test.Tasty (TestTree, adjustOption, testGroup, defaultMain)
 import Test.Tasty.QuickCheck (QuickCheckTests (QuickCheckTests))
 import Cardano.Crypto.Libsodium (sodiumInit)
+import Test.Crypto.Util (Lock, newLock)
 
 main :: IO ()
 main = do
     sodiumInit
-    defaultMain tests
+    lock <- newLock
+    defaultMain (tests lock)
 
-tests :: TestTree
-tests =
+tests :: Lock -> TestTree
+tests lock =
   -- The default QuickCheck test count is 100. This is too few to catch
   -- anything, so we set a minimum of 1000.
   adjustOption (\(QuickCheckTests i) -> QuickCheckTests $ max i 1000) . 
     testGroup "cardano-crypto-class" $
-      [ Test.Crypto.DSIGN.tests
+      [ Test.Crypto.DSIGN.tests lock
       , Test.Crypto.Hash.tests
-      , Test.Crypto.KES.tests
+      , Test.Crypto.KES.tests lock
       , Test.Crypto.VRF.tests
       ]

--- a/slotting/cardano-slotting.cabal
+++ b/slotting/cardano-slotting.cabal
@@ -1,4 +1,4 @@
-cabal-version: 2.2
+cabal-version: 3.0
 
 name:                cardano-slotting
 version:             0.1.0.0
@@ -24,7 +24,6 @@ common base                         { build-depends: base                       
 
 common project-config
   default-language:     Haskell2010
-  hs-source-dirs:       src
   ghc-options:          -Wall
                         -Wcompat
                         -Wincomplete-record-updates
@@ -37,11 +36,13 @@ common project-config
 
 library
   import:               base, project-config
+  hs-source-dirs:       src
 
   exposed-modules:
                         Cardano.Slotting.Block
                         Cardano.Slotting.EpochInfo
                         Cardano.Slotting.EpochInfo.API
+                        Cardano.Slotting.EpochInfo.Extend
                         Cardano.Slotting.EpochInfo.Impl
                         Cardano.Slotting.Slot
                         Cardano.Slotting.Time
@@ -56,3 +57,16 @@ library
                       , quiet
                       , serialise
                       , time             >=1.9.1 && <1.11
+
+test-suite tests
+  import:               base, project-config
+  type:                 exitcode-stdio-1.0
+  hs-source-dirs:       test
+  main-is:              Main.hs
+  other-modules:      Test.Cardano.Slotting.EpochInfo
+  build-depends:        base
+                      , cardano-slotting
+                      , tasty
+                      , tasty-quickcheck
+
+  ghc-options:          -threaded -rtsopts -with-rtsopts=-N

--- a/slotting/src/Cardano/Slotting/EpochInfo/API.hs
+++ b/slotting/src/Cardano/Slotting/EpochInfo/API.hs
@@ -11,6 +11,7 @@ module Cardano.Slotting.EpochInfo.API
     epochInfoRange,
     epochInfoSlotToRelativeTime,
     epochInfoSlotToUTCTime,
+    epochInfoSlotLength,
 
     -- * Utility
     hoistEpochInfo,
@@ -19,7 +20,7 @@ module Cardano.Slotting.EpochInfo.API
 where
 
 import Cardano.Slotting.Slot (EpochNo (..), EpochSize (..), SlotNo (..))
-import Cardano.Slotting.Time (RelativeTime, SystemStart, fromRelativeTime)
+import Cardano.Slotting.Time (RelativeTime, SystemStart, fromRelativeTime, SlotLength)
 import Control.Monad.Morph (generalize)
 import Data.Functor.Identity
 import Data.Time.Clock (UTCTime)
@@ -59,7 +60,10 @@ data EpochInfo m
         --
         -- See also 'epochInfoSlotToUTCTime'.
         epochInfoSlotToRelativeTime_ ::
-          HasCallStack => SlotNo -> m RelativeTime
+          HasCallStack => SlotNo -> m RelativeTime,
+        -- | Return the length of the specified slot.
+        epochInfoSlotLength_ ::
+          HasCallStack => SlotNo -> m SlotLength
       }
   deriving NoThunks via OnlyCheckWhnfNamed "EpochInfo" (EpochInfo m)
 
@@ -105,6 +109,10 @@ epochInfoSlotToRelativeTime ::
   HasCallStack => EpochInfo m -> SlotNo -> m RelativeTime
 epochInfoSlotToRelativeTime = epochInfoSlotToRelativeTime_
 
+epochInfoSlotLength ::
+  HasCallStack => EpochInfo m -> SlotNo -> m SlotLength
+epochInfoSlotLength = epochInfoSlotLength_
+
 {-------------------------------------------------------------------------------
   Utility
 -------------------------------------------------------------------------------}
@@ -114,7 +122,8 @@ hoistEpochInfo f ei = EpochInfo
   { epochInfoSize_ = f . epochInfoSize ei,
     epochInfoFirst_ = f . epochInfoFirst ei,
     epochInfoEpoch_ = f . epochInfoEpoch ei,
-    epochInfoSlotToRelativeTime_ = f . epochInfoSlotToRelativeTime ei
+    epochInfoSlotToRelativeTime_ = f . epochInfoSlotToRelativeTime ei,
+    epochInfoSlotLength_ = f . epochInfoSlotLength ei
   }
 
 generalizeEpochInfo :: Monad m => EpochInfo Identity -> EpochInfo m

--- a/slotting/src/Cardano/Slotting/EpochInfo/Extend.hs
+++ b/slotting/src/Cardano/Slotting/EpochInfo/Extend.hs
@@ -1,0 +1,72 @@
+module Cardano.Slotting.EpochInfo.Extend where
+
+import Cardano.Slotting.EpochInfo.API (EpochInfo (..))
+import Cardano.Slotting.Slot (EpochNo (EpochNo), EpochSize (EpochSize), SlotNo (SlotNo))
+import Cardano.Slotting.Time
+  ( SlotLength (getSlotLength),
+    addRelativeTime,
+    multNominalDiffTime,
+  )
+
+-- | Given a basis point, use it and its slot length to impute a linear
+-- relationship between slots and time in order to extend an 'EpochInfo' to
+-- infinity.
+--
+-- The returned `EpochInfo` may still fail (according to the semantics of the
+-- specified monad) if any of the underlying operations fail. For example, if we
+-- cannot translate the basis point.
+unsafeLinearExtendEpochInfo ::
+  Monad m =>
+  SlotNo ->
+  EpochInfo m ->
+  EpochInfo m
+unsafeLinearExtendEpochInfo basisSlot underlyingEI =
+  let lastKnownEpochM = epochInfoEpoch_ underlyingEI basisSlot
+
+      goSize = \en -> do
+        lke <- lastKnownEpochM
+        if en <= lke
+          then epochInfoSize_ underlyingEI en
+          else epochInfoSize_ underlyingEI lke
+      goFirst = \en -> do
+        lke <- lastKnownEpochM
+        if en <= lke
+          then epochInfoFirst_ underlyingEI en
+          else do
+            SlotNo lkeStart <- epochInfoFirst_ underlyingEI lke
+            EpochSize sz <- epochInfoSize_ underlyingEI en
+            let EpochNo numEpochs = en - lke
+            pure . SlotNo $ lkeStart + (numEpochs * sz)
+      goEpoch = \sn ->
+        if sn <= basisSlot
+          then epochInfoEpoch_ underlyingEI sn
+          else do
+            lke <- lastKnownEpochM
+            lkeStart <- epochInfoFirst_ underlyingEI lke
+            EpochSize sz <- epochInfoSize_ underlyingEI lke
+            let SlotNo slotsForward = sn - lkeStart
+            pure . (lke +) . EpochNo $ slotsForward `div` sz
+      goTime = \sn ->
+        if sn <= basisSlot
+          then epochInfoSlotToRelativeTime_ underlyingEI sn
+          else do
+            let SlotNo slotDiff = sn - basisSlot
+
+            a1 <- epochInfoSlotToRelativeTime_ underlyingEI basisSlot
+            lgth <- epochInfoSlotLength_ underlyingEI basisSlot
+
+            pure $
+              addRelativeTime
+                (multNominalDiffTime (getSlotLength lgth) slotDiff)
+                a1
+      goLength = \sn ->
+        if sn <= basisSlot
+          then epochInfoSlotLength_ underlyingEI sn
+          else epochInfoSlotLength_ underlyingEI basisSlot
+   in EpochInfo
+        { epochInfoSize_ = goSize,
+          epochInfoFirst_ = goFirst,
+          epochInfoEpoch_ = goEpoch,
+          epochInfoSlotToRelativeTime_ = goTime,
+          epochInfoSlotLength_ = goLength
+        }

--- a/slotting/src/Cardano/Slotting/EpochInfo/Impl.hs
+++ b/slotting/src/Cardano/Slotting/EpochInfo/Impl.hs
@@ -20,7 +20,8 @@ fixedEpochInfo (EpochSize size) slotLength = EpochInfo
     epochInfoFirst_ = \e -> return $ fixedEpochInfoFirst (EpochSize size) e,
     epochInfoEpoch_ = \sl -> return $ fixedEpochInfoEpoch (EpochSize size) sl,
     epochInfoSlotToRelativeTime_ = \(SlotNo slot) ->
-      return $ RelativeTime (fromIntegral slot * getSlotLength slotLength)
+      return $ RelativeTime (fromIntegral slot * getSlotLength slotLength),
+    epochInfoSlotLength_ = const $ pure slotLength
   }
 
 -- | The pure computation underlying 'epochInfoFirst' applied to

--- a/slotting/src/Cardano/Slotting/Time.hs
+++ b/slotting/src/Cardano/Slotting/Time.hs
@@ -11,7 +11,10 @@ module Cardano.Slotting.Time (
   , addRelativeTime
   , diffRelativeTime
   , fromRelativeTime
+  , multRelativeTime
   , toRelativeTime
+    -- * Nominal diff time
+  , multNominalDiffTime
     -- * Slot length
   , getSlotLength
   , mkSlotLength
@@ -28,7 +31,14 @@ import           Cardano.Binary (FromCBOR(..), ToCBOR(..))
 import           Codec.Serialise
 import           Control.Exception (assert)
 import           Data.Fixed
-import           Data.Time (NominalDiffTime, UTCTime, addUTCTime, diffUTCTime)
+import           Data.Time
+                  ( NominalDiffTime,
+                    UTCTime,
+                    addUTCTime,
+                    diffUTCTime,
+                    nominalDiffTimeToSeconds,
+                    secondsToNominalDiffTime,
+                  )
 import           GHC.Generics (Generic)
 import           NoThunks.Class (InspectHeap (..), NoThunks)
 import           Quiet
@@ -69,6 +79,16 @@ toRelativeTime (SystemStart t) t' = assert (t' >= t) $
 
 fromRelativeTime :: SystemStart -> RelativeTime -> UTCTime
 fromRelativeTime (SystemStart t) (RelativeTime t') = addUTCTime t' t
+
+multRelativeTime :: Integral f => RelativeTime -> f -> RelativeTime
+multRelativeTime (RelativeTime t) =
+  RelativeTime . multNominalDiffTime t
+
+multNominalDiffTime :: Integral f => NominalDiffTime -> f -> NominalDiffTime
+multNominalDiffTime t f =
+  secondsToNominalDiffTime $
+    nominalDiffTimeToSeconds t * fromIntegral f
+
 
 {-------------------------------------------------------------------------------
   SlotLength

--- a/slotting/test/Main.hs
+++ b/slotting/test/Main.hs
@@ -1,0 +1,8 @@
+import Test.Tasty
+import Test.Cardano.Slotting.EpochInfo (epochInfoTests)
+
+main :: IO ()
+main = defaultMain tests
+
+tests :: TestTree
+tests = testGroup "EpochInfo" [epochInfoTests]

--- a/slotting/test/Test/Cardano/Slotting/EpochInfo.hs
+++ b/slotting/test/Test/Cardano/Slotting/EpochInfo.hs
@@ -1,0 +1,49 @@
+module Test.Cardano.Slotting.EpochInfo where
+
+import Cardano.Slotting.EpochInfo.API (EpochInfo (..))
+import Cardano.Slotting.EpochInfo.Extend (unsafeLinearExtendEpochInfo)
+import Cardano.Slotting.EpochInfo.Impl (fixedEpochInfo)
+import Cardano.Slotting.Slot (EpochNo (EpochNo), EpochSize (EpochSize), SlotNo (SlotNo))
+import Cardano.Slotting.Time (slotLengthFromSec)
+import Data.Functor.Identity (Identity)
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.QuickCheck as QC
+  ( Arbitrary (arbitrary),
+    choose,
+    testProperty,
+    (===),
+  )
+
+baseEpochInfo :: EpochInfo Identity
+baseEpochInfo = fixedEpochInfo (EpochSize 10) (slotLengthFromSec 10)
+
+-- An extended epoch info from a fixedEpochInfo should act as identity.
+extendedEpochInfo :: SlotNo -> EpochInfo Identity
+extendedEpochInfo sn = unsafeLinearExtendEpochInfo sn baseEpochInfo
+
+newtype TestSlotNo = TestSlotNo SlotNo
+  deriving (Eq, Show)
+
+instance Arbitrary TestSlotNo where
+  arbitrary = TestSlotNo . SlotNo <$> choose (1, 200)
+
+newtype TestEpochNo = TestEpochNo EpochNo
+  deriving (Eq, Show)
+
+instance Arbitrary TestEpochNo where
+  arbitrary = TestEpochNo . EpochNo <$> choose (0, 20)
+
+epochInfoTests :: TestTree
+epochInfoTests =
+  testGroup
+    "linearExtend"
+    [ QC.testProperty "epochSize matches" $ \(TestSlotNo basisSlot, TestEpochNo sn) ->
+        epochInfoSize_ baseEpochInfo sn === epochInfoSize_ (extendedEpochInfo basisSlot) sn,
+      QC.testProperty "epochFirst matches" $ \(TestSlotNo basisSlot, TestEpochNo sn) ->
+        epochInfoFirst_ baseEpochInfo sn === epochInfoFirst_ (extendedEpochInfo basisSlot) sn,
+      QC.testProperty "epochEpoch matches" $ \(TestSlotNo basisSlot, TestSlotNo sn) ->
+        epochInfoEpoch_ baseEpochInfo sn === epochInfoEpoch_ (extendedEpochInfo basisSlot) sn,
+      QC.testProperty "epochTime matches" $ \(TestSlotNo basisSlot, TestSlotNo sn) ->
+        epochInfoSlotToRelativeTime_ baseEpochInfo sn
+          === epochInfoSlotToRelativeTime_ (extendedEpochInfo basisSlot) sn
+    ]


### PR DESCRIPTION
We will need this for a KES Agent: in order to send and receive keys over a secure network connection, we have to serialize and deserialize them. The serialized format is still just as confidential as the deserialized form, so we need to treat them with the same care, and that involves storing them in mlocked memory.

We also need to make sure no intermediate values ever reach unprotected memory, so we cannot use the usual Haskell serialization primitives, as these may store intermediates on the Haskell heap. At the same time, mlocked memory is a scarce resource, and we don't want to allocate excessive amounts of it, so in the case of staged KES algorithms (`SumKES` / `CompactSumKES`), we cannot create a new temporary variable for each sub-key at each stage - ideally, we want to allocate a single block of mlocked memory for the final key, and perform all operations on it, in-place.

Hence, we use the following approach:

- We extend the `MLockedSizedBytes` API with a function `mlsbMemcpy`, which, just like the `memcpy` C function, takes two pointers (`MLockedSizedBytes`) and a length, and copies this many bytes from one `MLockedSizedBytes` to the other. However, this function has two additional `offset` parameters, which allow us to address memory locations within the `MLockedSizedBytes`, and, unlike `memcpy`, we add bounds checking to prevent buffer overruns.
- The `DSIGNM` and `KESSignAlgorithm` classes expose two methods for serializing and deserializing their SignKeys; these methods accept a target `MLockedSizedBytes` value that they write to, and an offset into it. This is a slightly awkward signature for user code, but it allows us to delegate the serialization of sub-keys recursively.
- To deal with the awkwardness, then, we provide a pair of convenience wrappers that have more palatable signatures (`SignKey -> IO MLockedSizedBytes` for serialization, and `MLockedSizedBytes -> IO (Maybe SignKey)` for deserialization). These can't be used for recursive ser/deser of composite keys, but they are perfect for user code.
