### PR TITLE
Convert from hex at compile time

### DIFF
--- a/cardano-crypto-class/cardano-crypto-class.cabal
+++ b/cardano-crypto-class/cardano-crypto-class.cabal
@@ -110,6 +110,7 @@ library
     , primitive
     , serialise
     , strict-containers
+    , template-haskell
     , text
     , transformers
     , vector

--- a/cardano-crypto-class/src/Cardano/Crypto/PackedBytes.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/PackedBytes.hs
@@ -8,7 +8,6 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
-{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE TypeFamilyDependencies #-}
 {-# LANGUAGE UnboxedTuples #-}
 

--- a/cardano-crypto-class/src/Cardano/Crypto/PinnedSizedBytes.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/PinnedSizedBytes.hs
@@ -120,32 +120,29 @@ instance KnownNat n => Ord (PinnedSizedBytes n) where
         size = fromInteger (natVal (Proxy :: Proxy n))
 
 
--- | This instance meant to be used with TemplateHaskell
+-- | This instance is meant to be used with @TemplateHaskell@
 --
 -- >>> import Cardano.Crypto.PinnedSizedBytes
 -- >>> :set -XTemplateHaskell
 -- >>> :set -XOverloadedStrings
 -- >>> :set -XDataKinds
--- >>> let psb = $$("0xdeadbeef") :: PinnedSizedBytes 4
--- >>> print psb
+-- >>> print ($$("0xdeadbeef") :: PinnedSizedBytes 4)
 -- "deadbeef"
--- >>> let badPsb = $$("0xdeadbeef") :: PinnedSizedBytes 5
-
--- <interactive>:8:17: error:
---     • <PinnedSizedBytes>: Incorrect hex length. Expected: 5 but got: 4
+-- >>> print ($$("deadbeef") :: PinnedSizedBytes 4)
+-- "deadbeef"
+-- >>> let bsb = $$("0xdeadbeef") :: PinnedSizedBytes 5
+-- <interactive>:9:14: error:
+--     • <PinnedSizedBytes>: Expected in decoded form to be: 5 bytes, but got: 4
 --     • In the Template Haskell splice $$("0xdeadbeef")
 --       In the expression: $$("0xdeadbeef") :: PinnedSizedBytes 5
---       In an equation for ‘badPsb’:
---           badPsb = $$("0xdeadbeef") :: PinnedSizedBytes 5
--- >>> let badPsb = $$("deadbeef") :: PinnedSizedBytes 4
-
--- <interactive>:9:17: error:
---     • <PinnedSizedBytes>: Expected a hex encoded string to be prefixed with '0x', instead got: "deadbeef"
---     • In the Template Haskell splice $$("deadbeef")
---       In the expression: $$("deadbeef") :: PinnedSizedBytes 4
---       In an equation for ‘badPsb’:
---           badPsb = $$("deadbeef") :: PinnedSizedBytes 4
-
+--       In an equation for ‘bsb’:
+--           bsb = $$("0xdeadbeef") :: PinnedSizedBytes 5
+-- >>> let bsb = $$("nogood") :: PinnedSizedBytes 5
+-- <interactive>:11:14: error:
+--     • <PinnedSizedBytes>: Malformed hex: invalid character at offset: 0
+--     • In the Template Haskell splice $$("nogood")
+--       In the expression: $$("nogood") :: PinnedSizedBytes 5
+--       In an equation for ‘bsb’: bsb = $$("nogood") :: PinnedSizedBytes 5
 instance KnownNat n => IsString (Q (TExp (PinnedSizedBytes n))) where
     fromString hexStr = do
       let n = fromInteger $ natVal (Proxy :: Proxy n)

--- a/cardano-crypto-class/src/Cardano/Crypto/Util.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Util.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MagicHash #-}
+{-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Cardano.Crypto.Util
   ( Empty
@@ -20,15 +22,25 @@ module Cardano.Crypto.Util
 
   -- * ByteString manipulation
   , slice
+
+  -- * Base16 conversion
+  , decodeHexByteString
+  , decodeHexString
+  , decodeHexStringQ
   )
 where
 
+import           Control.Monad (unless)
+import           Data.Char (isAscii)
 import           Data.Word
 import           Numeric.Natural
 import           Data.Bits
 import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BSC8
 import qualified Data.ByteString.Internal as BS
 import           Data.ByteString (ByteString)
+import           Data.ByteString.Base16 as BS16
+import           Language.Haskell.TH
 
 import qualified GHC.Exts    as GHC
 import qualified GHC.IO      as GHC (unsafeDupablePerformIO)
@@ -129,4 +141,31 @@ bytesToInteger (BS.PS fp (GHC.I# off#) (GHC.I# len#)) =
 slice :: Word -> Word -> ByteString -> ByteString
 slice offset size = BS.take (fromIntegral size)
                   . BS.drop (fromIntegral offset)
+
+-- | Decode base16 ByteString, while ensuring expected length.
+decodeHexByteString :: ByteString -> Int -> Either String ByteString
+decodeHexByteString bsHex lenExpected = do
+  bs <- BS16.decode bsHex
+  let lenActual = BS.length bs
+  unless (lenExpected == lenActual) $
+    Left $ "Incorrect hex length. Expected: " ++
+           show lenExpected ++ " but got: " ++ show lenActual
+  pure bs
+
+
+-- | Decode base16 String, while ensuring expected length. Unlike
+-- `decodeHexByteString` this function expects a '0x' prefix.
+decodeHexString :: String -> Int -> Either String ByteString
+decodeHexString ('0':'x':hexStr) lenExpected = do
+  unless (all isAscii hexStr) $ Left $ "Input string contrains invalid characters: " ++ hexStr
+  decodeHexByteString (BSC8.pack hexStr) lenExpected
+decodeHexString hexStr _lenExpected =
+  Left $ "Expected a hex encoded string to be prefixed with '0x', instead got: " ++ show hexStr
+
+-- | Decode a `String` with Hex characters, while ensuring expected length.
+decodeHexStringQ :: String -> Int -> Q Exp
+decodeHexStringQ hexStr n = do
+  case decodeHexString hexStr n of
+    Left err -> fail $ "<decodeHexByteString>: " ++ err
+    Right _  -> [| either error id (decodeHexString hexStr n) |]
 


### PR DESCRIPTION
This PR is meant to be a replacement for the approach taken in #294 

Implement `IsString` instances for a `Q (TExp (PinnedSizedBytes n))` and `Q (TExp (Hash h a))`

This allows us to safely construct `PinnedSizedBytes` and `Hash` at compile time when we know the value statically (such as unit tests for example). Here are a few examples that were included in the haddock:

```haskell
>>> import Cardano.Crypto.PinnedSizedBytes
>>> :set -XTemplateHaskell
>>> :set -XOverloadedStrings
>>> :set -XDataKinds
>>> print ($$("0xdeadbeef") :: PinnedSizedBytes 4)
"deadbeef"
>>> print ($$("deadbeef") :: PinnedSizedBytes 4)
"deadbeef"
>>> let bsb = $$("0xdeadbeef") :: PinnedSizedBytes 5
<interactive>:9:14: error:
    • <PinnedSizedBytes>: Expected in decoded form to be: 5 bytes, but got: 4
    • In the Template Haskell splice $$("0xdeadbeef")
      In the expression: $$("0xdeadbeef") :: PinnedSizedBytes 5
      In an equation for ‘bsb’:
          bsb = $$("0xdeadbeef") :: PinnedSizedBytes 5
>>> let bsb = $$("nogood") :: PinnedSizedBytes 5
<interactive>:11:14: error:
    • <PinnedSizedBytes>: Malformed hex: invalid character at offset: 0
    • In the Template Haskell splice $$("nogood")
      In the expression: $$("nogood") :: PinnedSizedBytes 5
      In an equation for ‘bsb’: bsb = $$("nogood") :: PinnedSizedBytes 5
```

and for Hashes

```haskell
>>> import Cardano.Crypto.Hash.Class (Hash)
>>> import Cardano.Crypto.Hash.Short (ShortHash)
>>> :set -XTemplateHaskell
>>> :set -XOverloadedStrings
>>>  let hash = $$("0xBADC0FFEE0DDF00D") :: Hash ShortHash ()
>>> print hash
"badc0ffee0ddf00d"
>>> let hash = $$("0123456789abcdef") :: Hash ShortHash ()
>>> print hash
"0123456789abcdef"
>>> let hash = $$("deadbeef") :: Hash ShortHash ()
<interactive>:5:15: error:
    • <Hash blake2b_prefix_8>: Expected in decoded form to be: 8 bytes, but got: 4
    • In the Template Haskell splice $$("deadbeef")
      In the expression: $$("deadbeef") :: Hash ShortHash ()
      In an equation for ‘hash’:
          hash = $$("deadbeef") :: Hash ShortHash ()
>>> let hash = $$("123") :: Hash ShortHash ()
<interactive>:6:15: error:
    • <Hash blake2b_prefix_8>: Malformed hex: invalid bytestring size
    • In the Template Haskell splice $$("123")
      In the expression: $$("123") :: Hash ShortHash ()
      In an equation for ‘hash’: hash = $$("123") :: Hash ShortHash ()
```
Other safety fixes:
* Remove `IsString (PinnedSizedBytes n)` instance
* Fix `psbFromByteString` to fail on invalid input