### PR TITLE
DESIGN -> DSIGN

### DIFF
--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Class.hs
@@ -38,7 +38,7 @@ module Cardano.Crypto.DSIGN.Class
 
     -- * Encoded 'Size' expresssions
   , encodedVerKeyDSIGNSizeExpr
-  , encodedSignKeyDESIGNSizeExpr
+  , encodedSignKeyDSIGNSizeExpr
   , encodedSigDSIGNSizeExpr
   )
 where
@@ -290,8 +290,8 @@ encodedVerKeyDSIGNSizeExpr _proxy =
 -- | 'Size' expression for 'SignKeyDSIGN' which is using 'sizeSignKeyDSIGN'
 -- encoded as 'Size'.
 --
-encodedSignKeyDESIGNSizeExpr :: forall v. DSIGNAlgorithm v => Proxy (SignKeyDSIGN v) -> Size
-encodedSignKeyDESIGNSizeExpr _proxy =
+encodedSignKeyDSIGNSizeExpr :: forall v. DSIGNAlgorithm v => Proxy (SignKeyDSIGN v) -> Size
+encodedSignKeyDSIGNSizeExpr _proxy =
       -- 'encodeBytes' envelope
       fromIntegral ((withWordSize :: Word -> Integer) (sizeSignKeyDSIGN (Proxy :: Proxy v)))
       -- payload

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/EcdsaSecp256k1.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/EcdsaSecp256k1.hs
@@ -74,7 +74,7 @@ import Cardano.Crypto.DSIGN.Class (
   encodedVerKeyDSIGNSizeExpr,
   decodeVerKeyDSIGN,
   encodeSignKeyDSIGN,
-  encodedSignKeyDESIGNSizeExpr,
+  encodedSignKeyDSIGNSizeExpr,
   decodeSignKeyDSIGN,
   encodeSigDSIGN,
   encodedSigDSIGNSizeExpr,
@@ -272,7 +272,7 @@ instance FromCBOR (VerKeyDSIGN EcdsaSecp256k1DSIGN) where
 
 instance ToCBOR (SignKeyDSIGN EcdsaSecp256k1DSIGN) where
   toCBOR = encodeSignKeyDSIGN
-  encodedSizeExpr _ = encodedSignKeyDESIGNSizeExpr
+  encodedSizeExpr _ = encodedSignKeyDSIGNSizeExpr
 
 instance FromCBOR (SignKeyDSIGN EcdsaSecp256k1DSIGN) where
   fromCBOR = decodeSignKeyDSIGN

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed25519.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed25519.hs
@@ -194,7 +194,7 @@ instance FromCBOR (VerKeyDSIGN Ed25519DSIGN) where
 
 instance ToCBOR (SignKeyDSIGN Ed25519DSIGN) where
   toCBOR = encodeSignKeyDSIGN
-  encodedSizeExpr _ = encodedSignKeyDESIGNSizeExpr
+  encodedSizeExpr _ = encodedSignKeyDSIGNSizeExpr
 
 instance FromCBOR (SignKeyDSIGN Ed25519DSIGN) where
   fromCBOR = decodeSignKeyDSIGN

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed448.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed448.hs
@@ -115,7 +115,7 @@ instance FromCBOR (VerKeyDSIGN Ed448DSIGN) where
 
 instance ToCBOR (SignKeyDSIGN Ed448DSIGN) where
   toCBOR = encodeSignKeyDSIGN
-  encodedSizeExpr _ = encodedSignKeyDESIGNSizeExpr
+  encodedSizeExpr _ = encodedSignKeyDSIGNSizeExpr
 
 instance FromCBOR (SignKeyDSIGN Ed448DSIGN) where
   fromCBOR = decodeSignKeyDSIGN

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Mock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Mock.hs
@@ -138,7 +138,7 @@ instance FromCBOR (VerKeyDSIGN MockDSIGN) where
 
 instance ToCBOR (SignKeyDSIGN MockDSIGN) where
   toCBOR = encodeSignKeyDSIGN
-  encodedSizeExpr _ = encodedSignKeyDESIGNSizeExpr
+  encodedSizeExpr _ = encodedSignKeyDSIGNSizeExpr
 
 instance FromCBOR (SignKeyDSIGN MockDSIGN) where
   fromCBOR = decodeSignKeyDSIGN

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/SchnorrSecp256k1.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/SchnorrSecp256k1.hs
@@ -79,7 +79,7 @@ import Cardano.Crypto.DSIGN.Class (
   encodedVerKeyDSIGNSizeExpr,
   decodeVerKeyDSIGN,
   encodeSignKeyDSIGN,
-  encodedSignKeyDESIGNSizeExpr,
+  encodedSignKeyDSIGNSizeExpr,
   decodeSignKeyDSIGN,
   encodeSigDSIGN,
   encodedSigDSIGNSizeExpr,
@@ -212,7 +212,7 @@ instance FromCBOR (VerKeyDSIGN SchnorrSecp256k1DSIGN) where
 
 instance ToCBOR (SignKeyDSIGN SchnorrSecp256k1DSIGN) where
   toCBOR = encodeSignKeyDSIGN
-  encodedSizeExpr _ = encodedSignKeyDESIGNSizeExpr
+  encodedSizeExpr _ = encodedSignKeyDSIGNSizeExpr
 
 instance FromCBOR (SignKeyDSIGN SchnorrSecp256k1DSIGN) where
   fromCBOR = decodeSignKeyDSIGN


### PR DESCRIPTION
The `cardano-crypto-class` source contains a number of occurrences of `encodedSignKeyDESIGNSizeExpr` which should clearly be `encodedSignKeyDSIGNSizeExpr` (see https://github.com/input-output-hk/cardano-base/issues/275).  This fixes that.