### PR TITLE
Bump up the version and add changelog for `cardano-crypto-praos`

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,7 @@ A collection of miscellaneous packages used by Cardano that cover:
 
 Each sub-project has its own README.
 
+All releases for packages found in this repository are recorded in [Cardano Haskell
+package repository](https://github.com/input-output-hk/cardano-haskell-packages)
+
 See the [wiki](https://github.com/input-output-hk/cardano-base/wiki) for more documentation.

--- a/cardano-crypto-praos/CHANGELOG.md
+++ b/cardano-crypto-praos/CHANGELOG.md
@@ -1,0 +1,14 @@
+# 2.1.0.0
+
+* Remove redundant and unused `unsafeRawSeed`, `io_crypto_vrf_publickeybytes` and
+  `io_crypto_vrf_secretkeybytes`.
+* Stop exporting internal `crypto_vrf_publickeybytes`, `crypto_vrf_secretkeybytes`,
+  `crypto_vrf_proofbytes`, `crypto_vrf_outputbytes` and `crypto_vrf_seedbytes` in favor of
+  `sizeVerKeyVRF`, `sizeSignKeyVRF`, `sizeCertVRF`, `sizeOutputVRF` and `seedSizeVRF`
+  respectfully.
+* Export `proofFromBytes`, `skFromBytes` and `vkFromBytes`
+* Expose internal types without constructors: `Proof`, `SignKey`, `VerKey` and `Output`
+
+# 2.0.0.1
+
+* Initial version released on [CHaP](https://github.com/input-output-hk/cardano-haskell-packages)

--- a/cardano-crypto-praos/cardano-crypto-praos.cabal
+++ b/cardano-crypto-praos/cardano-crypto-praos.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.2
 
 name:                cardano-crypto-praos
-version:             2.0.0.1
+version:             2.1.0.0
 synopsis:            Crypto primitives from libsodium
 description:         VRF (and KES, tba) primitives from libsodium.
 license:             Apache-2.0
@@ -14,6 +14,7 @@ copyright:           2019-2021 IOHK
 category:            Currency
 build-type:          Simple
 extra-source-files:  README.md
+                     CHANGELOG.md
 
 extra-source-files:    cbits/crypto_vrf.h
 


### PR DESCRIPTION
We've switched recently to CHaP, but recent PR #316 did not update changelog and did not bump up the version