### PR TITLE
Fix index-state syntax in cabal.project

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -9,10 +9,13 @@ repository cardano-haskell-packages
     c00aae8461a256275598500ea0e187588c35a5d5d7454fb57eac18d9edb86a56
     d4a35cd3121aa00d18544bb0ac01c3e1691d618f462c46129271bccf39f7e8ee
 
--- The hackage index-state
+-- The hackage index-state is repeated twice to work around haskell.nix
+-- limited parsing ability
 index-state: 2022-10-07T01:58:16Z
--- The CHaP index-state
-index-state: cardano-haskell-packages 2022-10-20T01:58:16Z
+index-state:
+  , hackage.haskell.org 2022-10-07T01:58:16Z
+  -- The CHaP index-state
+  , cardano-haskell-packages 2022-10-20T01:58:16Z
 
 packages:
   base-deriving-via


### PR DESCRIPTION
The index-state stanza in cabal.project is "last wins", so 
```
index-state: 2022-12-24T00:00:00Z
index-state: cardano-haskell-packages 2022-11-02T15:34:17Z
```
would set the index state of hackage to HEAD.

The correct syntax to set the index-state of both repositories is
```
index-state:
  , hackage.haskell.org 2022-12-24T00:00:00Z
  , cardano-haskell-packages 2022-11-02T15:34:17Z
```
haskell.nix has trouble parsing the index-state syntax with multiple repositories, so we repeat the index-state for Hackage. Cabal will ignore the first index-state stanza anyway.