### PR TITLE
Update nix sources

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -43,10 +43,10 @@
         "homepage": null,
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "ccd5bf7d8168a0452d9ec504ea1b559ada7752df",
-        "sha256": "10p6nmqz3frslh5y92dnvi4zdkhiybl18s3wmsbysfxz6gpzwgy7",
+        "rev": "03a6755865b7461b3b75dc34c3dd2d5e74920196",
+        "sha256": "1cp2rb3acyc1f5kgaz4ci0mks1zvmp7i51zn4p5jc3alviv8lnmr",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/iohk-nix/archive/ccd5bf7d8168a0452d9ec504ea1b559ada7752df.tar.gz",
+        "url": "https://github.com/input-output-hk/iohk-nix/archive/03a6755865b7461b3b75dc34c3dd2d5e74920196.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "nixpkgs": {


### PR DESCRIPTION
Unfortunately we have old versions of cardano-base running with last version of nix/libsodium. Therefore we had to reinstate a function in libsodium for backwards compatibility. This PR points to the latest iohk-nix.