### PR TITLE
Remove the chance of false positive test failures in mempool

### DIFF
--- a/cardano-mempool/tests/Test/Cardano/Memory/PoolTests.hs
+++ b/cardano-mempool/tests/Test/Cardano/Memory/PoolTests.hs
@@ -4,7 +4,6 @@
 
 module Test.Cardano.Memory.PoolTests (poolTests) where
 
-
 import Cardano.Memory.Pool
 import Common
 import Control.Concurrent (threadDelay)
@@ -71,8 +70,8 @@ propFindNextZeroIndex w = monadicIO . run $
             ("Expected found index to be different, but got same: " ++ show ix)
             (ix' /= ix)
           assertBool
-            ("Expected the bit under index: " ++ show ix' ++ " to not be set")
-            $ not (testBit w ix')
+            ("Expected the bit under index: " ++ show ix' ++ " to not be set") $
+            not (testBit w ix')
 
 -- We allow one extra page be allocated due to concurrency false positives in block
 -- reservations
@@ -89,9 +88,12 @@ checkNumPages pool n numBlocks = do
        ])
     (numPages <= estimatedUpperBoundOfPages)
 
-
 checkBlockBytes ::
-  (KnownNat n, Storable a, Eq a, Show a) => Block n -> a -> Ptr b -> Assertion
+     (KnownNat n, Storable a, Eq a, Show a)
+  => Block n
+  -> a
+  -> Ptr b
+  -> Assertion
 checkBlockBytes block byte ptr =
   let checkFillByte i =
         when (i >= 0) $ do
@@ -106,85 +108,120 @@ mallocPreFilled preFillByte bc = do
   withForeignPtr mfp $ \ptr -> setPtr (castPtr ptr) bc preFillByte
   pure mfp
 
+
+-- | @ensureAllGCedWith iterations delay expectedCount registerCounter@ waits
+-- for all items to be GCed by triggering garbage collection @iterations@
+-- times, once every @delay@ milliseconds. After @iterations@ attempts, if the
+-- counter hook was not called exactly @expectedCount@ times, a test failure is
+-- raised via 'assertFailure'. Garbage collection is tracked via finalizers
+-- (see below).
+ensureAllGCedWith ::
+     Int
+  -- ^ Number of GC attempts to make before failing
+  -> Int
+  -- ^ Delay between attempts, in milliseconds
+  -> Int
+  -- ^ Expected number of counter hook firings (in practice: individual
+  -- garbage collections on 'ForeignPtr's, as per their finalizers).
+  -> (IO () -> IO a)
+  -- ^ Function for registering the counter hook. The argument to this
+  -- function should be attached to each 'ForeignPtr' we're interested in
+  -- as a finalizer.
+  -> IO a
+ensureAllGCedWith iterations delay expectedCount registerCounter = do
+  countRef <- newPVar (0 :: Int)
+  res <- registerCounter (void $ atomicAddIntPVar countRef 1)
+  let go i = do
+        performGC
+        threadDelay (delay * 1000)
+        n <- atomicReadIntPVar countRef
+        unless (n == expectedCount) $ do
+          if i <= 1
+            then assertFailure $
+                 "Expected all " ++
+                 show expectedCount ++
+                 " pointers to be GCed in " ++
+                 show (delay * iterations) ++
+                 "ms, but " ++ show n ++ " where GCed instead"
+            else go (i - 1)
+  res <$ go iterations
+
+
+-- | 'ensureAllGCedWith' with default values: 100 iterations, 10ms delay.
+ensureAllGCed :: Int -> (IO () -> IO a) -> IO a
+ensureAllGCed = ensureAllGCedWith 100 10
+
+
 propPoolGarbageCollected ::
-  forall n.
-  KnownNat n =>
-  Block n ->
-  Positive Int ->
-  Word16 ->
-  Word8 ->
-  Word8 ->
-  Property
+     forall n. KnownNat n
+  => Block n
+  -> Positive Int
+  -> Word16
+  -> Word8
+  -> Word8
+  -> Property
 propPoolGarbageCollected block (Positive n) numBlocks16 preFillByte fillByte =
   monadicIO . run $ do
     let numBlocks = 1 + (fromIntegral numBlocks16 `div` 20) -- make it not too big
-    countRef <- newPVar (0 :: Int)
-    pool <-
-      initPool n (mallocPreFilled preFillByte) $ \ptr -> do
-        setPtr (castPtr ptr) (blockByteCount block) fillByte
-        void $ atomicAddIntPVar countRef 1
-    fmps :: [ForeignPtr (Block n)] <-
-      replicateConcurrently numBlocks (grabNextBlock pool)
-    touch fmps
-    -- Here we return just the pointers and let the GC collect the ForeignPtrs
-    ptrs <-
-      forM fmps $ \fma ->
-        withForeignPtr fma $ \ptr -> do
-          let bytePtr = castPtr ptr
-          checkBlockBytes block preFillByte bytePtr
-          setPtr bytePtr (blockByteCount block) fillByte
-          pure bytePtr
-    performGC
-    -- allow some time for all blocks to finalize
-    threadDelay 50000
-    numBlocks' <- atomicReadIntPVar countRef
-    numBlocks' @?= numBlocks
+    (pool, ptrs) <-
+      ensureAllGCed numBlocks $ \countOneBlockGCed -> do
+        pool <-
+          initPool n (mallocPreFilled preFillByte) $ \ptr -> do
+            setPtr (castPtr ptr) (blockByteCount block) fillByte
+            countOneBlockGCed
+        fmps :: [ForeignPtr (Block n)] <-
+          replicateConcurrently numBlocks (grabNextBlock pool)
+        touch fmps
+        -- Here we return just the pointers and let the GC collect the ForeignPtrs
+        ptrs <-
+          forM fmps $ \fma ->
+            withForeignPtr fma $ \ptr -> do
+              let bytePtr = castPtr ptr
+              checkBlockBytes block preFillByte bytePtr
+              setPtr bytePtr (blockByteCount block) fillByte
+              pure bytePtr
+        pure (pool, ptrs)
     forM_ ptrs (checkBlockBytes block fillByte)
     checkNumPages pool n numBlocks
     -- Ensure that memory to that the pointers are referencing to is still alive
     touch pool
 
 propPoolAllocateAndFinalize ::
-  forall n.
-  KnownNat n =>
-  Block n ->
-  Positive Int ->
-  Word16 ->
-  Word8 ->
-  Word8 ->
-  Property
+     forall n. KnownNat n
+  => Block n
+  -> Positive Int
+  -> Word16
+  -> Word8
+  -> Word8
+  -> Property
 propPoolAllocateAndFinalize block (Positive n) numBlocks16 emptyByte fullByte =
   monadicIO . run $ do
     let numBlocks = 1 + (fromIntegral numBlocks16 `div` 20)
-    countRef <- newPVar (0 :: Int)
-    chan <- newChan
     pool <-
-      initPool n (mallocPreFilled emptyByte) $ \(ptr :: Ptr (Block n)) -> do
-        setPtr (castPtr ptr) (blockByteCount block) emptyByte
-        void $ atomicAddIntPVar countRef 1
-    -- allocate and finalize blocks concurrently
-    concurrently_
-      (do replicateConcurrently_ numBlocks $ do
-            fp <- grabNextBlock pool
-            withForeignPtr fp (checkBlockBytes block emptyByte)
-            writeChan chan (Just fp)
-          -- place Nothing to indicate we are done allocating blocks
-          writeChan chan Nothing)
-      (fix $ \loop -> do
-         mfp <- readChan chan
-         forM_ mfp $ \fp -> do
-           withForeignPtr fp $ \ptr ->
-             -- fill the newly allocated block
-             setPtr (castPtr ptr) (blockByteCount block) fullByte
-           -- manually finalize every other block and let the GC to pick the rest
-           shouldFinalize <- uniformM globalStdGen
-           when shouldFinalize $ finalizeForeignPtr fp
-           loop)
-    performGC
-    -- allow some time for all blocks to finalize
-    threadDelay 50000
-    -- verify all finalizers have been executed
-    numBlocks' <- atomicReadIntPVar countRef
-    numBlocks' @?= numBlocks
+      ensureAllGCed numBlocks $ \countOneBlockGCed -> do
+        chan <- newChan
+        pool <-
+          initPool n (mallocPreFilled emptyByte) $ \(ptr :: Ptr (Block n)) -> do
+            setPtr (castPtr ptr) (blockByteCount block) emptyByte
+            countOneBlockGCed
+        -- allocate and finalize blocks concurrently
+        pool <$
+          concurrently_
+            (do replicateConcurrently_ numBlocks $ do
+                  fp <- grabNextBlock pool
+                  withForeignPtr fp (checkBlockBytes block emptyByte)
+                  writeChan chan (Just fp)
+                -- place Nothing to indicate that we are done allocating blocks
+                writeChan chan Nothing)
+            (fix $ \loop -> do
+               mfp <- readChan chan
+               forM_ mfp $ \fp -> do
+                 withForeignPtr fp $ \ptr ->
+                   -- fill the newly allocated block
+                   setPtr (castPtr ptr) (blockByteCount block) fullByte
+                 -- manually finalize every other block and let the GC to pick the rest
+                 shouldFinalize <- uniformM globalStdGen
+                 when shouldFinalize $ finalizeForeignPtr fp
+                 loop)
     -- verify number of pages
     checkNumPages pool n numBlocks


### PR DESCRIPTION
Make the test case more resilient to failures by waiting until GC executes all finalizers for a full second, while checking if all ForeignPtrs got GCed every 10ms. Also speeds up the test suite.