### PR TITLE
Remove unused cardano-crypto dependency

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -16,10 +16,6 @@ packages:
   slotting
   strict-containers
 
--- Disable tests in a dependency (which are currently broken)
-package cardano-crypto
-  tests: False
-
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
@@ -28,9 +24,3 @@ source-repository-package
   subdir:
     cardano-prelude
     cardano-prelude-test
-
-source-repository-package
-  type: git
-  location: https://github.com/input-output-hk/cardano-crypto
-  tag: 2547ad1e80aeabca2899951601079408becbc92c
-  --sha256: 1p2kg2w02q5w1cvqzhfhqmxviy4xrzada3mmb096j2n6hfr20kri

--- a/shell.nix
+++ b/shell.nix
@@ -11,15 +11,14 @@ let
   inherit (pkgs.haskell-nix) haskellLib;
 
   # This provides a development environment that can be used with nix-shell or
-  # lorri. See https://input-output-hk.github.io/haskell.nix/user-guide/development/
+  # lorri. See https://input-output-hk.github.io/haskell.nix/tutorials/development.html
   shell = cardanoBaseHaskellPackages.shellFor {
     name = "cabal-dev-shell";
 
-    # If shellFor default local packages selection is wrong,
-    # then list all local packages then include source-repository-package that cabal complains about:
     packages = ps: builtins.attrValues (haskellLib.selectProjectPackages ps);
 
     nativeBuildInputs = [ cabalWrapped ];
+
     # These programs will be available inside the nix-shell.
     buildInputs = with haskellPackages; [
       ghcid
@@ -33,7 +32,7 @@ let
     ];
 
     tools = {
-      cabal = "3.2.0.0";
+      cabal = "3.6.2.0";
       haskell-language-server = "latest";
     };
 

--- a/shell.nix
+++ b/shell.nix
@@ -40,9 +40,6 @@ let
     # *all* dependencies are provided by Nix.
     exactDeps = false;
 
-    NIX_SSL_CERT_FILE = "/etc/ssl/certs/ca-bundle.crt";
-    SSL_CERT_FILE = "/etc/ssl/certs/ca-bundle.crt";
-
     inherit withHoogle;
   };
 


### PR DESCRIPTION
This is more of a cleanup PR:
* `cardano-crypto` is no longer used, since there was a full switch to libsodium a while back
* Update broken link and use suggestion from the documentation: remove
  `packages` from shell.nix, since default is all the project's local packages
* Bump up the cabal version to the latest one.