### PR TITLE
Cleanup and ensure return is not ignored

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -3,6 +3,28 @@ name: Haskell CI
 on: [push]
 
 jobs:
+  whitespace:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash
+
+    strategy:
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Traing whitespace check
+      if: matrix.os != 'windows-latest'
+      run: |
+        offenders="$(git grep "\s$" -- *.hs *.c *.h *.nix *.yml *.md || true)";
+        if [ -n "${offenders}" ]; then
+          echo -e "Fix trailing whitespace in:\n"
+          echo -n "${offenders}"
+          exit 1
+        fi
   build:
     runs-on: ${{ matrix.os }}
 

--- a/binary/src/Cardano/Binary/Deserialize.hs
+++ b/binary/src/Cardano/Binary/Deserialize.hs
@@ -30,7 +30,7 @@ import qualified Codec.CBOR.Decoding as D
 import qualified Codec.CBOR.Read as Read
 import qualified Codec.CBOR.Write as CBOR.Write
 import Control.Exception.Safe (impureThrow)
-import Control.Monad (when) 
+import Control.Monad (when)
 import Control.Monad.ST (ST, runST)
 import Data.Bifunctor (bimap)
 import qualified Data.ByteString as BS

--- a/binary/test/Test/Cardano/Binary/Drop.hs
+++ b/binary/test/Test/Cardano/Binary/Drop.hs
@@ -11,7 +11,7 @@ import Data.Word (Word8, Word64)
 
 import Cardano.Binary
 
-import Hedgehog 
+import Hedgehog
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 
@@ -37,7 +37,7 @@ genWord64 = Gen.word64 Range.exponentialBounded
 prop_dropMap :: Property
 prop_dropMap = property $ do
   mp <- forAll $ Gen.map (Range.constant 0 10)
-      ((,) <$> genInt32 
+      ((,) <$> genInt32
            <*> Gen.list (Range.constant 0 10) genWord8
       )
   let encodedBs = serialize mp

--- a/binary/test/Test/Cardano/Binary/Failure.hs
+++ b/binary/test/Test/Cardano/Binary/Failure.hs
@@ -14,8 +14,8 @@ import GHC.Stack (HasCallStack, withFrozenCallStack)
 import Numeric.Natural (Natural)
 
 import Cardano.Binary hiding (Range)
- 
-import Hedgehog 
+
+import Hedgehog
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
 import Hedgehog.Internal.Property (failWith)
@@ -85,7 +85,7 @@ assertIsLeft (Right _) = withFrozenCallStack $ failWith Nothing "This should hav
 assertIsLeft (Left !x) = case x of
   DecoderErrorDeserialiseFailure _ (CR.DeserialiseFailure _ str) | not (null str) -> success
   DecoderErrorCanonicityViolation _  -> success
-  DecoderErrorCustom _  _            -> success 
+  DecoderErrorCustom _  _            -> success
   DecoderErrorEmptyList _            -> success
   DecoderErrorLeftover _ _           -> success
   DecoderErrorSizeMismatch _ _ _     -> success
@@ -93,7 +93,6 @@ assertIsLeft (Left !x) = case x of
   _                                  -> success
 
 decode :: FromCBOR a => Encoding -> Either DecoderError a
-decode enc = 
+decode enc =
  let encoded = serializeEncoding enc
  in decodeFull encoded
-

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/EcdsaSecp256k1.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/EcdsaSecp256k1.hs
@@ -222,10 +222,14 @@ instance DSIGNAlgorithm EcdsaSecp256k1DSIGN where
           alloca $ \(lenPtr :: Ptr CSize) -> do
             poke lenPtr len
             withForeignPtr secpCtxPtr $ \ctx -> do
-              void $ secpEcPubkeySerialize ctx dstp lenPtr psp secpEcCompressed
+              ret <- secpEcPubkeySerialize ctx dstp lenPtr psp secpEcCompressed
               writtenLen <- peek lenPtr
               unless (writtenLen == len)
                      (error "rawSerializeVerKeyDSIGN: Did not write correct length for VerKeyDSIGN EcdsaSecp256k1DSIGN")
+              -- This should never happen, since `secpEcPubkeySerialize` in the current
+              -- version of `secp256k1` library always returns 1:
+              unless (ret == 1)
+                     (error "rawSerializeVerKeyDSIGN: Failed for unknown reason")
     rawSerialiseSignKeyDSIGN (SignKeyEcdsaSecp256k1 psb) = psbToByteString psb
     {-# NOINLINE rawDeserialiseSigDSIGN #-}
     rawDeserialiseSigDSIGN bs =

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/EcdsaSecp256k1.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/EcdsaSecp256k1.hs
@@ -12,9 +12,9 @@
 -- Needed to ensure that our hash is the right size
 {-# OPTIONS_GHC -Wno-redundant-constraints #-}
 -- According to the documentation for unsafePerformIO:
--- 
--- > Make sure that the either you switch off let-floating 
--- > (-fno-full-laziness), or that the call to unsafePerformIO cannot float 
+--
+-- > Make sure that the either you switch off let-floating
+-- > (-fno-full-laziness), or that the call to unsafePerformIO cannot float
 -- > outside a lambda.
 --
 -- If we do not switch off let-floating, our calls to unsafeDupablePerformIO for
@@ -51,33 +51,33 @@ import GHC.Generics (Generic)
 import Control.DeepSeq (NFData)
 import NoThunks.Class (NoThunks)
 import Cardano.Crypto.DSIGN.Class (
-  DSIGNAlgorithm (VerKeyDSIGN, 
-                  SignKeyDSIGN, 
+  DSIGNAlgorithm (VerKeyDSIGN,
+                  SignKeyDSIGN,
                   SigDSIGN,
-                  SeedSizeDSIGN, 
-                  SizeSigDSIGN, 
-                  SizeSignKeyDSIGN, 
-                  SizeVerKeyDSIGN, 
+                  SeedSizeDSIGN,
+                  SizeSigDSIGN,
+                  SizeSignKeyDSIGN,
+                  SizeVerKeyDSIGN,
                   algorithmNameDSIGN,
-                  deriveVerKeyDSIGN, 
-                  signDSIGN, 
-                  verifyDSIGN, 
-                  genKeyDSIGN, 
+                  deriveVerKeyDSIGN,
+                  signDSIGN,
+                  verifyDSIGN,
+                  genKeyDSIGN,
                   rawSerialiseSigDSIGN,
-                  Signable, 
-                  rawSerialiseVerKeyDSIGN, 
-                  rawSerialiseSignKeyDSIGN, 
+                  Signable,
+                  rawSerialiseVerKeyDSIGN,
+                  rawSerialiseSignKeyDSIGN,
                   rawDeserialiseVerKeyDSIGN,
-                  rawDeserialiseSignKeyDSIGN, 
-                  rawDeserialiseSigDSIGN), 
-  encodeVerKeyDSIGN, 
-  encodedVerKeyDSIGNSizeExpr, 
-  decodeVerKeyDSIGN, 
-  encodeSignKeyDSIGN, 
-  encodedSignKeyDESIGNSizeExpr, 
-  decodeSignKeyDSIGN, 
-  encodeSigDSIGN, 
-  encodedSigDSIGNSizeExpr, 
+                  rawDeserialiseSignKeyDSIGN,
+                  rawDeserialiseSigDSIGN),
+  encodeVerKeyDSIGN,
+  encodedVerKeyDSIGNSizeExpr,
+  decodeVerKeyDSIGN,
+  encodeSignKeyDSIGN,
+  encodedSignKeyDESIGNSizeExpr,
+  decodeSignKeyDSIGN,
+  encodeSigDSIGN,
+  encodedSigDSIGNSizeExpr,
   decodeSigDSIGN
   )
 import Cardano.Crypto.SECP256K1.Constants (
@@ -119,7 +119,7 @@ import Cardano.Crypto.SECP256K1.C (
 --
 -- If you are verifying a message using the algorithm provided here, you should
 -- hash the message yourself before verifying. Specifically, the sender should
--- give you the message itself to verify, rather than the hash of the message 
+-- give you the message itself to verify, rather than the hash of the message
 -- used to compute the signature.
 newtype MessageHash = MH (PinnedSizedBytes SECP256K1_ECDSA_MESSAGE_BYTES)
   deriving Eq via (PinnedSizedBytes SECP256K1_ECDSA_MESSAGE_BYTES)
@@ -135,10 +135,10 @@ fromMessageHash :: MessageHash -> ByteString
 fromMessageHash (MH psb) = psbToByteString psb
 
 -- | A helper to use with the 'HashAlgorithm' API, as this can ensure sizing.
-hashAndPack :: forall (h :: Type) . 
-  (HashAlgorithm h, SizeHash h ~ SECP256K1_ECDSA_MESSAGE_BYTES) => 
+hashAndPack :: forall (h :: Type) .
+  (HashAlgorithm h, SizeHash h ~ SECP256K1_ECDSA_MESSAGE_BYTES) =>
   Proxy h -> ByteString -> MessageHash
-hashAndPack p bs = case psbFromByteStringCheck . digest p $ bs of 
+hashAndPack p bs = case psbFromByteStringCheck . digest p $ bs of
   Nothing -> error $ "hashAndPack: unexpected mismatch of guaranteed hash length\n" <>
                      "Please report this, it's a bug!"
   Just psb -> MH psb
@@ -151,66 +151,66 @@ instance DSIGNAlgorithm EcdsaSecp256k1DSIGN where
     type SizeSignKeyDSIGN EcdsaSecp256k1DSIGN = SECP256K1_ECDSA_PRIVKEY_BYTES
     type SizeVerKeyDSIGN EcdsaSecp256k1DSIGN = SECP256K1_ECDSA_PUBKEY_BYTES
     type Signable EcdsaSecp256k1DSIGN = ((~) MessageHash)
-    newtype VerKeyDSIGN EcdsaSecp256k1DSIGN = 
+    newtype VerKeyDSIGN EcdsaSecp256k1DSIGN =
       VerKeyEcdsaSecp256k1 (PinnedSizedBytes SECP256K1_ECDSA_PUBKEY_BYTES_INTERNAL)
       deriving newtype (Eq, NFData)
       deriving stock (Show, Generic)
       deriving anyclass (NoThunks)
-    newtype SignKeyDSIGN EcdsaSecp256k1DSIGN = 
+    newtype SignKeyDSIGN EcdsaSecp256k1DSIGN =
       SignKeyEcdsaSecp256k1 (PinnedSizedBytes SECP256K1_ECDSA_PRIVKEY_BYTES)
       deriving newtype (Eq, NFData)
       deriving stock (Show, Generic)
       deriving anyclass (NoThunks)
-    newtype SigDSIGN EcdsaSecp256k1DSIGN = 
+    newtype SigDSIGN EcdsaSecp256k1DSIGN =
       SigEcdsaSecp256k1 (PinnedSizedBytes SECP256K1_ECDSA_SIGNATURE_BYTES_INTERNAL)
       deriving newtype (Eq, NFData)
       deriving stock (Show, Generic)
       deriving anyclass (NoThunks)
     algorithmNameDSIGN _ = "ecdsa-secp256k1"
     {-# NOINLINE deriveVerKeyDSIGN #-}
-    deriveVerKeyDSIGN (SignKeyEcdsaSecp256k1 skBytes) = 
-      VerKeyEcdsaSecp256k1 <$> unsafeDupablePerformIO . psbUseAsSizedPtr skBytes $ 
-        \skp -> psbCreateSized $ \vkp -> 
+    deriveVerKeyDSIGN (SignKeyEcdsaSecp256k1 skBytes) =
+      VerKeyEcdsaSecp256k1 <$> unsafeDupablePerformIO . psbUseAsSizedPtr skBytes $
+        \skp -> psbCreateSized $ \vkp ->
           withForeignPtr secpCtxPtr $ \ctx -> do
             res <- secpEcPubkeyCreate ctx vkp skp
-            when (res /= 1) 
+            when (res /= 1)
                  (error "deriveVerKeyDSIGN: Failed to derive VerKeyDSIGN EcdsaSecp256k1DSIGN")
     {-# NOINLINE signDSIGN #-}
-    signDSIGN () (MH psb) (SignKeyEcdsaSecp256k1 skBytes) = 
+    signDSIGN () (MH psb) (SignKeyEcdsaSecp256k1 skBytes) =
       SigEcdsaSecp256k1 <$> unsafeDupablePerformIO . psbUseAsSizedPtr psb $ \psp -> do
         psbUseAsSizedPtr skBytes $ \skp ->
-          psbCreateSized $ \sigp -> 
+          psbCreateSized $ \sigp ->
             withForeignPtr secpCtxPtr $ \ctx -> do
               -- The two nullPtr arguments correspond to nonces and extra nonce
               -- data. We use neither, so we pass nullPtrs to indicate this to the
               -- C API.
               res <- secpEcdsaSign ctx sigp psp skp nullPtr nullPtr
-              when (res /= 1) 
+              when (res /= 1)
                    (error "signDSIGN: Failed to sign EcdsaSecp256k1DSIGN message")
     {-# NOINLINE verifyDSIGN #-}
-    verifyDSIGN () (VerKeyEcdsaSecp256k1 vkBytes) (MH psb) (SigEcdsaSecp256k1 sigBytes) = 
+    verifyDSIGN () (VerKeyEcdsaSecp256k1 vkBytes) (MH psb) (SigEcdsaSecp256k1 sigBytes) =
       unsafeDupablePerformIO . psbUseAsSizedPtr psb $ \psp -> do
-        psbUseAsSizedPtr sigBytes $ \sigp -> 
-          psbUseAsSizedPtr vkBytes $ \vkp -> 
+        psbUseAsSizedPtr sigBytes $ \sigp ->
+          psbUseAsSizedPtr vkBytes $ \vkp ->
             withForeignPtr secpCtxPtr $ \ctx -> do
               let res = secpEcdsaVerify ctx sigp psp vkp
-              pure $ case res of 
+              pure $ case res of
                 0 -> Left "verifyDSIGN: Incorrect or unparseable SigDSIGN EcdsaSecp256k1DSIGN"
                 _ -> Right ()
     genKeyDSIGN seed = runMonadRandomWithSeed seed $ do
       bs <- getRandomBytes 32
-      case psbFromByteStringCheck bs of 
+      case psbFromByteStringCheck bs of
         Nothing -> error "genKeyDSIGN: Failed to generate SignKeyDSIGN EcdsaSecp256k1DSIGN unexpectedly"
         Just psb -> pure $ SignKeyEcdsaSecp256k1 psb
     {-# NOINLINE rawSerialiseSigDSIGN #-}
-    rawSerialiseSigDSIGN (SigEcdsaSecp256k1 psb) = 
+    rawSerialiseSigDSIGN (SigEcdsaSecp256k1 psb) =
       psbToByteString @SECP256K1_ECDSA_SIGNATURE_BYTES . unsafeDupablePerformIO $ do
-        psbUseAsSizedPtr psb $ \psp -> 
+        psbUseAsSizedPtr psb $ \psp ->
           psbCreateSized $ \dstp ->
-            withForeignPtr secpCtxPtr $ \ctx -> 
+            withForeignPtr secpCtxPtr $ \ctx ->
               void $ secpEcdsaSignatureSerializeCompact ctx dstp psp
     {-# NOINLINE rawSerialiseVerKeyDSIGN #-}
-    rawSerialiseVerKeyDSIGN (VerKeyEcdsaSecp256k1 psb) = 
+    rawSerialiseVerKeyDSIGN (VerKeyEcdsaSecp256k1 psb) =
       psbToByteString . unsafeDupablePerformIO . psbUseAsSizedPtr psb $ \psp ->
         psbCreateLen @SECP256K1_ECDSA_PUBKEY_BYTES $ \ptr len -> do
           let dstp = castPtr ptr
@@ -224,39 +224,39 @@ instance DSIGNAlgorithm EcdsaSecp256k1DSIGN where
             withForeignPtr secpCtxPtr $ \ctx -> do
               void $ secpEcPubkeySerialize ctx dstp lenPtr psp secpEcCompressed
               writtenLen <- peek lenPtr
-              unless (writtenLen == len) 
+              unless (writtenLen == len)
                      (error "rawSerializeVerKeyDSIGN: Did not write correct length for VerKeyDSIGN EcdsaSecp256k1DSIGN")
     rawSerialiseSignKeyDSIGN (SignKeyEcdsaSecp256k1 psb) = psbToByteString psb
     {-# NOINLINE rawDeserialiseSigDSIGN #-}
-    rawDeserialiseSigDSIGN bs = 
+    rawDeserialiseSigDSIGN bs =
       SigEcdsaSecp256k1 <$> (psbFromByteStringCheck bs >>= go)
       where
-        go :: 
-          PinnedSizedBytes SECP256K1_ECDSA_SIGNATURE_BYTES -> 
+        go ::
+          PinnedSizedBytes SECP256K1_ECDSA_SIGNATURE_BYTES ->
           Maybe (PinnedSizedBytes SECP256K1_ECDSA_SIGNATURE_BYTES_INTERNAL)
         go psb = unsafeDupablePerformIO . psbUseAsSizedPtr psb $ \psp -> do
           (sigPsb, res) <- psbCreateSizedResult $ \sigp ->
-            withForeignPtr secpCtxPtr $ \ctx -> 
+            withForeignPtr secpCtxPtr $ \ctx ->
               secpEcdsaSignatureParseCompact ctx sigp psp
-          pure $ case res of 
+          pure $ case res of
             1 -> pure sigPsb
             _ -> Nothing
     {-# NOINLINE rawDeserialiseVerKeyDSIGN #-}
-    rawDeserialiseVerKeyDSIGN bs = 
+    rawDeserialiseVerKeyDSIGN bs =
       VerKeyEcdsaSecp256k1 <$> (psbFromByteStringCheck bs >>= go)
       where
-        go :: 
-          PinnedSizedBytes SECP256K1_ECDSA_PUBKEY_BYTES -> 
+        go ::
+          PinnedSizedBytes SECP256K1_ECDSA_PUBKEY_BYTES ->
           Maybe (PinnedSizedBytes SECP256K1_ECDSA_PUBKEY_BYTES_INTERNAL)
         go psb = unsafeDupablePerformIO . psbUseAsCPtrLen psb $ \p srcLen -> do
           let srcp = castPtr p
           (vkPsb, res) <- psbCreateSizedResult $ \vkp ->
-            withForeignPtr secpCtxPtr $ \ctx -> 
+            withForeignPtr secpCtxPtr $ \ctx ->
               secpEcPubkeyParse ctx vkp srcp srcLen
-          pure $ case res of 
+          pure $ case res of
             1 -> pure vkPsb
             _ -> Nothing
-    rawDeserialiseSignKeyDSIGN bs = 
+    rawDeserialiseSignKeyDSIGN bs =
       SignKeyEcdsaSecp256k1 <$> psbFromByteStringCheck bs
 
 instance ToCBOR (VerKeyDSIGN EcdsaSecp256k1DSIGN) where

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed25519.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed25519.hs
@@ -7,9 +7,9 @@
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeApplications #-}
 -- According to the documentation for unsafePerformIO:
--- 
--- > Make sure that the either you switch off let-floating 
--- > (-fno-full-laziness), or that the call to unsafePerformIO cannot float 
+--
+-- > Make sure that the either you switch off let-floating
+-- > (-fno-full-laziness), or that the call to unsafePerformIO cannot float
 -- > outside a lambda.
 --
 -- If we do not switch off let-floating, our calls to unsafeDupablePerformIO for
@@ -173,8 +173,8 @@ instance DSIGNAlgorithm Ed25519DSIGN where
     rawSerialiseVerKeyDSIGN   (VerKeyEd25519DSIGN vk) = psbToByteString vk
     rawSerialiseSignKeyDSIGN  (SignKeyEd25519DSIGN sk) =
         psbToByteString @(SeedSizeDSIGN Ed25519DSIGN) $ unsafeDupablePerformIO $ do
-          psbCreateSized $ \seedPtr -> 
-            psbUseAsSizedPtr sk $ \skPtr -> 
+          psbCreateSized $ \seedPtr ->
+            psbUseAsSizedPtr sk $ \skPtr ->
               cOrError "deriveVerKeyDSIGN @Ed25519DSIGN" "c_crypto_sign_ed25519_sk_to_seed"
                 $ c_crypto_sign_ed25519_sk_to_seed seedPtr skPtr
 

--- a/cardano-crypto-class/src/Cardano/Crypto/Init.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Init.hs
@@ -20,7 +20,7 @@ import Control.Exception (evaluate)
 --
 -- = Note
 --
--- This includes a call to 'sodiumInit'. 
+-- This includes a call to 'sodiumInit'.
 cryptoInit :: IO ()
 cryptoInit = do
   sodiumInit

--- a/cardano-crypto-class/src/Cardano/Crypto/PinnedSizedBytes.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/PinnedSizedBytes.hs
@@ -7,9 +7,6 @@
 {-# LANGUAGE ScopedTypeVariables        #-}
 {-# LANGUAGE UnboxedTuples              #-}
 {-# LANGUAGE TypeApplications           #-}
-
--- for pinnedByteArrayFromListN
-{-# OPTIONS_GHC -Wno-missing-local-signatures #-}
 module Cardano.Crypto.PinnedSizedBytes
   (
     PinnedSizedBytes,

--- a/cardano-crypto-class/src/Cardano/Crypto/PinnedSizedBytes.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/PinnedSizedBytes.hs
@@ -159,7 +159,7 @@ psbToByteString = BS.pack . psbToBytes
 --
 -- >>> psbToBytes . (id @(PinnedSizedBytes 4)) . psbFromBytes $ [1,2,3,4,5,6]
 -- [3,4,5,6]
--- 
+--
 {-# DEPRECATED psbFromBytes "This is not referentially transparent" #-}
 psbFromBytes :: forall n. KnownNat n => [Word8] -> PinnedSizedBytes n
 psbFromBytes ws0 = PSB (pinnedByteArrayFromListN size ws)
@@ -178,7 +178,7 @@ psbFromByteString :: KnownNat n => BS.ByteString -> PinnedSizedBytes n
 psbFromByteString = psbFromBytes . BS.unpack
 
 psbFromByteStringCheck :: forall n. KnownNat n => BS.ByteString -> Maybe (PinnedSizedBytes n)
-psbFromByteStringCheck bs 
+psbFromByteStringCheck bs
     | BS.length bs == size = Just $ unsafeDupablePerformIO $
         BS.useAsCStringLen bs $ \(Ptr addr#, _) -> do
             marr@(MutableByteArray marr#) <- newPinnedByteArray size
@@ -218,10 +218,10 @@ instance KnownNat n => Storable (PinnedSizedBytes n) where
 --
 -- The 'Ptr' given to the function argument /must not/ be used as the result of
 -- type @r@.
-psbUseAsCPtr :: 
+psbUseAsCPtr ::
   forall (n :: Nat) (r :: Type) .
-  PinnedSizedBytes n -> 
-  (Ptr Word8 -> IO r) -> 
+  PinnedSizedBytes n ->
+  (Ptr Word8 -> IO r) ->
   IO r
 psbUseAsCPtr (PSB ba) = runAndTouch ba
 
@@ -239,11 +239,11 @@ psbUseAsCPtr (PSB ba) = runAndTouch ba
 --
 -- The same caveats apply to the use of this function as to the use of
 -- 'psbUseAsCPtr'.
-psbUseAsCPtrLen :: 
-  forall (n :: Nat) (r :: Type) . 
-  (KnownNat n) => 
+psbUseAsCPtrLen ::
+  forall (n :: Nat) (r :: Type) .
+  (KnownNat n) =>
   PinnedSizedBytes n ->
-  (Ptr Word8 -> CSize -> IO r) -> 
+  (Ptr Word8 -> CSize -> IO r) ->
   IO r
 psbUseAsCPtrLen (PSB ba) f = do
   let len :: CSize = fromIntegral . natVal $ Proxy @n
@@ -253,10 +253,10 @@ psbUseAsCPtrLen (PSB ba) f = do
 --
 -- The same caveats apply to this use of this function as to the use of
 -- 'psbUseAsCPtr'.
-psbUseAsSizedPtr :: 
-  forall (n :: Nat) (r :: Type) . 
-  PinnedSizedBytes n -> 
-  (SizedPtr n -> IO r) -> 
+psbUseAsSizedPtr ::
+  forall (n :: Nat) (r :: Type) .
+  PinnedSizedBytes n ->
+  (SizedPtr n -> IO r) ->
   IO r
 psbUseAsSizedPtr (PSB ba) k = do
     r <- k (SizedPtr $ castPtr $ byteArrayContents ba)
@@ -264,19 +264,19 @@ psbUseAsSizedPtr (PSB ba) k = do
 
 -- | As 'psbCreateResult', but presumes that no useful value is produced: that
 -- is, the function argument is run only for its side effects.
-psbCreate :: 
-  forall (n :: Nat) . 
-  (KnownNat n) => 
-  (Ptr Word8 -> IO ()) -> 
+psbCreate ::
+  forall (n :: Nat) .
+  (KnownNat n) =>
+  (Ptr Word8 -> IO ()) ->
   IO (PinnedSizedBytes n)
 psbCreate f = fst <$> psbCreateResult f
 
 -- | As 'psbCreateResultLen', but presumes that no useful value is produced:
 -- that is, the function argument is run only for its side effects.
-psbCreateLen :: 
-  forall (n :: Nat) . 
-  (KnownNat n) => 
-  (Ptr Word8 -> CSize -> IO ()) -> 
+psbCreateLen ::
+  forall (n :: Nat) .
+  (KnownNat n) =>
+  (Ptr Word8 -> CSize -> IO ()) ->
   IO (PinnedSizedBytes n)
 psbCreateLen f = fst <$> psbCreateResultLen f
 
@@ -295,10 +295,10 @@ psbCreateLen f = fst <$> psbCreateResultLen f
 -- which can lead to segfaults or out-of-bounds reads.
 --
 -- This poses both correctness /and/ security risks, so please don't do it.
-psbCreateResult :: 
-  forall (n :: Nat) (r :: Type) . 
-  (KnownNat n) => 
-  (Ptr Word8 -> IO r) -> 
+psbCreateResult ::
+  forall (n :: Nat) (r :: Type) .
+  (KnownNat n) =>
+  (Ptr Word8 -> IO r) ->
   IO (PinnedSizedBytes n, r)
 psbCreateResult f = psbCreateResultLen (\p _ -> f p)
 
@@ -314,10 +314,10 @@ psbCreateResult f = psbCreateResultLen (\p _ -> f p)
 --
 -- The same caveats apply to this function as to 'psbCreateResult': the 'Ptr'
 -- given to the function argument /must not/ be returned as @r@.
-psbCreateResultLen :: 
-  forall (n :: Nat) (r :: Type) . 
-  (KnownNat n) => 
-  (Ptr Word8 -> CSize -> IO r) -> 
+psbCreateResultLen ::
+  forall (n :: Nat) (r :: Type) .
+  (KnownNat n) =>
+  (Ptr Word8 -> CSize -> IO r) ->
   IO (PinnedSizedBytes n, r)
 psbCreateResultLen f = do
   let len :: Int = fromIntegral . natVal $ Proxy @n
@@ -328,20 +328,20 @@ psbCreateResultLen f = do
 
 -- | As 'psbCreateSizedResult', but presumes that no useful value is produced:
 -- that is, the function argument is run only for its side effects.
-psbCreateSized :: 
-  forall (n :: Nat). 
-  (KnownNat n) => 
-  (SizedPtr n -> IO ()) -> 
+psbCreateSized ::
+  forall (n :: Nat).
+  (KnownNat n) =>
+  (SizedPtr n -> IO ()) ->
   IO (PinnedSizedBytes n)
 psbCreateSized k = psbCreate (k . SizedPtr . castPtr)
 
 -- | As 'psbCreateResult', but gives a 'SizedPtr' to the function argument. The
 -- same caveats apply to this function as to 'psbCreateResult': the 'SizedPtr'
 -- given to the function argument /must not/ be resulted as @r@.
-psbCreateSizedResult :: 
-  forall (n :: Nat) (r :: Type) . 
-  (KnownNat n) => 
-  (SizedPtr n -> IO r) -> 
+psbCreateSizedResult ::
+  forall (n :: Nat) (r :: Type) .
+  (KnownNat n) =>
+  (SizedPtr n -> IO r) ->
   IO (PinnedSizedBytes n, r)
 psbCreateSizedResult f = psbCreateResult (f . SizedPtr . castPtr)
 
@@ -375,9 +375,9 @@ die :: String -> String -> a
 die fun problem = error $ "PinnedSizedBytes." ++ fun ++ ": " ++ problem
 
 -- Wrapper that combines applying a function, then touching
-runAndTouch :: 
-  forall (a :: Type) . 
-  ByteArray -> 
+runAndTouch ::
+  forall (a :: Type) .
+  ByteArray ->
   (Ptr Word8 -> IO a) ->
   IO a
 runAndTouch ba f = do

--- a/cardano-crypto-class/src/Cardano/Crypto/SECP256K1/C.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/SECP256K1/C.hs
@@ -65,7 +65,7 @@ foreign import ccall unsafe "secp256k1.h &secp256k1_context_destroy"
   secpContextDestroy :: FinalizerPtr SECP256k1Context
 
 foreign import ccall unsafe "secp256k1.h secp256k1_context_create"
-  secpContextCreate :: 
+  secpContextCreate ::
      CUInt -- flags
   -> IO (Ptr SECP256k1Context)
 
@@ -82,14 +82,14 @@ foreign import capi "secp256k1.h value SECP256K1_EC_COMPRESSED"
   secpEcCompressed :: CUInt
 
 foreign import ccall unsafe "secp256k1_extrakeys.h secp256k1_keypair_create"
-  secpKeyPairCreate :: 
+  secpKeyPairCreate ::
      Ptr SECP256k1Context -- context initialized for signing
   -> SizedPtr SECP256K1_SCHNORR_KEYPAIR_BYTES -- out-param for keypair to initialize
   -> SizedPtr SECP256K1_SCHNORR_PRIVKEY_BYTES -- secret key (32 bytes)
   -> IO CInt -- 1 on success, 0 on failure
 
 foreign import ccall unsafe "secp256k1_schnorrsig.h secp256k1_schnorrsig_sign_custom"
-  secpSchnorrSigSignCustom :: 
+  secpSchnorrSigSignCustom ::
      Ptr SECP256k1Context -- context initialized for signing
   -> SizedPtr SECP256K1_SCHNORR_SIGNATURE_BYTES -- out-param for signature (64 bytes)
   -> Ptr CUChar -- message to sign
@@ -99,7 +99,7 @@ foreign import ccall unsafe "secp256k1_schnorrsig.h secp256k1_schnorrsig_sign_cu
   -> IO CInt -- 1 on success, 0 on failure
 
 foreign import ccall unsafe "secp256k1_extrakeys.h secp256k1_keypair_xonly_pub"
-  secpKeyPairXOnlyPub :: 
+  secpKeyPairXOnlyPub ::
      Ptr SECP256k1Context -- an initialized context
   -> SizedPtr SECP256K1_SCHNORR_PUBKEY_BYTES_INTERNAL -- out-param for xonly pubkey
   -> Ptr CInt -- parity (not used)
@@ -107,7 +107,7 @@ foreign import ccall unsafe "secp256k1_extrakeys.h secp256k1_keypair_xonly_pub"
   -> IO CInt -- 1 on success, 0 on error
 
 foreign import ccall unsafe "secp256k1_schnorrsig.h secp256k1_schnorrsig_verify"
-  secpSchnorrSigVerify :: 
+  secpSchnorrSigVerify ::
      Ptr SECP256k1Context -- context initialized for verifying
   -> SizedPtr SECP256K1_SCHNORR_SIGNATURE_BYTES -- signature to verify (64 bytes)
   -> Ptr CUChar -- message to verify
@@ -116,7 +116,7 @@ foreign import ccall unsafe "secp256k1_schnorrsig.h secp256k1_schnorrsig_verify"
   -> CInt -- 1 on success, 0 on failure
 
 foreign import ccall unsafe "secp256k1_extrakeys.h secp256k1_xonly_pubkey_serialize"
-  secpXOnlyPubkeySerialize :: 
+  secpXOnlyPubkeySerialize ::
      Ptr SECP256k1Context -- an initialized context
   -> SizedPtr SECP256K1_SCHNORR_PUBKEY_BYTES -- out-param for serialized representation
   -> SizedPtr SECP256K1_SCHNORR_PUBKEY_BYTES_INTERNAL -- the xonly pubkey to serialize
@@ -129,15 +129,15 @@ foreign import ccall unsafe "secp256k1_extrakeys.h secp256k1_xonly_pubkey_parse"
   -> Ptr CUChar -- bytes to deserialize
   -> IO CInt -- 1 if the parse succeeded, 0 if the parse failed (due to invalid representation)
 
-foreign import ccall unsafe "secp256k1.h secp256k1_ec_pubkey_create" 
-  secpEcPubkeyCreate :: 
+foreign import ccall unsafe "secp256k1.h secp256k1_ec_pubkey_create"
+  secpEcPubkeyCreate ::
      Ptr SECP256k1Context -- an initialized context
   -> SizedPtr SECP256K1_ECDSA_PUBKEY_BYTES_INTERNAL -- out-param for generated key
   -> SizedPtr SECP256K1_ECDSA_PRIVKEY_BYTES -- seed private key
   -> IO CInt -- 1 on success, 0 on error
 
 foreign import ccall unsafe "secp256k1.h secp256k1_ecdsa_sign"
-  secpEcdsaSign :: 
+  secpEcdsaSign ::
      Ptr SECP256k1Context -- context initialized for signing
   -> SizedPtr SECP256K1_ECDSA_SIGNATURE_BYTES_INTERNAL -- out-param for signature
   -> SizedPtr SECP256K1_ECDSA_MESSAGE_BYTES -- pointer to hashed message data
@@ -147,7 +147,7 @@ foreign import ccall unsafe "secp256k1.h secp256k1_ecdsa_sign"
   -> IO CInt -- 1 on success, 0 on error
 
 foreign import ccall unsafe "secp256k1.h secp256k1_ecdsa_verify"
-  secpEcdsaVerify :: 
+  secpEcdsaVerify ::
      Ptr SECP256k1Context -- context initialized for verification
   -> SizedPtr SECP256K1_ECDSA_SIGNATURE_BYTES_INTERNAL -- signature to verify
   -> SizedPtr SECP256K1_ECDSA_MESSAGE_BYTES -- pointer to hashed message data
@@ -155,7 +155,7 @@ foreign import ccall unsafe "secp256k1.h secp256k1_ecdsa_verify"
   -> CInt -- 1 if valid, 0 if invalid or malformed signature
 
 foreign import ccall unsafe "secp256k1.h secp256k1_ec_pubkey_serialize"
-  secpEcPubkeySerialize :: 
+  secpEcPubkeySerialize ::
      Ptr SECP256k1Context -- an initialized context
   -> Ptr CUChar -- allocated buffer to write to
   -> Ptr CSize -- pointer to number of bytes to write, will be overwritten with how much we actually wrote
@@ -164,21 +164,21 @@ foreign import ccall unsafe "secp256k1.h secp256k1_ec_pubkey_serialize"
   -> IO CInt -- always 1
 
 foreign import ccall unsafe "secp256k1.h secp256k1_ecdsa_signature_serialize_compact"
-  secpEcdsaSignatureSerializeCompact :: 
+  secpEcdsaSignatureSerializeCompact ::
      Ptr SECP256k1Context -- an initialized context
   -> SizedPtr SECP256K1_ECDSA_SIGNATURE_BYTES -- allocated buffer to write to
   -> SizedPtr SECP256K1_ECDSA_SIGNATURE_BYTES_INTERNAL -- signature to serialize
   -> IO CInt -- always 1
 
 foreign import ccall unsafe "secp256k1.h secp256k1_ecdsa_signature_parse_compact"
-  secpEcdsaSignatureParseCompact :: 
+  secpEcdsaSignatureParseCompact ::
      Ptr SECP256k1Context -- an initialized context
   -> SizedPtr SECP256K1_ECDSA_SIGNATURE_BYTES_INTERNAL -- allocated buffer to write to
   -> SizedPtr SECP256K1_ECDSA_SIGNATURE_BYTES -- signature to deserialize
   -> IO CInt -- 1 if parsed successfully, 0 if parse failed
 
 foreign import ccall unsafe "secp256k1.h secp256k1_ec_pubkey_parse"
-  secpEcPubkeyParse :: 
+  secpEcPubkeyParse ::
      Ptr SECP256k1Context -- an initialized context
   -> SizedPtr SECP256K1_ECDSA_PUBKEY_BYTES_INTERNAL -- allocated buffer to write to
   -> Ptr CUChar -- input data (must be 33 bytes long)

--- a/cardano-crypto-class/src/Cardano/Crypto/SECP256K1/Constants.hsc
+++ b/cardano-crypto-class/src/Cardano/Crypto/SECP256K1/Constants.hsc
@@ -18,16 +18,16 @@ module Cardano.Crypto.SECP256K1.Constants (
 
 -- ECDSA-related constants
 
-type SECP256K1_ECDSA_PRIVKEY_BYTES = 32 
+type SECP256K1_ECDSA_PRIVKEY_BYTES = 32
 -- As we do not want to serialize the internal state used by ECDSA directly, we
 -- define _two_ values: one for the 'external' representation size, and one for
 -- the 'internal' representation size.
 type SECP256K1_ECDSA_PUBKEY_BYTES = 33
-type SECP256K1_ECDSA_PUBKEY_BYTES_INTERNAL = 64 
+type SECP256K1_ECDSA_PUBKEY_BYTES_INTERNAL = 64
 -- Same as here. They happen to be the same, but by using different tags, we can
 -- ensure we don't mix them up on accident.
 type SECP256K1_ECDSA_SIGNATURE_BYTES = 64
-type SECP256K1_ECDSA_SIGNATURE_BYTES_INTERNAL = 64 
+type SECP256K1_ECDSA_SIGNATURE_BYTES_INTERNAL = 64
 -- Since the ECDSA scheme signs hashes, not whole messages, we define this for
 -- clarity.
 type SECP256K1_ECDSA_MESSAGE_BYTES = 32

--- a/cardano-crypto-praos/cbits/vrf03/crypto_vrf_ietfdraft03.h
+++ b/cardano-crypto-praos/cbits/vrf03/crypto_vrf_ietfdraft03.h
@@ -72,7 +72,7 @@ int crypto_vrf_ietfdraft03_is_valid_key(const unsigned char *pk)
 // Generate a VRF proof for a message using a secret key.
 //
 // The VRF output hash can be obtained by calling crypto_vrf_proof_to_hash(proof).
-// 
+//
 // Returns 0 on success, -1 on error decoding the (augmented) secret key
 //
 // This runs in time constant with respect to sk and, fixing a value of mlen,

--- a/cardano-crypto-praos/src/Cardano/Crypto/VRF/Praos.hs
+++ b/cardano-crypto-praos/src/Cardano/Crypto/VRF/Praos.hs
@@ -54,7 +54,7 @@ module Cardano.Crypto.VRF.Praos
   -- * Core VRF operations
   , prove
   , verify
-  
+
   , SignKeyVRF (..)
   , VerKeyVRF (..)
   , CertVRF (..)

--- a/cardano-crypto-tests/src/Test/Crypto/DSIGN.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/DSIGN.hs
@@ -22,8 +22,8 @@ import qualified Test.QuickCheck.Gen as Gen
 import Data.Kind (Type)
 import Data.Proxy (Proxy (..))
 import Cardano.Crypto.DSIGN (
-  MockDSIGN, 
-  Ed25519DSIGN, 
+  MockDSIGN,
+  Ed25519DSIGN,
   Ed448DSIGN,
 #ifdef SECP256K1_ENABLED
   EcdsaSecp256k1DSIGN,
@@ -71,10 +71,10 @@ import Test.Crypto.Util (
   )
 import Test.Crypto.Instances ()
 import Test.QuickCheck (
-  (=/=), 
-  (===), 
-  Arbitrary(..), 
-  Gen, 
+  (=/=),
+  (===),
+  Arbitrary(..),
+  Gen,
   Property,
   forAllShow
   )
@@ -92,7 +92,7 @@ ed448SigGen = defaultSigGen
 
 #ifdef SECP256K1_ENABLED
 secp256k1SigGen :: Gen (SigDSIGN EcdsaSecp256k1DSIGN)
-secp256k1SigGen = do 
+secp256k1SigGen = do
   msg <- genSECPMsg
   signDSIGN () msg <$> defaultSignKeyGen
 
@@ -100,22 +100,22 @@ schnorrSigGen :: Gen (SigDSIGN SchnorrSecp256k1DSIGN)
 schnorrSigGen = defaultSigGen
 
 genSECPMsg :: Gen MessageHash
-genSECPMsg = 
-  Gen.suchThatMap (GHC.fromListN 32 <$> replicateM 32 arbitrary) 
+genSECPMsg =
+  Gen.suchThatMap (GHC.fromListN 32 <$> replicateM 32 arbitrary)
                   toMessageHash
 #endif
 
-defaultVerKeyGen :: forall (a :: Type) . 
+defaultVerKeyGen :: forall (a :: Type) .
   (DSIGNAlgorithm a) => Gen (VerKeyDSIGN a)
 defaultVerKeyGen = deriveVerKeyDSIGN <$> defaultSignKeyGen @a
 
 defaultSignKeyGen :: forall (a :: Type).
   (DSIGNAlgorithm a) => Gen (SignKeyDSIGN a)
-defaultSignKeyGen = 
+defaultSignKeyGen =
   genKeyDSIGN <$> arbitrarySeedOfSize (seedSizeDSIGN (Proxy :: Proxy a))
 
-defaultSigGen :: forall (a :: Type) . 
-  (DSIGNAlgorithm a, ContextDSIGN a ~ (), Signable a Message) => 
+defaultSigGen :: forall (a :: Type) .
+  (DSIGNAlgorithm a, ContextDSIGN a ~ (), Signable a Message) =>
   Gen (SigDSIGN a)
 defaultSigGen = do
   msg :: Message <- arbitrary
@@ -152,52 +152,52 @@ testDSIGNAlgorithm :: forall (v :: Type) (a :: Type).
    FromCBOR (SignKeyDSIGN v),
    ToCBOR (SigDSIGN v),
    FromCBOR (SigDSIGN v)) =>
-  Gen (SigDSIGN v) -> 
-  Gen a -> 
-  String -> 
+  Gen (SigDSIGN v) ->
+  Gen a ->
+  String ->
   TestTree
 testDSIGNAlgorithm genSig genMsg name = testGroup name [
   testGroup "serialization" [
     testGroup "raw" [
       testProperty "VerKey" .
         forAllShow (defaultVerKeyGen @v)
-                   ppShow $ 
+                   ppShow $
                    prop_raw_serialise rawSerialiseVerKeyDSIGN rawDeserialiseVerKeyDSIGN,
-      testProperty "SignKey" . 
+      testProperty "SignKey" .
         forAllShow (defaultSignKeyGen @v)
-                   ppShow $ 
+                   ppShow $
                    prop_raw_serialise rawSerialiseSignKeyDSIGN rawDeserialiseSignKeyDSIGN,
-      testProperty "Sig" . 
-        forAllShow genSig 
-                   ppShow $ 
+      testProperty "Sig" .
+        forAllShow genSig
+                   ppShow $
                    prop_raw_serialise rawSerialiseSigDSIGN rawDeserialiseSigDSIGN
       ],
-    testGroup "size" [ 
-      testProperty "VerKey" . 
+    testGroup "size" [
+      testProperty "VerKey" .
         forAllShow (defaultVerKeyGen @v)
-                   ppShow $ 
+                   ppShow $
                    prop_size_serialise rawSerialiseVerKeyDSIGN (sizeVerKeyDSIGN (Proxy @v)),
       testProperty "SignKey" .
         forAllShow (defaultSignKeyGen @v)
-                   ppShow $ 
+                   ppShow $
                    prop_size_serialise rawSerialiseSignKeyDSIGN (sizeSignKeyDSIGN (Proxy @v)),
-      testProperty "Sig" . 
-        forAllShow genSig 
-                   ppShow $ 
+      testProperty "Sig" .
+        forAllShow genSig
+                   ppShow $
                    prop_size_serialise rawSerialiseSigDSIGN (sizeSigDSIGN (Proxy @v))
       ],
     testGroup "direct CBOR" [
-      testProperty "VerKey" . 
+      testProperty "VerKey" .
         forAllShow (defaultVerKeyGen @v)
-                   ppShow $ 
+                   ppShow $
                    prop_cbor_with encodeVerKeyDSIGN decodeVerKeyDSIGN,
-      testProperty "SignKey" . 
+      testProperty "SignKey" .
         forAllShow (defaultSignKeyGen @v)
-                   ppShow $ 
+                   ppShow $
                    prop_cbor_with encodeSignKeyDSIGN decodeSignKeyDSIGN,
-      testProperty "Sig" . 
-        forAllShow genSig 
-                   ppShow $ 
+      testProperty "Sig" .
+        forAllShow genSig
+                   ppShow $
                    prop_cbor_with encodeSigDSIGN decodeSigDSIGN
       ],
     testGroup "To/FromCBOR class" [
@@ -211,26 +211,26 @@ testDSIGNAlgorithm genSig genMsg name = testGroup name [
       testProperty "Sig" . forAllShow genSig ppShow $ prop_cbor_size
       ],
     testGroup "direct matches class" [
-      testProperty "VerKey" . 
-        forAllShow (defaultVerKeyGen @v) ppShow $ 
+      testProperty "VerKey" .
+        forAllShow (defaultVerKeyGen @v) ppShow $
         prop_cbor_direct_vs_class encodeVerKeyDSIGN,
-      testProperty "SignKey" . 
-        forAllShow (defaultSignKeyGen @v) ppShow $ 
+      testProperty "SignKey" .
+        forAllShow (defaultSignKeyGen @v) ppShow $
         prop_cbor_direct_vs_class encodeSignKeyDSIGN,
-      testProperty "Sig" . 
-        forAllShow genSig ppShow $ 
+      testProperty "Sig" .
+        forAllShow genSig ppShow $
         prop_cbor_direct_vs_class encodeSigDSIGN
       ]
     ],
     testGroup "verify" [
-      testProperty "signing and verifying with matching keys" . 
+      testProperty "signing and verifying with matching keys" .
         forAllShow ((,) <$> genMsg <*> defaultSignKeyGen @v) ppShow $
         prop_dsign_verify,
-      testProperty "verifying with wrong key" . 
+      testProperty "verifying with wrong key" .
         forAllShow genWrongKey ppShow $
         prop_dsign_verify_wrong_key,
-      testProperty "verifying wrong message" . 
-        forAllShow genWrongMsg ppShow $ 
+      testProperty "verifying wrong message" .
+        forAllShow genWrongMsg ppShow $
         prop_dsign_verify_wrong_msg
     ],
     testGroup "NoThunks" [
@@ -255,12 +255,12 @@ testDSIGNAlgorithm genSig genMsg name = testGroup name [
 
 -- If we sign a message with the key, we can verify the signature with the
 -- corresponding verification key.
-prop_dsign_verify  
-  :: forall (v :: Type) (a :: Type) . 
-  (DSIGNAlgorithm v, ContextDSIGN v ~ (), Signable v a) 
+prop_dsign_verify
+  :: forall (v :: Type) (a :: Type) .
+  (DSIGNAlgorithm v, ContextDSIGN v ~ (), Signable v a)
   => (a, SignKeyDSIGN v)
   -> Property
-prop_dsign_verify (msg, sk) = 
+prop_dsign_verify (msg, sk) =
   let signed = signDSIGN () msg sk
       vk = deriveVerKeyDSIGN sk
     in verifyDSIGN () vk msg signed === Right ()
@@ -269,22 +269,22 @@ prop_dsign_verify (msg, sk) =
 -- verification fails.
 prop_dsign_verify_wrong_key
   :: forall (v :: Type) (a :: Type) .
-  (DSIGNAlgorithm v, Signable v a, ContextDSIGN v ~ ()) 
-  => (a, SignKeyDSIGN v, SignKeyDSIGN v) 
+  (DSIGNAlgorithm v, Signable v a, ContextDSIGN v ~ ())
+  => (a, SignKeyDSIGN v, SignKeyDSIGN v)
   -> Property
-prop_dsign_verify_wrong_key (msg, sk, sk') = 
+prop_dsign_verify_wrong_key (msg, sk, sk') =
   let signed = signDSIGN () msg sk
       vk' = deriveVerKeyDSIGN sk'
     in verifyDSIGN () vk' msg signed =/= Right ()
 
 -- If we signa a message with a key, but then try to verify with a different
 -- message, then verification fails.
-prop_dsign_verify_wrong_msg 
+prop_dsign_verify_wrong_msg
   :: forall (v :: Type) (a :: Type) .
   (DSIGNAlgorithm v, Signable v a, ContextDSIGN v ~ ())
   => (a, a, SignKeyDSIGN v)
   -> Property
-prop_dsign_verify_wrong_msg (msg, msg', sk) = 
+prop_dsign_verify_wrong_msg (msg, msg', sk) =
   let signed = signDSIGN () msg sk
       vk = deriveVerKeyDSIGN sk
     in verifyDSIGN () vk msg' signed =/= Right ()

--- a/cardano-crypto-tests/src/Test/Crypto/Hash.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/Hash.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}

--- a/cardano-crypto-tests/src/Test/Crypto/Instances.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/Instances.hs
@@ -26,7 +26,7 @@ instance KnownNat n => Arbitrary (NaCl.MLockedSizedBytes n) where
 instance KnownNat n => Arbitrary (PinnedSizedBytes n) where
     arbitrary = do
       let size :: Int = fromIntegral . natVal $ Proxy @n
-      Gen.suchThatMap (fromListN size <$> Gen.vectorOf size arbitrary) 
+      Gen.suchThatMap (fromListN size <$> Gen.vectorOf size arbitrary)
                       psbFromByteStringCheck
-    shrink psb = case toList . psbToByteString $ psb of 
+    shrink psb = case toList . psbToByteString $ psb of
       bytes -> mapMaybe (psbFromByteStringCheck . fromList) . shrink $ bytes

--- a/cardano-crypto-tests/test/Main.hs
+++ b/cardano-crypto-tests/test/Main.hs
@@ -3,7 +3,7 @@ module Main (main) where
 import qualified Test.Crypto.DSIGN
 import qualified Test.Crypto.Hash
 import qualified Test.Crypto.KES
-import qualified Test.Crypto.VRF 
+import qualified Test.Crypto.VRF
 import qualified Test.Crypto.Regressions
 import Test.Tasty (TestTree, adjustOption, testGroup, defaultMain)
 import Test.Tasty.QuickCheck (QuickCheckTests (QuickCheckTests))
@@ -18,7 +18,7 @@ tests :: TestTree
 tests =
   -- The default QuickCheck test count is 100. This is too few to catch
   -- anything, so we set a minimum of 1000.
-  adjustOption (\(QuickCheckTests i) -> QuickCheckTests $ max i 1000) . 
+  adjustOption (\(QuickCheckTests i) -> QuickCheckTests $ max i 1000) .
     testGroup "cardano-crypto-class" $
       [ Test.Crypto.DSIGN.tests
       , Test.Crypto.Hash.tests

--- a/measures/src/Data/Measure/Class.hs
+++ b/measures/src/Data/Measure/Class.hs
@@ -209,7 +209,7 @@ instance (Prelude.Bounded a, Prelude.Monoid a, Prelude.Ord a)
 
 instance (Prelude.Eq a, Generic a, GMeasure (Rep a))
       => Measure (InstantiatedAt Generic a) where
-  zero = coerce $     to @a gzero 
+  zero = coerce $     to @a gzero
   plus = coerce $ gbinop @a gplus
   min  = coerce $ gbinop @a gmin
   max  = coerce $ gbinop @a gmax

--- a/measures/test/Main.hs
+++ b/measures/test/Main.hs
@@ -10,7 +10,7 @@ import qualified Test.Data.Measure (tests)
 
 main :: IO ()
 main = defaultMain tests
-  
+
 tests :: TestTree
 tests = testGroup "measures package"
     [ Test.Data.Measure.tests


### PR DESCRIPTION
This PR mostly does a bit of cleanup and future proofing in logically separate commits:

* removes trailing whitespace from all source files and adds a CI check for preventing those getting in in the future
* removes unusued language extension and ghc flag
* Adds a redundant check, thus addressing @vincenthz's comment: https://github.com/input-output-hk/cardano-base/pull/289#discussion_r933414243
