### PR TITLE
Addition of test vectors to test-crypto test suite for ecdsa and schnorr

### DIFF
--- a/cardano-crypto-tests/cardano-crypto-tests.cabal
+++ b/cardano-crypto-tests/cardano-crypto-tests.cabal
@@ -57,6 +57,10 @@ library
                         Bench.Crypto.VRF
                         Bench.Crypto.KES
                         Bench.Crypto.BenchData
+                        Test.Crypto.Vector.Secp256k1DSIGN
+                        Test.Crypto.Vector.Vectors
+                        Test.Crypto.Vector.StringConstants
+                        Test.Crypto.Vector.SerializationUtils
 
   build-depends:        base
                       , bytestring
@@ -75,6 +79,7 @@ library
                       , tasty-hunit
                       , tasty-quickcheck
                       , criterion
+                      , base16-bytestring
 
   if flag(secp256k1-support)
     cpp-options: -DSECP256K1_ENABLED

--- a/cardano-crypto-tests/src/Test/Crypto/Vector/Secp256k1DSIGN.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/Vector/Secp256k1DSIGN.hs
@@ -1,0 +1,339 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Test.Crypto.Vector.Secp256k1DSIGN
+  ( tests,
+  )
+where
+
+import Cardano.Binary (DecoderError (DecoderErrorDeserialiseFailure), FromCBOR, decodeFull')
+import Cardano.Crypto.DSIGN
+  ( DSIGNAlgorithm
+      ( ContextDSIGN,
+        SigDSIGN,
+        SignKeyDSIGN,
+        Signable,
+        VerKeyDSIGN,
+        deriveVerKeyDSIGN,
+        signDSIGN,
+        verifyDSIGN
+      ),
+    EcdsaSecp256k1DSIGN,
+    MessageHash,
+    SchnorrSecp256k1DSIGN,
+    hashAndPack,
+    toMessageHash,
+  )
+import Cardano.Crypto.Hash.SHA3_256 (SHA3_256)
+import Codec.CBOR.Read (DeserialiseFailure (..))
+import Control.Monad (forM_)
+import Data.ByteString (ByteString)
+import Data.Either (isLeft, isRight)
+import Data.Maybe (isNothing)
+import Data.Proxy (Proxy (..))
+import Test.Crypto.Vector.SerializationUtils as Utils (HexStringInCBOR (..), dropBytes, hexByteStringLength)
+import Test.Crypto.Vector.StringConstants
+  ( cannotDecodeVerificationKeyError,
+    invalidEcdsaSigLengthError,
+    invalidEcdsaVerKeyLengthError,
+    invalidSchnorrSigLengthError,
+    invalidSchnorrVerKeyLengthError,
+    unexpectedDecodingError,
+  )
+import Test.Crypto.Vector.Vectors
+  ( defaultMessage,
+    defaultSKey,
+    ecdsaMismatchMessageAndSignature,
+    ecdsaNegSigTestVectors,
+    ecdsaVerKeyAndSigVerifyTestVectors,
+    ecdsaWrongLengthSigTestVectorsRaw,
+    schnorrMismatchMessageAndSignature,
+    schnorrVerKeyAndSigVerifyTestVectors,
+    schnorrWrongLengthSigTestVectorsRaw,
+    signAndVerifyTestVectors,
+    verKeyNotOnCurveTestVectorRaw,
+    wrongEcdsaVerKeyTestVector,
+    wrongLengthMessageHashTestVectors,
+    wrongLengthVerKeyTestVectorsRaw,
+    wrongSchnorrVerKeyTestVector,
+  )
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.HUnit (assertBool, assertEqual, testCase)
+
+ecdsaProxy :: Proxy EcdsaSecp256k1DSIGN
+ecdsaProxy = Proxy
+
+schnorrProxy :: Proxy SchnorrSecp256k1DSIGN
+schnorrProxy = Proxy
+
+tests :: TestTree
+tests =
+  testGroup
+    "Secp256k1 Test Vectors"
+    [ -- Note : Proxies are here repetead due to specific test vectors need to be used with specific proxy
+      testGroup
+        "EcdsaSecp256k1"
+        [ signAndVerifyTest ecdsaProxy,
+          verifyOnlyTest ecdsaVerKeyAndSigVerifyTestVectors,
+          wrongMessageHashLengthTest,
+          mismatchSignKeyVerKeyTest wrongEcdsaVerKeyTestVector,
+          mismatchMessageSignatureTest ecdsaMismatchMessageAndSignature,
+          verKeyNotOnCurveParserTest ecdsaProxy verKeyNotOnCurveTestVectorRaw,
+          invalidLengthVerKeyParserTest ecdsaProxy wrongLengthVerKeyTestVectorsRaw invalidEcdsaVerKeyLengthError,
+          invalidLengthSignatureParserTest ecdsaProxy ecdsaWrongLengthSigTestVectorsRaw invalidEcdsaSigLengthError,
+          negativeSignatureTest ecdsaNegSigTestVectors
+        ],
+      testGroup
+        "SchnorrSecp256k1"
+        [ signAndVerifyTest schnorrProxy,
+          verifyOnlyTest schnorrVerKeyAndSigVerifyTestVectors,
+          mismatchSignKeyVerKeyTest wrongSchnorrVerKeyTestVector,
+          mismatchMessageSignatureTest schnorrMismatchMessageAndSignature,
+          -- Note: First byte is dropped for schnorr as it doesn't require Y-cordinate information and assumed to be even and our vectors contains Y-information.
+          verKeyNotOnCurveParserTest schnorrProxy (Utils.dropBytes 1 verKeyNotOnCurveTestVectorRaw),
+          invalidLengthVerKeyParserTest schnorrProxy (map (Utils.dropBytes 1) wrongLengthVerKeyTestVectorsRaw) invalidSchnorrVerKeyLengthError,
+          invalidLengthSignatureParserTest schnorrProxy schnorrWrongLengthSigTestVectorsRaw invalidSchnorrSigLengthError
+        ]
+    ]
+
+negativeSignatureTest ::
+  forall v a.
+  ( DSIGNAlgorithm v,
+    ContextDSIGN v ~ (),
+    Signable v a,
+    ToSignable v a
+  ) =>
+  (VerKeyDSIGN v, ByteString, SigDSIGN v) ->
+  TestTree
+negativeSignatureTest (vKey, msg, sig) =
+  testCase "Verification should fail when using negative signature." $ do
+    let result = verifyDSIGN () vKey (toSignable (Proxy @v) msg) sig
+    assertBool "Test failed. Verification should be false for negative signature." $ isLeft result
+
+type InvalidLengthErrorFunction = Integer -> String
+
+invalidLengthSignatureParserTest ::
+  forall v.
+  ( FromCBOR (SigDSIGN v)
+  ) =>
+  Proxy v ->
+  [HexStringInCBOR] ->
+  InvalidLengthErrorFunction ->
+  TestTree
+invalidLengthSignatureParserTest _ invalidLengthSigs errorF =
+  testCase "Parsing should fail when using invalid length signatures." $
+    forM_ invalidLengthSigs $ \invalidSig -> do
+      let (DeserialiseFailure _ actualError) = invalidSigParserTest (Proxy @v) invalidSig
+      assertEqual "Expected invalid length signature error.." (errorF $ Utils.hexByteStringLength invalidSig) actualError
+
+-- Try to parse the raw string into signature key and return the deserialize error
+invalidSigParserTest ::
+  forall v.
+  ( FromCBOR (SigDSIGN v)
+  ) =>
+  Proxy v ->
+  HexStringInCBOR ->
+  DeserialiseFailure
+invalidSigParserTest _ rawSig = do
+  let result = fullSigParser (Proxy @v) rawSig
+  case result of
+    Left (DecoderErrorDeserialiseFailure _ err) -> err
+    Left _ -> error unexpectedDecodingError
+    Right _ -> error "Test failed. Invalid signature is treated as valid."
+
+-- Signature parser using decodeFull
+fullSigParser ::
+  forall v.
+  ( FromCBOR (SigDSIGN v)
+  ) =>
+  Proxy v ->
+  HexStringInCBOR ->
+  Either DecoderError (SigDSIGN v)
+fullSigParser _ (HexCBOR hs) = decodeFull' hs
+
+-- Try to parse invalid length raw verification key
+invalidLengthVerKeyParserTest ::
+  forall v.
+  ( FromCBOR (VerKeyDSIGN v)
+  ) =>
+  Proxy v ->
+  [HexStringInCBOR] ->
+  InvalidLengthErrorFunction ->
+  TestTree
+invalidLengthVerKeyParserTest _ invalidLengthVKeys errorF =
+  testCase "Parsing should fail when using invalid length verification keys." $
+    forM_ invalidLengthVKeys $ \invalidVKey -> do
+      let (DeserialiseFailure _ actualError) = invalidVerKeyParserTest (Proxy @v) invalidVKey
+      assertEqual "Expected invalid length verification key error." (errorF $ Utils.hexByteStringLength invalidVKey) actualError
+
+-- Try to parse raw verification key string and expect decode key error.
+verKeyNotOnCurveParserTest ::
+  forall v.
+  ( FromCBOR (VerKeyDSIGN v)
+  ) =>
+  Proxy v ->
+  HexStringInCBOR ->
+  TestTree
+verKeyNotOnCurveParserTest _ rawVKey = testCase "Parsing should fail when trying to parse verification key not on the curve." $ do
+  let (DeserialiseFailure _ actualError) = invalidVerKeyParserTest (Proxy @v) rawVKey
+  assertEqual "Expected cannot decode key error." cannotDecodeVerificationKeyError actualError
+
+-- Try to parse the raw string into verification key and return the deserialize error
+invalidVerKeyParserTest ::
+  forall v.
+  ( FromCBOR (VerKeyDSIGN v)
+  ) =>
+  Proxy v ->
+  HexStringInCBOR ->
+  DeserialiseFailure
+invalidVerKeyParserTest _ rawVKey = do
+  let result = fullVerKeyParser (Proxy @v) rawVKey
+  case result of
+    Left (DecoderErrorDeserialiseFailure _ err) -> err
+    Left _ -> error unexpectedDecodingError
+    Right _ -> error "Test failed. Invalid verification key is treated as valid."
+
+-- Vkey parser using decodeFull
+fullVerKeyParser ::
+  forall v.
+  ( FromCBOR (VerKeyDSIGN v)
+  ) =>
+  Proxy v ->
+  HexStringInCBOR ->
+  Either DecoderError (VerKeyDSIGN v)
+fullVerKeyParser _ (HexCBOR hs) = decodeFull' hs
+
+-- Use mismatch messages and signature vectors to test how verification behaves on wrong message or wrong signature
+mismatchMessageSignatureTest ::
+  forall v a.
+  ( DSIGNAlgorithm v,
+    ContextDSIGN v ~ (),
+    Signable v a,
+    ToSignable v a
+  ) =>
+  [(ByteString, VerKeyDSIGN v, SigDSIGN v)] ->
+  TestTree
+mismatchMessageSignatureTest mismatchMessageSignatureVectors =
+  testCase "Verification should not be successful when using mismatch message, signature and vice versa." $
+    forM_
+      mismatchMessageSignatureVectors
+      ( \(msg, vKey, sig) -> do
+          let result = verifyDSIGN () vKey (toSignable (Proxy @v) msg) sig
+          assertBool "Test Failed. Verification should not be successful." $ isLeft result
+      )
+
+-- Use mismatch verification key for the signature generated by another signing key
+mismatchSignKeyVerKeyTest ::
+  forall v a.
+  ( DSIGNAlgorithm v,
+    ContextDSIGN v ~ (),
+    Signable v a,
+    ToSignable v a,
+    FromCBOR (SignKeyDSIGN v)
+  ) =>
+  VerKeyDSIGN v ->
+  TestTree
+mismatchSignKeyVerKeyTest vKey = testCase "Verification should not be successful when using wrong verification key." $ do
+  let result = signAndVerifyWithVkey (Proxy @v) defaultSKey vKey defaultMessage
+  assertBool "Test failed. Verification should not be successful." $ isLeft result
+
+-- Wrong message hash length parser test for ecdsa
+wrongMessageHashLengthTest :: TestTree
+wrongMessageHashLengthTest = testCase "toMessageHash should return Nothing when using invalid length message hash." $
+  forM_ wrongLengthMessageHashTestVectors $ \msg -> do
+    let msgHash = toMessageHash msg
+    assertBool "Test failed. Wrong message hash length is treated as right." $ isNothing msgHash
+
+-- Test for vKey, message and signature test vectors without using sign key
+verifyOnlyTest ::
+  forall v a.
+  ( DSIGNAlgorithm v,
+    ContextDSIGN v ~ (),
+    Signable v a,
+    ToSignable v a
+  ) =>
+  (VerKeyDSIGN v, ByteString, SigDSIGN v) ->
+  TestTree
+verifyOnlyTest (vKey, msg, sig) = testCase "Verification only should be successful." $ verifyOnly (Proxy @v) vKey msg sig
+
+-- Sign using given sKey and verify it
+signAndVerifyTest ::
+  forall v a.
+  ( DSIGNAlgorithm v,
+    ContextDSIGN v ~ (),
+    Signable v a,
+    ToSignable v a,
+    FromCBOR (SignKeyDSIGN v)
+  ) =>
+  Proxy v ->
+  TestTree
+signAndVerifyTest _ =
+  testCase "Signing and verifications should be successful." $
+    mapM_ (uncurry $ signAndVerify (Proxy @v)) signAndVerifyTestVectors
+
+-- Sign a message using sign key, dervive verification key and check the signature
+-- Used for testing whole sign and verification flow
+signAndVerify ::
+  forall v a.
+  ( DSIGNAlgorithm v,
+    ContextDSIGN v ~ (),
+    Signable v a,
+    ToSignable v a
+  ) =>
+  Proxy v ->
+  SignKeyDSIGN v ->
+  ByteString ->
+  IO ()
+signAndVerify _ sKey msg = do
+  let vKey = deriveVerKeyDSIGN sKey
+      result = signAndVerifyWithVkey (Proxy @v) sKey vKey msg
+  assertBool "Test failed. Sign and verification should be successful." $ isRight result
+
+-- Sign a message using given sign key, verification key and check the signature
+-- Used for testing whole sign and verification flow
+signAndVerifyWithVkey ::
+  forall v a.
+  ( DSIGNAlgorithm v,
+    ContextDSIGN v ~ (),
+    Signable v a,
+    ToSignable v a
+  ) =>
+  Proxy v ->
+  SignKeyDSIGN v ->
+  VerKeyDSIGN v ->
+  ByteString ->
+  Either String ()
+signAndVerifyWithVkey _ sKey vKey msg =
+  let sig = signDSIGN () (toSignable (Proxy @v) msg) sKey
+   in verifyDSIGN () vKey (toSignable (Proxy @v) msg) sig
+
+-- Use alreday given signature, message and vkey to verify the signature
+verifyOnly ::
+  forall v a.
+  ( DSIGNAlgorithm v,
+    ContextDSIGN v ~ (),
+    Signable v a,
+    ToSignable v a
+  ) =>
+  Proxy v ->
+  VerKeyDSIGN v ->
+  ByteString ->
+  SigDSIGN v ->
+  IO ()
+verifyOnly _ vKey msg sig = do
+  let result = verifyDSIGN () vKey (toSignable (Proxy @v) msg) sig
+  assertBool "Test failed. Verification only should be successful." $ isRight result
+
+-- Class for supplying required message format according to signature algorithm used
+class ToSignable v a | v -> a where
+  toSignable :: Signable v a => Proxy v -> ByteString -> a
+
+instance ToSignable EcdsaSecp256k1DSIGN MessageHash where
+  toSignable _ bs = hashAndPack (Proxy @SHA3_256) bs
+
+instance ToSignable SchnorrSecp256k1DSIGN ByteString where
+  toSignable _ bs = bs

--- a/cardano-crypto-tests/src/Test/Crypto/Vector/SerializationUtils.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/Vector/SerializationUtils.hs
@@ -1,0 +1,64 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RankNTypes #-}
+
+module Test.Crypto.Vector.SerializationUtils
+  ( unHex,
+    unsafeUnHex,
+    SignatureResult,
+    HexStringInCBOR (..),
+    sKeyParser,
+    vKeyParser,
+    sigParser,
+    dropBytes,
+    hexByteStringLength,
+  )
+where
+
+import Cardano.Binary (FromCBOR, serialize', unsafeDeserialize')
+import Cardano.Crypto.DSIGN
+  ( DSIGNAlgorithm (SigDSIGN, SignKeyDSIGN, VerKeyDSIGN),
+  )
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Base16 as BS16
+import qualified Data.ByteString.Char8 as BS8
+import Data.String (IsString (fromString))
+import Prelude hiding (drop)
+
+-- Wrapper for serialized CBOR ByteString parsed from hex string
+newtype HexStringInCBOR = HexCBOR ByteString
+
+instance IsString HexStringInCBOR where
+  fromString s =
+    let bs = unsafeUnHex $ BS8.pack s
+        cborBs = serialize' bs
+     in HexCBOR cborBs
+
+instance Show HexStringInCBOR where
+  show (HexCBOR bs) = BS8.unpack $ BS16.encode bs
+
+--Drop from actual bytestring without cbor then recalculate
+dropBytes :: Int -> HexStringInCBOR -> HexStringInCBOR
+dropBytes n (HexCBOR bs) = HexCBOR $ serialize' $ BS.drop n (unsafeDeserialize' bs)
+
+hexByteStringLength :: HexStringInCBOR -> Integer
+hexByteStringLength (HexCBOR bs) = toInteger $ BS.length $ unsafeDeserialize' bs
+
+unHex :: ByteString -> Either String ByteString
+unHex = BS16.decode
+
+unsafeUnHex :: ByteString -> ByteString
+unsafeUnHex hexBs = case unHex hexBs of
+  Left err -> error $ "Couldn't unHex the Hex string. Incorrect format: " ++ err
+  Right bytes' -> bytes'
+
+type SignatureResult = (Either String ())
+
+sKeyParser :: forall d. (FromCBOR (SignKeyDSIGN d)) => HexStringInCBOR -> SignKeyDSIGN d
+sKeyParser (HexCBOR bs) = unsafeDeserialize' bs
+
+vKeyParser :: forall d. (FromCBOR (VerKeyDSIGN d)) => HexStringInCBOR -> VerKeyDSIGN d
+vKeyParser (HexCBOR bs) = unsafeDeserialize' bs
+
+sigParser :: forall d. (FromCBOR (SigDSIGN d)) => HexStringInCBOR -> SigDSIGN d
+sigParser (HexCBOR bs) = unsafeDeserialize' bs

--- a/cardano-crypto-tests/src/Test/Crypto/Vector/StringConstants.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/Vector/StringConstants.hs
@@ -1,0 +1,42 @@
+
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Crypto.Vector.StringConstants
+  ( invalidEcdsaSigLengthError,
+    invalidSchnorrVerKeyLengthError,
+    invalidEcdsaVerKeyLengthError,
+    invalidSchnorrSigLengthError,
+    cannotDecodeVerificationKeyError,
+    unexpectedDecodingError,
+  )
+where
+
+import Data.Data (Proxy (Proxy))
+import GHC.TypeLits (natVal)
+import Cardano.Crypto.SECP256K1.Constants (SECP256K1_ECDSA_PUBKEY_BYTES, SECP256K1_SCHNORR_PUBKEY_BYTES, SECP256K1_ECDSA_SIGNATURE_BYTES, SECP256K1_SCHNORR_SIGNATURE_BYTES)
+
+invalidEcdsaVerKeyLengthError :: Integer -> String
+invalidEcdsaVerKeyLengthError = invalidVerKeyLengthError $ natVal $ Proxy @SECP256K1_ECDSA_PUBKEY_BYTES
+
+invalidSchnorrVerKeyLengthError :: Integer -> String
+invalidSchnorrVerKeyLengthError = invalidVerKeyLengthError $ natVal $ Proxy @SECP256K1_SCHNORR_PUBKEY_BYTES
+
+invalidVerKeyLengthError :: Integer -> Integer -> String
+invalidVerKeyLengthError expectedLength actualLength =
+  "decodeVerKeyDSIGN: wrong length, expected " ++ show expectedLength ++ " bytes but got " ++ show actualLength
+
+invalidEcdsaSigLengthError :: Integer -> String
+invalidEcdsaSigLengthError = invalidSigLengthError $ natVal $ Proxy @SECP256K1_ECDSA_SIGNATURE_BYTES
+
+invalidSchnorrSigLengthError :: Integer -> String
+invalidSchnorrSigLengthError = invalidSigLengthError $ natVal $ Proxy @SECP256K1_SCHNORR_SIGNATURE_BYTES
+
+invalidSigLengthError :: Integer -> Integer -> String
+invalidSigLengthError expectedLength actualLength =
+  "decodeSigDSIGN: wrong length, expected " ++ show expectedLength ++ " bytes but got " ++ show actualLength
+
+cannotDecodeVerificationKeyError :: String
+cannotDecodeVerificationKeyError = "decodeVerKeyDSIGN: cannot decode key"
+
+unexpectedDecodingError :: String
+unexpectedDecodingError = "Test failed. Unexpected decoding error encountered."

--- a/cardano-crypto-tests/src/Test/Crypto/Vector/Vectors.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/Vector/Vectors.hs
@@ -1,0 +1,154 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+
+module Test.Crypto.Vector.Vectors
+  ( defaultSKey,
+    defaultMessage,
+    signAndVerifyTestVectors,
+    wrongEcdsaVerKeyTestVector,
+    wrongSchnorrVerKeyTestVector,
+    wrongLengthMessageHashTestVectors,
+    ecdsaVerKeyAndSigVerifyTestVectors,
+    schnorrVerKeyAndSigVerifyTestVectors,
+    ecdsaMismatchMessageAndSignature,
+    schnorrMismatchMessageAndSignature,
+    verKeyNotOnCurveTestVectorRaw,
+    wrongLengthVerKeyTestVectorsRaw,
+    ecdsaWrongLengthSigTestVectorsRaw,
+    schnorrWrongLengthSigTestVectorsRaw,
+    ecdsaNegSigTestVectors,
+  )
+where
+
+import Cardano.Binary (FromCBOR)
+import Cardano.Crypto.DSIGN
+  ( DSIGNAlgorithm (SigDSIGN, SignKeyDSIGN, VerKeyDSIGN),
+    EcdsaSecp256k1DSIGN,
+    SchnorrSecp256k1DSIGN,
+  )
+import Data.ByteString (ByteString)
+import Test.Crypto.Vector.SerializationUtils
+  ( HexStringInCBOR (..),
+    sKeyParser,
+    sigParser,
+    vKeyParser,
+  )
+
+defaultSKey :: forall d. (FromCBOR (SignKeyDSIGN d)) => SignKeyDSIGN d
+defaultSKey = sKeyParser "B7E151628AED2A6ABF7158809CF4F3C762E7160F38B4DA56A784D9045190CFEF"
+
+defaultMessage :: ByteString
+defaultMessage = "243F6A8885A308D313198A2E03707344A4093822299F31D0082EFA98EC4E6C89"
+
+-- These vectors contains secret key which first signs the given message and verifies using generated signature and derived vKey
+signAndVerifyTestVectors :: forall d. (FromCBOR (SignKeyDSIGN d)) => [(SignKeyDSIGN d, ByteString)]
+signAndVerifyTestVectors =
+  map
+    (\(sk, m) -> (sKeyParser sk, m))
+    [ ( "0000000000000000000000000000000000000000000000000000000000000003",
+        "0000000000000000000000000000000000000000000000000000000000000000"
+      ),
+      ( "B7E151628AED2A6ABF7158809CF4F3C762E7160F38B4DA56A784D9045190CFEF",
+        "243F6A8885A308D313198A2E03707344A4093822299F31D0082EFA98EC4E6C89"
+      ),
+      ( "C90FDAA22168C234C4C6628B80DC1CD129024E088A67CC74020BBEA63B14E5C9",
+        "7E2D58D8B3BCDF1ABADEC7829054F90DDA9805AAB56C77333024B9D0A508B75C"
+      ),
+      ( "0B432B2677937381AEF05BB02A66ECD012773062CF3FA2549E44F58ED2401710",
+        "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
+      )
+    ]
+
+-- It is used for testing already given message, signature and vKey so that Ver should be sucessful without needing secret key to sign the message for ecdsa.
+ecdsaVerKeyAndSigVerifyTestVectors :: (VerKeyDSIGN EcdsaSecp256k1DSIGN, ByteString, SigDSIGN EcdsaSecp256k1DSIGN)
+ecdsaVerKeyAndSigVerifyTestVectors =
+  ( vKeyParser "02599de3e582e2a3779208a210dfeae8f330b9af00a47a7fb22e9bb8ef596f301b",
+    "0000000000000000000000000000000000000000000000000000000000000000",
+    sigParser "354b868c757ef0b796003f7c23dd754d2d1726629145be2c7b7794a25fec80a06254f0915935f33b91bceb16d46ff2814f659e9b6791a4a21ff8764b78d7e114"
+  )
+
+ecdsaNegSigTestVectors :: (VerKeyDSIGN EcdsaSecp256k1DSIGN, ByteString, SigDSIGN EcdsaSecp256k1DSIGN)
+ecdsaNegSigTestVectors =
+  ( vKeyParser "02599de3e582e2a3779208a210dfeae8f330b9af00a47a7fb22e9bb8ef596f301b",
+    "0000000000000000000000000000000000000000000000000000000000000000",
+    sigParser "354b868c757ef0b796003f7c23dd754d2d1726629145be2c7b7794a25fec80a09dab0f6ea6ca0cc46e4314e92b900d7d6b493e4b47b6fb999fd9e841575e602d"
+  )
+
+-- It is used for testing already given message, signature and vKey so that Ver should be sucessful without needing secret key to sign the message for schnorr.
+schnorrVerKeyAndSigVerifyTestVectors :: (VerKeyDSIGN SchnorrSecp256k1DSIGN, ByteString, SigDSIGN SchnorrSecp256k1DSIGN)
+schnorrVerKeyAndSigVerifyTestVectors =
+  ( vKeyParser "599de3e582e2a3779208a210dfeae8f330b9af00a47a7fb22e9bb8ef596f301b",
+    "0000000000000000000000000000000000000000000000000000000000000000",
+    sigParser "5a56da88e6fd8419181dec4d3dd6997bab953d2fc71ab65e23cfc9e7e3d1a310613454a60f6703819a39fdac2a410a094442afd1fc083354443e8d8bb4461a9b"
+  )
+
+-- Wrong length message hash are used to test ecdsa toMessageHash function
+wrongLengthMessageHashTestVectors :: [ByteString]
+wrongLengthMessageHashTestVectors =
+  [ "0",
+    "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFE"
+  ]
+
+wrongEcdsaVerKeyTestVector :: VerKeyDSIGN EcdsaSecp256k1DSIGN
+wrongEcdsaVerKeyTestVector = vKeyParser "02D69C3509BB99E412E68B0FE8544E72837DFA30746D8BE2AA65975F29D22DC7B9"
+
+wrongSchnorrVerKeyTestVector :: VerKeyDSIGN SchnorrSecp256k1DSIGN
+wrongSchnorrVerKeyTestVector = vKeyParser "D69C3509BB99E412E68B0FE8544E72837DFA30746D8BE2AA65975F29D22DC7B9"
+
+-- Raw string verification key that is not on the curve should result in ver key parse failed
+verKeyNotOnCurveTestVectorRaw :: HexStringInCBOR
+verKeyNotOnCurveTestVectorRaw = "02EEFDEA4CDB677750A420FEE807EACF21EB9898AE79B9768766E4FAA04A2D4A34"
+
+-- Parse these vectors and expect the errors on tests with parity bit
+wrongLengthVerKeyTestVectorsRaw :: [HexStringInCBOR]
+wrongLengthVerKeyTestVectorsRaw =
+  [ -- Ver key of length 30 bytes
+    "02DFF1D77F2A671C5F36183726DB2341BE58FEAE1DA2DECED843240F7B50",
+    -- Ver key of length 34 bytes
+    "02DFF1D77F2A671C5F36183726DB2341BE58FEAE1DA2DECED843240F7B502BA659FF"
+  ]
+
+-- Raw hexstring to be used in invalid length signature parser tests for ecdsa
+ecdsaWrongLengthSigTestVectorsRaw :: [HexStringInCBOR]
+ecdsaWrongLengthSigTestVectorsRaw =
+  [ "354b868c757ef0b796003f7c23dd754d2d1726629145be2c7b7794a25fec80a06254f0915935f33b91bceb16d46ff2814f659e9b6791a4a21ff8764b78d7e1",
+    "354b868c757ef0b796003f7c23dd754d2d1726629145be2c7b7794a25fec80a06254f0915935f33b91bceb16d46ff2814f659e9b6791a4a21ff8764b78d7e114FF"
+  ]
+
+-- Raw hexstring to be used in invalid length signature parser tests for schnorr
+schnorrWrongLengthSigTestVectorsRaw :: [HexStringInCBOR]
+schnorrWrongLengthSigTestVectorsRaw =
+  [ "5a56da88e6fd8419181dec4d3dd6997bab953d2fc71ab65e23cfc9e7e3d1a310613454a60f6703819a39fdac2a410a094442afd1fc083354443e8d8bb4461a",
+    "5a56da88e6fd8419181dec4d3dd6997bab953d2fc71ab65e23cfc9e7e3d1a310613454a60f6703819a39fdac2a410a094442afd1fc083354443e8d8bb4461a9bFF"
+  ]
+
+ecdsaMismatchMessageAndSignature :: [(ByteString, VerKeyDSIGN EcdsaSecp256k1DSIGN, SigDSIGN EcdsaSecp256k1DSIGN)]
+ecdsaMismatchMessageAndSignature =
+  map
+    (\(vm, vKey, sig) -> (vm, vKeyParser vKey, sigParser sig))
+    --  verifyMessage, vKey, signature
+    [ ( "243F6A8885A308D313198A2E03707344A4093822299F31D0082EFA98EC4E6C89",
+        "0325d1dff95105f5253c4022f628a996ad3a0d95fbf21d468a1b33f8c160d8f517",
+        "3dccc57be49991e95b112954217e8b4fe884d4d26843dfec794feb370981407b79151d1e5af85aba21721876896957adb2b35bcbb84986dcf82daa520a87a9f9" -- wrong verify message but right signature
+      ),
+      ( "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF",
+        "0325d1dff95105f5253c4022f628a996ad3a0d95fbf21d468a1b33f8c160d8f517",
+        "5ef63d477c5d1572550016ccf72a2310c7368beeb843c85b1b5697290872222a09e7519702cb2c9a65bbce92d273080a0193b77588bc2eac6dbcbfc15c6dfefd" -- right verify message but wrong signature
+      )
+    ]
+
+schnorrMismatchMessageAndSignature :: [(ByteString, VerKeyDSIGN SchnorrSecp256k1DSIGN, SigDSIGN SchnorrSecp256k1DSIGN)]
+schnorrMismatchMessageAndSignature =
+  map
+    (\(vm, vKey, sig) -> (vm, vKeyParser vKey, sigParser sig))
+    -- verifyMessage, vKey, signature
+    [ ( "243F6A8885A308D313198A2E03707344A4093822299F31D0082EFA98EC4E6C89",
+        "599de3e582e2a3779208a210dfeae8f330b9af00a47a7fb22e9bb8ef596f301b",
+        "5a56da88e6fd8419181dec4d3dd6997bab953d2fc71ab65e23cfc9e7e3d1a310613454a60f6703819a39fdac2a410a094442afd1fc083354443e8d8bb4461a9b" -- wrong verify message but right signature
+      ),
+      ( "0000000000000000000000000000000000000000000000000000000000000000",
+        "599de3e582e2a3779208a210dfeae8f330b9af00a47a7fb22e9bb8ef596f301b",
+        "18a66fb829009a9df6312e1d7f4b53af0ac8a6aa17c2b7ff5941b57a27b24c23531f01bd11135dd844318f814241ea41040cc68958a6c47da489a32f0e22b805" -- right verify message but wrong signature
+      )
+    ]

--- a/cardano-crypto-tests/test/Main.hs
+++ b/cardano-crypto-tests/test/Main.hs
@@ -5,6 +5,7 @@ import qualified Test.Crypto.Hash
 import qualified Test.Crypto.KES
 import qualified Test.Crypto.VRF
 import qualified Test.Crypto.Regressions
+import qualified Test.Crypto.Vector.Secp256k1DSIGN
 import Test.Tasty (TestTree, adjustOption, testGroup, defaultMain)
 import Test.Tasty.QuickCheck (QuickCheckTests (QuickCheckTests))
 import Cardano.Crypto.Libsodium (sodiumInit)
@@ -25,4 +26,5 @@ tests =
       , Test.Crypto.KES.tests
       , Test.Crypto.VRF.tests
       , Test.Crypto.Regressions.tests
+      , Test.Crypto.Vector.Secp256k1DSIGN.tests
       ]


### PR DESCRIPTION
An initial pull request that contains test vectors for secp256k1. which includes following : 

**ECDSA**
    - Signing and verification successful
    - Invalid length for required parameters check
    - Signing and verification of pre-image message by hashing it
    - Invalid message hash length check for ecdsa
    - Invalid verification key check
    - Invalid message hash check
    - Invalid signature check

**Schnorr**
    - Signing and verification successful
    - Invalid length for required parameters check
    - Invalid verification key check
    - Invalid message check
    - Invalid signature check
