### PR TITLE
Revert index-state update

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,4 @@
-index-state: 2022-08-15T00:00:00Z
+index-state: 2022-02-18T00:00:00Z
 
 -- Ensures colourized output from tasty
 test-show-details: direct
@@ -19,8 +19,8 @@ packages:
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/cardano-prelude
-  tag: 533aec85c1ca05c7d171da44b89341fb736ecfe5
-  --sha256: 0z2y3wzppc12bpn9bl48776ms3nszw8j58xfsdxf97nzjgrmd62g
+  tag: fd773f7a58412131512b9f694ab95653ac430852
+  --sha256: 02jddik1yw0222wd6q0vv10f7y8rdgrlqaiy83ph002f9kjx7mh6
   subdir:
     cardano-prelude
     cardano-prelude-test


### PR DESCRIPTION
In #288 index-state was updated, which made master unbuildable under nix. @hamishmack is looking into how get this problem resolved, but until the this PR reverts #288 to unblock other work. 

This reverts commit 278e71d44ad2a347992449a08e5de72a6672c0d7, reversing
changes made to ff9915d1a6b34c61b9d02faeeddb8b71c232a30d.