### PR TITLE
Remove quirks.h from extra-source-files

### DIFF
--- a/cardano-crypto-praos/cardano-crypto-praos.cabal
+++ b/cardano-crypto-praos/cardano-crypto-praos.cabal
@@ -23,7 +23,6 @@ extra-source-files:    cbits/crypto_vrf.h
                        cbits/vrf13_batchcompat/crypto_vrf_ietfdraft13.h
 
                        cbits/private/common.h
-                       cbits/private/quirks.h
                        cbits/private/ed25519_ref10.h
                        cbits/private/core_h2c.h
                        cbits/private/ed25519_ref10_fe_25_5.h


### PR DESCRIPTION
The file `cbits/private/quirks.h` no longer exists, but it is still mentioned in `extra-source-files`, causing `cabal sdist` to fail.

CI does not catch this, because it only builds cardano-base packages locally, not as dependencies, and thus ignores `extra-source-files`, but any code depending on `cardano-base/cardano-crypto-praos` will cause Cabal to make and install a source tarball ("sdist"), and fail due to a missing file.

This PR fixes the error itself, but in order to catch this in CI, it would be useful to run `cabal sdist all` at some point (this will create a source bundle, and fail with a nonzero exit status if any problems were found).