### PR TITLE
Cabal wrapped

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ dist-newstyle/
 .ghc.environment.x86_64-linux-8.6.5
 stack.yaml.lock
 cabal.project.local
+.nix-shell-cabal.project
 
 # Editors
 TAGS

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -25,6 +25,7 @@ let
     ++ iohkNixMain.overlays.crypto
     # iohkNix: nix utilities and niv:
     ++ iohkNixMain.overlays.iohkNix
+    ++ iohkNixMain.overlays.utils
     # our own overlays:
     ++ [
       (pkgs: _: with pkgs; {

--- a/shell.nix
+++ b/shell.nix
@@ -25,6 +25,7 @@ let
        orphans-deriving-via
     ];
 
+    nativeBuildInputs = [ cabalWrapped ];
     # These programs will be available inside the nix-shell.
     buildInputs = with haskellPackages; [
       ghcid

--- a/shell.nix
+++ b/shell.nix
@@ -8,6 +8,8 @@
 }:
 with pkgs;
 let
+  inherit (pkgs.haskell-nix) haskellLib;
+
   # This provides a development environment that can be used with nix-shell or
   # lorri. See https://input-output-hk.github.io/haskell.nix/user-guide/development/
   shell = cardanoBaseHaskellPackages.shellFor {
@@ -15,17 +17,7 @@ let
 
     # If shellFor default local packages selection is wrong,
     # then list all local packages then include source-repository-package that cabal complains about:
-    packages = ps: with ps; [
-       base-deriving-via
-       cardano-binary
-       cardano-crypto-class
-       cardano-crypto-praos
-       cardano-crypto-tests
-       cardano-slotting
-       measures
-       orphans-deriving-via
-       strict-containers
-    ];
+    packages = ps: builtins.attrValues (haskellLib.selectProjectPackages ps);
 
     nativeBuildInputs = [ cabalWrapped ];
     # These programs will be available inside the nix-shell.

--- a/shell.nix
+++ b/shell.nix
@@ -20,9 +20,11 @@ let
        cardano-binary
        cardano-crypto-class
        cardano-crypto-praos
+       cardano-crypto-tests
        cardano-slotting
        measures
        orphans-deriving-via
+       strict-containers
     ];
 
     nativeBuildInputs = [ cabalWrapped ];


### PR DESCRIPTION
Cabal is missing a feature to conditionalise the `source-repository-package` clauses -- this problem has been known for 1.5 years now.

Because of this missing feature, these clauses makes Cabal ignore the dependencies already provided by Nix, and so it has to get them and build on its own. ..and sometimes Cabal fails for no good reason.

The `cabalWrapped` shell wrapper creates a filtered cabal.project without these clauses: https://github.com/input-output-hk/iohk-nix/blob/master/overlays/utils/default.nix#L32-L78

This cuts down the amount of dependency supplementation work that Cabal has to do to `0`
Moreover, it ensures that Cabal doesn't deviate from Nix -- and hence from CI.

Which is how it is supposed to be.