### PR TITLE
Add upper version bound on vector

### DIFF
--- a/cardano-crypto-class/cardano-crypto-class.cabal
+++ b/cardano-crypto-class/cardano-crypto-class.cabal
@@ -111,7 +111,7 @@ library
     , th-compat
     , text
     , transformers
-    , vector
+    , vector < 0.13
 
   if impl(ghc < 9.0.0)
     build-depends:


### PR DESCRIPTION
After spending a couple of hours trying to figure out why cardano-crypto-class was not compiling in certain repos.