### PR TITLE
Fix deserialization bug with Schnorr signatures, put repro test in place

### DIFF
--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/SchnorrSecp256k1.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/SchnorrSecp256k1.hs
@@ -26,6 +26,7 @@ module Cardano.Crypto.DSIGN.SchnorrSecp256k1 (
   SigDSIGN
   ) where
 
+import GHC.TypeNats (natVal)
 import Foreign.ForeignPtr (withForeignPtr)
 import Data.Proxy (Proxy (Proxy))
 import Data.ByteString (useAsCStringLen)
@@ -187,7 +188,7 @@ instance DSIGNAlgorithm SchnorrSecp256k1DSIGN where
   {-# NOINLINE rawDeserialiseVerKeyDSIGN #-}
   rawDeserialiseVerKeyDSIGN bs = 
     unsafeDupablePerformIO . unsafeUseAsCStringLen bs $ \(ptr, len) ->
-      if len /= 32
+      if len /= (fromIntegral . natVal $ Proxy @(SizeVerKeyDSIGN SchnorrSecp256k1DSIGN))
       then pure Nothing
       else do
         let dataPtr = castPtr ptr

--- a/cardano-crypto-tests/cardano-crypto-tests.cabal
+++ b/cardano-crypto-tests/cardano-crypto-tests.cabal
@@ -51,6 +51,7 @@ library
                         Test.Crypto.KES
                         Test.Crypto.Util
                         Test.Crypto.VRF
+                        Test.Crypto.Regressions
                         Test.Crypto.Instances
                         Bench.Crypto.VRF
                         Bench.Crypto.KES
@@ -69,11 +70,12 @@ library
                       , QuickCheck
                       , quickcheck-instances
                       , tasty
+                      , tasty-hunit
                       , tasty-quickcheck
                       , criterion
 
   if flag(secp256k1-support)
-    cpp-options: -DSECP256K1
+    cpp-options: -DSECP256K1_ENABLED
 
 test-suite test-crypto
   import:               base, project-config

--- a/cardano-crypto-tests/src/Test/Crypto/Regressions.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/Regressions.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE OverloadedStrings #-}
+#ifdef SECP256K1_ENABLED
+{-# LANGUAGE TypeApplications #-}
+#endif
+
+module Test.Crypto.Regressions (
+  tests
+  ) where
+
+import Test.Tasty.HUnit (testCase, assertEqual)
+import Test.Tasty (TestTree, testGroup)
+#ifdef SECP256K1_ENABLED
+import Cardano.Crypto.DSIGN (rawDeserialiseVerKeyDSIGN)
+import Cardano.Crypto.DSIGN.SchnorrSecp256k1 (SchnorrSecp256k1DSIGN)
+#endif
+
+tests :: TestTree
+tests = testGroup "Regressions" [
+#ifdef SECP256K1_ENABLED
+  testGroup "DSIGN" [
+    testGroup "Schnorr serialization" [
+        testCase "Schnorr verkey deserialization fails on \"m\" literal" $ do
+          let actual = rawDeserialiseVerKeyDSIGN @SchnorrSecp256k1DSIGN "m"
+          assertEqual "" Nothing actual
+      ]
+    ]
+#endif
+  ]

--- a/cardano-crypto-tests/test/Main.hs
+++ b/cardano-crypto-tests/test/Main.hs
@@ -1,9 +1,10 @@
 module Main (main) where
 
-import qualified Test.Crypto.DSIGN (tests)
-import qualified Test.Crypto.Hash (tests)
-import qualified Test.Crypto.KES (tests)
-import qualified Test.Crypto.VRF (tests)
+import qualified Test.Crypto.DSIGN
+import qualified Test.Crypto.Hash
+import qualified Test.Crypto.KES
+import qualified Test.Crypto.VRF 
+import qualified Test.Crypto.Regressions
 import Test.Tasty (TestTree, adjustOption, testGroup, defaultMain)
 import Test.Tasty.QuickCheck (QuickCheckTests (QuickCheckTests))
 import Cardano.Crypto.Libsodium (sodiumInit)
@@ -23,4 +24,5 @@ tests =
       , Test.Crypto.Hash.tests
       , Test.Crypto.KES.tests
       , Test.Crypto.VRF.tests
+      , Test.Crypto.Regressions.tests
       ]


### PR DESCRIPTION
This is in relation to a test failure [in this PR](https://github.com/input-output-hk/plutus/pull/4786), as evidenced [here](https://github.com/input-output-hk/plutus/pull/4786#issuecomment-1197479222). The cause of this issue was that `secp256k1_xonly_pubkey_parse` does not (and cannot) check the length of the input it is given, which led it to read 'off the end' of the `ByteString` it was passed. Strangely, one specific case (the literal `"m"`) caused it to parse successfully: this has been included as a regression case to make sure this kind of issue does not arise again.

This partly came about as a result of the way we currently test serialization and deserialization. If we observe:

```haskell
prop_raw_serialise :: (Eq a, Show a)
                   => (a -> ByteString)
                   -> (ByteString -> Maybe a)
                   -> a -> Property
prop_raw_serialise serialise deserialise x =
    case deserialise (serialise x) of
      Just y  -> y === x
      Nothing -> property False
```

This verifies that _if_ a serialized form is valid, _then_ it will deserialize. However, it does _not_ check the other direction, so this does not verify the 'if and only if' this truly ought to be. The CBOR encoding checks are also vulnerable to this.

This should be addressed with a much more thorough set of tests, both property and unit, to ensure we don't get bitten by this again. I haven't included such tests here, as this PR is urgent.