### PR TITLE
Handling some minor comments on the SECP changes

### DIFF
--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed25519.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed25519.hs
@@ -182,7 +182,7 @@ instance DSIGNAlgorithm Ed25519DSIGN where
 
     rawDeserialiseVerKeyDSIGN  = fmap VerKeyEd25519DSIGN . psbFromByteStringCheck
     rawDeserialiseSignKeyDSIGN bs = do
-      guard (BS.length bs == 32)
+      guard (fromIntegral (BS.length bs) == seedSizeDSIGN (Proxy @Ed25519DSIGN))
       pure . genKeyDSIGN . mkSeedFromBytes $ bs
     rawDeserialiseSigDSIGN     = fmap SigEd25519DSIGN . psbFromByteStringCheck
 

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed25519.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed25519.hs
@@ -32,7 +32,7 @@ import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks)
 import System.IO.Unsafe (unsafeDupablePerformIO)
 import GHC.IO.Exception (ioException)
-import Control.Monad (unless)
+import Control.Monad (unless, guard)
 import Foreign.C.Error (errnoToIOError, getErrno)
 import Foreign.Ptr (castPtr, nullPtr)
 import qualified Data.ByteString as BS
@@ -181,7 +181,9 @@ instance DSIGNAlgorithm Ed25519DSIGN where
     rawSerialiseSigDSIGN      (SigEd25519DSIGN sig) = psbToByteString sig
 
     rawDeserialiseVerKeyDSIGN  = fmap VerKeyEd25519DSIGN . psbFromByteStringCheck
-    rawDeserialiseSignKeyDSIGN = Just . genKeyDSIGN . mkSeedFromBytes
+    rawDeserialiseSignKeyDSIGN bs = do
+      guard (BS.length bs == 32)
+      pure . genKeyDSIGN . mkSeedFromBytes $ bs
     rawDeserialiseSigDSIGN     = fmap SigEd25519DSIGN . psbFromByteStringCheck
 
 

--- a/cardano-crypto-tests/src/Test/Crypto/DSIGN.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/DSIGN.hs
@@ -97,16 +97,16 @@ ed448SigGen :: Gen (SigDSIGN Ed448DSIGN)
 ed448SigGen = defaultSigGen
 
 #ifdef SECP256K1_ENABLED
-secp256k1SigGen :: Gen (SigDSIGN EcdsaSecp256k1DSIGN)
-secp256k1SigGen = do
-  msg <- genSECPMsg
+ecdsaSigGen :: Gen (SigDSIGN EcdsaSecp256k1DSIGN)
+ecdsaSigGen = do
+  msg <- genEcdsaMsg
   signDSIGN () msg <$> defaultSignKeyGen
 
 schnorrSigGen :: Gen (SigDSIGN SchnorrSecp256k1DSIGN)
 schnorrSigGen = defaultSigGen
 
-genSECPMsg :: Gen MessageHash
-genSECPMsg =
+genEcdsaMsg :: Gen MessageHash
+genEcdsaMsg =
   Gen.suchThatMap (GHC.fromListN 32 <$> replicateM 32 arbitrary)
                   toMessageHash
 #endif
@@ -140,7 +140,7 @@ tests =
     , testDSIGNAlgorithm ed25519SigGen (arbitrary @Message) "Ed25519DSIGN"
     , testDSIGNAlgorithm ed448SigGen (arbitrary @Message) "Ed448DSIGN"
 #ifdef SECP256K1_ENABLED
-    , testDSIGNAlgorithm secp256k1SigGen genSECPMsg "EcdsaSecp256k1DSIGN"
+    , testDSIGNAlgorithm ecdsaSigGen genEcdsaMsg "EcdsaSecp256k1DSIGN"
     , testDSIGNAlgorithm schnorrSigGen (arbitrary @Message) "SchnorrSecp256k1DSIGN"
 #endif
     ]

--- a/cardano-crypto-tests/src/Test/Crypto/DSIGN.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/DSIGN.hs
@@ -4,8 +4,7 @@
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UndecidableInstances #-}
-
-{-# OPTIONS_GHC -Wno-orphans #-}
+{-# LANGUAGE NumericUnderscores #-}
 
 module Test.Crypto.DSIGN
   ( tests
@@ -31,17 +30,19 @@ import Cardano.Crypto.DSIGN (
   MessageHash,
   toMessageHash,
 #endif
-  DSIGNAlgorithm (VerKeyDSIGN,
-                  SignKeyDSIGN,
-                  SigDSIGN,
-                  ContextDSIGN,
-                  Signable,
-                  rawSerialiseVerKeyDSIGN,
-                  rawDeserialiseVerKeyDSIGN,
-                  rawSerialiseSignKeyDSIGN,
-                  rawDeserialiseSignKeyDSIGN,
-                  rawSerialiseSigDSIGN,
-                  rawDeserialiseSigDSIGN),
+  DSIGNAlgorithm (
+    VerKeyDSIGN,
+    SignKeyDSIGN,
+    SigDSIGN,
+    ContextDSIGN,
+    Signable,
+    rawSerialiseVerKeyDSIGN,
+    rawDeserialiseVerKeyDSIGN,
+    rawSerialiseSignKeyDSIGN,
+    rawDeserialiseSignKeyDSIGN,
+    rawSerialiseSigDSIGN,
+    rawDeserialiseSigDSIGN
+    ),
   sizeVerKeyDSIGN,
   sizeSignKeyDSIGN,
   sizeSigDSIGN,
@@ -61,13 +62,17 @@ import Cardano.Binary (FromCBOR, ToCBOR)
 import Test.Crypto.Util (
   Message,
   prop_raw_serialise,
+  prop_raw_deserialise,
   prop_size_serialise,
   prop_cbor_with,
   prop_cbor,
   prop_cbor_size,
   prop_cbor_direct_vs_class,
   prop_no_thunks,
-  arbitrarySeedOfSize
+  arbitrarySeedOfSize,
+  genBadInputFor,
+  shrinkBadInputFor,
+  showBadInputFor,
   )
 import Test.Crypto.Instances ()
 import Test.QuickCheck (
@@ -76,10 +81,11 @@ import Test.QuickCheck (
   Arbitrary(..),
   Gen,
   Property,
-  forAllShow
+  forAllShow,
+  forAllShrinkShow,
   )
-import Test.Tasty (TestTree, testGroup)
-import Test.Tasty.QuickCheck (testProperty)
+import Test.Tasty (TestTree, testGroup, adjustOption)
+import Test.Tasty.QuickCheck (testProperty, QuickCheckTests)
 
 mockSigGen :: Gen (SigDSIGN MockDSIGN)
 mockSigGen = defaultSigGen
@@ -156,21 +162,36 @@ testDSIGNAlgorithm :: forall (v :: Type) (a :: Type).
   Gen a ->
   String ->
   TestTree
-testDSIGNAlgorithm genSig genMsg name = testGroup name [
+testDSIGNAlgorithm genSig genMsg name = adjustOption testEnough . testGroup name $ [
   testGroup "serialization" [
     testGroup "raw" [
-      testProperty "VerKey" .
+      testProperty "VerKey serialization" .
         forAllShow (defaultVerKeyGen @v)
                    ppShow $
                    prop_raw_serialise rawSerialiseVerKeyDSIGN rawDeserialiseVerKeyDSIGN,
-      testProperty "SignKey" .
+      testProperty "VerKey deserialization (wrong length)" .
+        forAllShrinkShow (genBadInputFor . expectedVKLen $ expected)
+                         (shrinkBadInputFor @(VerKeyDSIGN v))
+                         showBadInputFor $
+                         prop_raw_deserialise rawDeserialiseVerKeyDSIGN,
+      testProperty "SignKey serialization" .
         forAllShow (defaultSignKeyGen @v)
                    ppShow $
                    prop_raw_serialise rawSerialiseSignKeyDSIGN rawDeserialiseSignKeyDSIGN,
-      testProperty "Sig" .
+      testProperty "SignKey deserialization (wrong length)" .
+        forAllShrinkShow (genBadInputFor . expectedSKLen $ expected)
+                         (shrinkBadInputFor @(SignKeyDSIGN v))
+                         showBadInputFor $
+                         prop_raw_deserialise rawDeserialiseSignKeyDSIGN,
+      testProperty "Sig serialization" .
         forAllShow genSig
                    ppShow $
-                   prop_raw_serialise rawSerialiseSigDSIGN rawDeserialiseSigDSIGN
+                   prop_raw_serialise rawSerialiseSigDSIGN rawDeserialiseSigDSIGN,
+      testProperty "Sig deserialization (wrong length)" .
+        forAllShrinkShow (genBadInputFor . expectedSigLen $ expected)
+                         (shrinkBadInputFor @(SigDSIGN v))
+                         showBadInputFor $
+                         prop_raw_deserialise rawDeserialiseSigDSIGN
       ],
     testGroup "size" [
       testProperty "VerKey" .
@@ -240,6 +261,8 @@ testDSIGNAlgorithm genSig genMsg name = testGroup name [
     ]
   ]
   where
+    expected :: ExpectedLengths v
+    expected = defaultExpected
     genWrongKey :: Gen (a, SignKeyDSIGN v, SignKeyDSIGN v)
     genWrongKey = do
       sk1 <- defaultSignKeyGen
@@ -252,6 +275,8 @@ testDSIGNAlgorithm genSig genMsg name = testGroup name [
       msg2 <- Gen.suchThat genMsg (/= msg1)
       sk <- defaultSignKeyGen
       pure (msg1, msg2, sk)
+    testEnough :: QuickCheckTests -> QuickCheckTests
+    testEnough = max 10_000
 
 -- If we sign a message with the key, we can verify the signature with the
 -- corresponding verification key.
@@ -277,7 +302,7 @@ prop_dsign_verify_wrong_key (msg, sk, sk') =
       vk' = deriveVerKeyDSIGN sk'
     in verifyDSIGN () vk' msg signed =/= Right ()
 
--- If we signa a message with a key, but then try to verify with a different
+-- If we sign a a message with a key, but then try to verify with a different
 -- message, then verification fails.
 prop_dsign_verify_wrong_msg
   :: forall (v :: Type) (a :: Type) .
@@ -288,3 +313,20 @@ prop_dsign_verify_wrong_msg (msg, msg', sk) =
   let signed = signDSIGN () msg sk
       vk = deriveVerKeyDSIGN sk
     in verifyDSIGN () vk msg' signed =/= Right ()
+
+data ExpectedLengths (v :: Type) =
+  ExpectedLengths {
+    expectedVKLen :: Int,
+    expectedSKLen :: Int,
+    expectedSigLen :: Int
+    }
+
+defaultExpected ::
+  forall (v :: Type) .
+  (DSIGNAlgorithm v) =>
+  ExpectedLengths v
+defaultExpected = ExpectedLengths {
+  expectedVKLen = fromIntegral . sizeVerKeyDSIGN $ Proxy @v,
+  expectedSKLen = fromIntegral . sizeSignKeyDSIGN $ Proxy @v,
+  expectedSigLen = fromIntegral . sizeSigDSIGN $ Proxy @v
+  }

--- a/cardano-crypto-tests/src/Test/Crypto/KES.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/KES.hs
@@ -27,9 +27,9 @@ import Test.Tasty (TestTree, testGroup, adjustOption)
 import Test.Tasty.QuickCheck (testProperty, QuickCheckMaxSize(..))
 
 import Test.Crypto.Util (
-  ToCBOR, 
-  FromCBOR, 
-  Message, 
+  ToCBOR,
+  FromCBOR,
+  Message,
   prop_raw_serialise,
   prop_size_serialise,
   prop_cbor_with,

--- a/cardano-crypto-tests/src/Test/Crypto/KES.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/KES.hs
@@ -26,7 +26,19 @@ import Test.QuickCheck
 import Test.Tasty (TestTree, testGroup, adjustOption)
 import Test.Tasty.QuickCheck (testProperty, QuickCheckMaxSize(..))
 
-import Test.Crypto.Util hiding (label)
+import Test.Crypto.Util (
+  ToCBOR, 
+  FromCBOR, 
+  Message, 
+  prop_raw_serialise,
+  prop_size_serialise,
+  prop_cbor_with,
+  prop_cbor,
+  prop_cbor_size,
+  prop_cbor_direct_vs_class,
+  prop_no_thunks,
+  arbitrarySeedOfSize,
+  )
 import Test.Crypto.Instances ()
 
 {- HLINT ignore "Reduce duplication" -}

--- a/cardano-crypto-tests/src/Test/Crypto/Regressions.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/Regressions.hs
@@ -10,20 +10,27 @@ module Test.Crypto.Regressions (
 
 import Test.Tasty.HUnit (testCase, assertEqual)
 import Test.Tasty (TestTree, testGroup)
-#ifdef SECP256K1_ENABLED
 import Cardano.Crypto.DSIGN (rawDeserialiseVerKeyDSIGN)
+import Cardano.Crypto.DSIGN.Ed25519 (Ed25519DSIGN)
+import qualified Data.ByteString as BS
+#ifdef SECP256K1_ENABLED
 import Cardano.Crypto.DSIGN.SchnorrSecp256k1 (SchnorrSecp256k1DSIGN)
 #endif
 
 tests :: TestTree
 tests = testGroup "Regressions" [
-#ifdef SECP256K1_ENABLED
   testGroup "DSIGN" [
+#ifdef SECP256K1_ENABLED
     testGroup "Schnorr serialization" [
         testCase "Schnorr verkey deserialization fails on \"m\" literal" $ do
           let actual = rawDeserialiseVerKeyDSIGN @SchnorrSecp256k1DSIGN "m"
           assertEqual "" Nothing actual
+      ],
+#endif
+    testGroup "Ed25519 serialization" [
+      testCase "Ed25519 sign key deserialization fails on 33 NUL bytes" $ do
+        let actual = rawDeserialiseVerKeyDSIGN @Ed25519DSIGN . BS.replicate 33 $ 0
+        assertEqual "" Nothing actual
       ]
     ]
-#endif
   ]

--- a/cardano-crypto-tests/src/Test/Crypto/Util.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/Util.hs
@@ -51,16 +51,16 @@ import GHC.Exts (fromListN, fromList, toList)
 import Text.Show.Pretty (ppShow)
 import Data.Kind (Type)
 import Cardano.Binary (
-  FromCBOR (fromCBOR), 
+  FromCBOR (fromCBOR),
   ToCBOR (toCBOR),
-  Encoding, 
-  Decoder, 
+  Encoding,
+  Decoder,
   Range (Range),
-  decodeFullDecoder, 
-  serializeEncoding, 
-  szGreedy, 
+  decodeFullDecoder,
+  serializeEncoding,
+  szGreedy,
   szSimplify,
-  lo, 
+  lo,
   hi,
   encodedSizeExpr
   )
@@ -204,17 +204,17 @@ prop_raw_serialise serialise deserialise x =
       Just y  -> y === x
       Nothing -> property False
 
-prop_raw_deserialise :: 
+prop_raw_deserialise ::
   forall (a :: Type) .
   (Show a) =>
-  (ByteString -> Maybe a) -> 
-  BadInputFor a -> 
+  (ByteString -> Maybe a) ->
+  BadInputFor a ->
   Property
-prop_raw_deserialise deserialise (BadInputFor (forbiddenLen, bs)) = 
-  checkCoverage . 
+prop_raw_deserialise deserialise (BadInputFor (forbiddenLen, bs)) =
+  checkCoverage .
   cover 50.0 (BS.length bs > forbiddenLen) "too long" .
   cover 50.0 (BS.length bs < forbiddenLen) "too short" $
-  case deserialise bs of 
+  case deserialise bs of
     Nothing -> property True
     Just x -> counterexample (ppShow x) False
 
@@ -257,11 +257,11 @@ type role BadInputFor nominal
 
 -- Needed instead of an Arbitrary instance, as there's no (good) way of knowing
 -- what our forbidden (i.e. correct) length is.
-genBadInputFor :: 
-  forall (a :: Type) . 
-  Int -> 
+genBadInputFor ::
+  forall (a :: Type) .
+  Int ->
   Gen (BadInputFor a)
-genBadInputFor forbiddenLen = 
+genBadInputFor forbiddenLen =
   BadInputFor . (,) forbiddenLen <$> Gen.oneof [tooLow, tooHigh]
   where
     tooLow :: Gen ByteString
@@ -275,9 +275,9 @@ genBadInputFor forbiddenLen =
 
 -- This ensures we don't \'shrink out of case\': we shrink too-longs to
 -- (smaller) too-longs, and too-shorts to (smaller) too-shorts.
-shrinkBadInputFor :: 
-  forall (a :: Type) . 
-  BadInputFor a -> 
+shrinkBadInputFor ::
+  forall (a :: Type) .
+  BadInputFor a ->
   [BadInputFor a]
 shrinkBadInputFor (BadInputFor (len, bs)) = BadInputFor . (len,) <$> do
   bs' <- fromList <$> shrink (toList bs)
@@ -285,9 +285,9 @@ shrinkBadInputFor (BadInputFor (len, bs)) = BadInputFor . (len,) <$> do
   pure bs'
 
 -- This shows only the ByteString, in hex.
-showBadInputFor :: 
-  forall (a :: Type) . 
-  BadInputFor a -> 
+showBadInputFor ::
+  forall (a :: Type) .
+  BadInputFor a ->
   String
-showBadInputFor (BadInputFor (_, bs)) = 
+showBadInputFor (BadInputFor (_, bs)) =
   "0x" <> BS.foldr showHex "" bs <> " (length " <> show (BS.length bs) <> ")"

--- a/cardano-crypto-tests/src/Test/Crypto/Util.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/Util.hs
@@ -4,6 +4,10 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE RoleAnnotations #-}
+{-# LANGUAGE TupleSections #-}
 
 module Test.Crypto.Util
   ( -- * CBOR
@@ -15,6 +19,7 @@ module Test.Crypto.Util
   , prop_cbor_valid
   , prop_cbor_roundtrip
   , prop_raw_serialise
+  , prop_raw_deserialise
   , prop_size_serialise
   , prop_cbor_direct_vs_class
 
@@ -32,14 +37,40 @@ module Test.Crypto.Util
 
    -- * test messages for signings
   , Message(..)
+
+    -- * Test generation and shrinker helpers
+  , BadInputFor
+  , genBadInputFor
+  , shrinkBadInputFor
+  , showBadInputFor
   )
 where
 
-import Cardano.Binary (FromCBOR (..), ToCBOR (..),
-                       Encoding, Decoder, Range (..),
-                       decodeFullDecoder, serializeEncoding, szGreedy, szSimplify)
-import Codec.CBOR.FlatTerm
-import Codec.CBOR.Write
+import Numeric (showHex)
+import GHC.Exts (fromListN, fromList, toList)
+import Text.Show.Pretty (ppShow)
+import Data.Kind (Type)
+import Cardano.Binary (
+  FromCBOR (fromCBOR), 
+  ToCBOR (toCBOR),
+  Encoding, 
+  Decoder, 
+  Range (Range),
+  decodeFullDecoder, 
+  serializeEncoding, 
+  szGreedy, 
+  szSimplify,
+  lo, 
+  hi,
+  encodedSizeExpr
+  )
+import Codec.CBOR.FlatTerm  (
+  validFlatTerm,
+  toFlatTerm
+  )
+import Codec.CBOR.Write (
+  toStrictByteString
+  )
 import Cardano.Crypto.Seed (Seed, mkSeedFromBytes)
 import Cardano.Crypto.Util (SignableRepresentation(..))
 import Crypto.Random
@@ -48,8 +79,9 @@ import Crypto.Random
   , drgNewTest
   , withDRG
   )
-import Data.ByteString as BS (ByteString, pack, unpack, length)
-import Data.Proxy (Proxy (..))
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import Data.Proxy (Proxy (Proxy))
 import Data.Word (Word64)
 import NoThunks.Class (NoThunks, unsafeNoThunks)
 import Numeric.Natural (Natural)
@@ -65,8 +97,12 @@ import Test.QuickCheck
   , property
   , shrink
   , vector
+  , checkCoverage
+  , cover
   )
-import Formatting.Buildable (Buildable (..))
+import Formatting.Buildable (build)
+import qualified Test.QuickCheck.Gen as Gen
+import Control.Monad (guard, when)
 
 --------------------------------------------------------------------------------
 -- Connecting MonadRandom to Gen
@@ -85,7 +121,6 @@ testSeedToChaCha = drgNewTest . getTestSeed
 
 nullTestSeed :: TestSeed
 nullTestSeed = TestSeed (0, 0, 0, 0, 0)
-
 
 instance Arbitrary TestSeed where
   arbitrary =
@@ -113,7 +148,6 @@ instance Arbitrary Message where
   arbitrary = Message . BS.pack <$> arbitrary
   shrink    = map (Message . BS.pack) . shrink . BS.unpack . messageBytes
 
-
 --------------------------------------------------------------------------------
 -- Serialisation properties
 --------------------------------------------------------------------------------
@@ -133,7 +167,6 @@ prop_cbor_size a = counterexample (show lo ++ " ≰ " ++ show len) (lo <= len)
         Right x -> x
         Left err -> error . show . build $ err
 
-
 prop_cbor_with :: (Eq a, Show a)
                => (a -> Encoding)
                -> (forall s. Decoder s a)
@@ -141,7 +174,6 @@ prop_cbor_with :: (Eq a, Show a)
 prop_cbor_with encoder decoder x =
       prop_cbor_valid     encoder         x
  .&&. prop_cbor_roundtrip encoder decoder x
-
 
 prop_cbor_valid :: (a -> Encoding) -> a -> Property
 prop_cbor_valid encoder x =
@@ -153,7 +185,6 @@ prop_cbor_valid encoder x =
     errmsg   = "invalid flat term " ++ show term
             ++ " from encoding " ++ show encoding
 
-
 -- Written like this so that an Eq DeserialiseFailure is not required.
 prop_cbor_roundtrip :: (Eq a, Show a)
                     => (a -> Encoding)
@@ -164,7 +195,6 @@ prop_cbor_roundtrip encoder decoder x =
       Right y  -> y === x
       Left err -> counterexample (show err) (property False)
 
-
 prop_raw_serialise :: (Eq a, Show a)
                    => (a -> ByteString)
                    -> (ByteString -> Maybe a)
@@ -173,6 +203,20 @@ prop_raw_serialise serialise deserialise x =
     case deserialise (serialise x) of
       Just y  -> y === x
       Nothing -> property False
+
+prop_raw_deserialise :: 
+  forall (a :: Type) .
+  (Show a) =>
+  (ByteString -> Maybe a) -> 
+  BadInputFor a -> 
+  Property
+prop_raw_deserialise deserialise (BadInputFor (forbiddenLen, bs)) = 
+  checkCoverage . 
+  cover 50.0 (BS.length bs > forbiddenLen) "too long" .
+  cover 50.0 (BS.length bs < forbiddenLen) "too short" $
+  case deserialise bs of 
+    Nothing -> property True
+    Just x -> counterexample (ppShow x) . property $ False
 
 -- | The crypto algorithm classes have direct encoding functions, and the key
 -- types are also typically a member of the 'ToCBOR' class. Where a 'ToCBOR'
@@ -183,7 +227,6 @@ prop_cbor_direct_vs_class :: ToCBOR a
                           -> a -> Property
 prop_cbor_direct_vs_class encoder x =
   toFlatTerm (encoder x) === toFlatTerm (toCBOR x)
-
 
 prop_size_serialise :: (a -> ByteString) -> Word -> a -> Property
 prop_size_serialise serialise size x =
@@ -198,3 +241,54 @@ prop_no_thunks :: NoThunks a => a -> Property
 prop_no_thunks !a = case unsafeNoThunks a of
     Nothing  -> property True
     Just msg -> counterexample (show msg) (property False)
+
+--------------------------------------------------------------------------------
+-- Helpers for property testing
+--------------------------------------------------------------------------------
+
+-- Essentially a ByteString carrying around the length it's not allowed to be.
+-- This is annoying, but so's QuickCheck sometimes.
+newtype BadInputFor (a :: Type) = BadInputFor (Int, ByteString)
+  deriving (Eq) via (Int, ByteString)
+  deriving stock (Show)
+
+-- Coercion around a phantom parameter here is dangerous, as there's an implicit
+-- relation between it and the forbidden length. We ensure this is impossible.
+type role BadInputFor nominal
+
+-- Needed instead of an Arbitrary instance, as there's no (good) way of knowing
+-- what our forbidden (i.e. correct) length is.
+genBadInputFor :: 
+  forall (a :: Type) . 
+  Int -> 
+  Gen (BadInputFor a)
+genBadInputFor forbiddenLen = 
+  BadInputFor . (forbiddenLen,) <$> Gen.oneof [tooLow, tooHigh]
+  where
+    tooLow :: Gen ByteString
+    tooLow = do
+      len <- Gen.chooseInt (0, forbiddenLen - 1)
+      fromListN len <$> Gen.vectorOf len arbitrary
+    tooHigh :: Gen ByteString
+    tooHigh = do
+      len <- Gen.chooseInt (forbiddenLen + 1, forbiddenLen * 2)
+      fromListN len <$> Gen.vectorOf len arbitrary
+
+-- This ensures we don't \'shrink out of case\': we shrink too-longs to
+-- (smaller) too-longs, and too-shorts to (smaller) too-shorts.
+shrinkBadInputFor :: 
+  forall (a :: Type) . 
+  BadInputFor a -> 
+  [BadInputFor a]
+shrinkBadInputFor (BadInputFor (len, bs)) = BadInputFor . (len,) <$> do
+  bs' <- fromList <$> (shrink . toList $ bs)
+  when (BS.length bs > len) (guard (BS.length bs' > len))
+  pure bs'
+
+-- This shows only the ByteString, in hex.
+showBadInputFor :: 
+  forall (a :: Type) . 
+  BadInputFor a -> 
+  String
+showBadInputFor (BadInputFor (_, bs)) = 
+  "0x" <> BS.foldr showHex "" bs <> " (length " <> (show . BS.length $ bs) <> ")"


### PR DESCRIPTION
This handles [the comment](https://github.com/input-output-hk/cardano-base/pull/295#discussion_r950145389) in the original PR, some comments outputs of the audit by bcryptic, and some name changes in the tests. 

We close #295 in favour of this PR due to inactivity for a while. 