### PR TITLE
Enable GitHub Actions for prs

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,6 +1,10 @@
 name: Haskell CI
 
-on: [push]
+on:
+  push:
+    branches: [ '*' ]
+  pull_request:
+    branches: [ "master" ]
 
 jobs:
   whitespace:


### PR DESCRIPTION
Currently Github Actions CI does not run on pull requests, which means that any PR from a forked repo will not have Github Actions executed