### PR TITLE
Bump CHaP

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,4 +1,18 @@
+repository cardano-haskell-packages
+  url: https://input-output-hk.github.io/cardano-haskell-packages
+  secure: True
+  root-keys:
+    3e0cce471cf09815f930210f7827266fd09045445d65923e6d0238a6cd15126f
+    443abb7fb497a134c343faf52f0b659bd7999bc06b7f63fa76dc99d631f9bea1
+    a86a1f6ce86c449c46666bda44268677abf29b5b2d2eb5ec7af903ec2f117a82
+    bcec67e8e99cabfa7764d75ad9b158d72bfacf70ca1d0ec8bc6b4406d1bf8413
+    c00aae8461a256275598500ea0e187588c35a5d5d7454fb57eac18d9edb86a56
+    d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
+
+-- The hackage index-state
 index-state: 2022-10-07T01:58:16Z
+-- The CHaP index-state
+index-state: cardano-haskell-packages 2022-10-20T01:58:16Z
 
 packages:
   base-deriving-via
@@ -16,13 +30,3 @@ packages:
 -- Ensures colourized output from test runners
 test-show-details: direct
 
-repository cardano-haskell-packages
-  url: https://input-output-hk.github.io/cardano-haskell-packages
-  secure: True
-  root-keys:
-    3e0cce471cf09815f930210f7827266fd09045445d65923e6d0238a6cd15126f
-    443abb7fb497a134c343faf52f0b659bd7999bc06b7f63fa76dc99d631f9bea1
-    a86a1f6ce86c449c46666bda44268677abf29b5b2d2eb5ec7af903ec2f117a82
-    bcec67e8e99cabfa7764d75ad9b158d72bfacf70ca1d0ec8bc6b4406d1bf8413
-    c00aae8461a256275598500ea0e187588c35a5d5d7454fb57eac18d9edb86a56
-    d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "f13512bf50057c26a2761d672adaa7141df6a9a4",
-        "sha256": "1zwcswgil4xafjaw8aq9jkkk8s8fgnwxhmf3sdjl0pnyzhrcvx2m",
+        "rev": "fed10e6b18c6f67ff2fb43031e810b38ab6d3f4f",
+        "sha256": "085f52f8gpmi569xxk76rry2xx7nn3zvqa6zsg1ghxfxa9vgdbqj",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/hackage.nix/archive/f13512bf50057c26a2761d672adaa7141df6a9a4.tar.gz",
+        "url": "https://github.com/input-output-hk/hackage.nix/archive/fed10e6b18c6f67ff2fb43031e810b38ab6d3f4f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz",
         "version": "b3c99d7f13df89a9a918c835ecb7114098912962"
     },

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -30,10 +30,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "3a9ba9f06a4e7151db61dd69e46f95f33368d42e",
-        "sha256": "0pzczg5i6h3wnzi7maqgs9pxvpz2zfips1ra1lrwhnrnbx3nb31v",
+        "rev": "6cf5f8f5a388cc17c3bd4a1a9706066f11e7a5bc",
+        "sha256": "00b7c1if1xpvkjc3qrj291rxlgpk54xmrqkndjqnfyqx2kjbx6pq",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/3a9ba9f06a4e7151db61dd69e46f95f33368d42e.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/6cf5f8f5a388cc17c3bd4a1a9706066f11e7a5bc.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz",
         "version": "962ecfed3a4fb656b5a91d89159291e00ed766bc"
     },

--- a/slotting/cardano-slotting.cabal
+++ b/slotting/cardano-slotting.cabal
@@ -3,8 +3,6 @@ cabal-version: 3.0
 name:                cardano-slotting
 version:             0.1.0.2
 synopsis:            Key slotting types for cardano libraries
--- description:
--- bug-reports:
 license:             Apache-2.0
 license-files:
   LICENSE
@@ -12,7 +10,6 @@ license-files:
 author:              IOHK Formal Methods Team
 maintainer:          formal.methods@iohk.io
 copyright:           IOHK
--- category:
 build-type:          Simple
 
 flag development


### PR DESCRIPTION
- Bump hackage.nix, which was too old for the index-state
- Give CHaP its own index-state, bump it to get newly released stuff