### PR TITLE
CI improvements

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -368,11 +368,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1666853863,
-        "narHash": "sha256-hr2WE/+qrXbEuLds5TFu791I7dEeuN3H3x35aqMfc00=",
+        "lastModified": 1668711738,
+        "narHash": "sha256-CBjky16o9pqsGE1bWu6nRlRajgSXMEk+yaFQLibqXcE=",
         "owner": "input-output-hk",
         "repo": "tullia",
-        "rev": "70af83b77604313561d8e14e2f27a8173e8a888b",
+        "rev": "ead1f515c251f0e060060ef0e2356a51d3dfe4b0",
         "type": "github"
       },
       "original": {

--- a/nix/cells/automation/pipelines.nix
+++ b/nix/cells/automation/pipelines.nix
@@ -18,7 +18,11 @@
     };
 
     command.text = config.preset.github.status.lib.reportBulk {
-      bulk.text = "nix eval .#hydraJobs --apply __attrNames --json | nix-systems -i";
+      bulk.text = ''
+        nix eval .#hydraJobs --apply __attrNames --json |
+        nix-systems -i |
+        jq 'with_entries(select(.value))' # filter out systems that we cannot build for
+      '';
       each.text = ''nix build -L .#hydraJobs."$1".required'';
       skippedDescription = lib.escapeShellArg "No nix builder for this system";
     };

--- a/nix/cells/automation/pipelines.nix
+++ b/nix/cells/automation/pipelines.nix
@@ -1,52 +1,29 @@
 {
   inputs,
   cell,
-}: let
-  inherit (inputs.tullia) flakeOutputTasks taskSequence;
-  inherit (inputs.nixpkgs) system lib;
-
-  common = {config, ...}: {
+}: {
+  ci = {config, lib, ...}: {
     preset = {
-      # needed on top-level task to set runtime options
       nix.enable = true;
 
-      github-ci = {
+      github.ci = {
         # Tullia tasks can run locally or on Cicero.
         # When no facts are present we know that we are running locally and vice versa.
         # When running locally, the current directory is already bind-mounted into the container,
         # so we don't need to fetch the source from GitHub and we don't want to report a GitHub status.
         enable = config.actionRun.facts != {};
-        repo = "input-output-hk/cardano-base";
-        sha = config.preset.github-ci.lib.getRevision inputs.cells.cloud.library.actionCiInputName null;
+        repository = "input-output-hk/cardano-base";
+        revision = config.preset.github.lib.readRevision inputs.cells.cloud.library.actionCiInputName null;
       };
     };
-  };
 
-  ciTasks =
-    __mapAttrs
-    (_: flakeOutputTask: {...}: {
-      imports = [common flakeOutputTask];
-
-      memory = 1024 * 8;
-      nomad.resources.cpu = 10000;
-    })
-    (flakeOutputTasks ["hydraJobs" system] { outputs.hydraJobs.${system} = cell.hydraJobs; });
-
-  ciTasksSeq = taskSequence "ci/" ciTasks (
-    # make sure the aggregate is built last
-    let
-      required = "hydraJobs.${system}.required";
-      all = __attrNames ciTasks;
-    in
-      assert __elem required all;
-        lib.remove required all ++ [required]
-  );
-in
-  ciTasks # for running separately
-  // ciTasksSeq # for running in an arbitrary sequence
-  // {
-    "ci" = {lib, ...}: {
-      imports = [common];
-      after = __attrNames ciTasksSeq;
+    command.text = config.preset.github.status.lib.reportBulk {
+      bulk.text = "nix eval .#hydraJobs --apply __attrNames --json | nix-systems -i";
+      each.text = ''nix build -L .#hydraJobs."$1".required'';
+      skippedDescription = lib.escapeShellArg "No nix builder for this system";
     };
-  }
+
+    memory = 1024 * 8;
+    nomad.resources.cpu = 10000;
+  };
+}


### PR DESCRIPTION
- Just have one tullia task that builds all hydra jobs instead of building one tullia task for each hydra job.
- build for all available platforms
  - report one github status each