### PR TITLE
Fix compatibility with newer template-haskell

### DIFF
--- a/cardano-crypto-class/src/Cardano/Crypto/Hash/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Hash/Class.hs
@@ -74,7 +74,7 @@ import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import Language.Haskell.TH.Syntax (Q, TExp(..))
-import Language.Haskell.TH.Syntax.Compat (examineSplice)
+import Language.Haskell.TH.Syntax.Compat (Code (Code), examineSplice)
 
 import Data.Aeson (FromJSON(..), FromJSONKey(..), ToJSON(..), ToJSONKey(..))
 import qualified Data.Aeson as Aeson
@@ -142,6 +142,8 @@ instance HashAlgorithm h => IsString (Q (TExp (Hash h a))) where
       Left err -> fail $ "<Hash " ++ hashAlgorithmName (Proxy :: Proxy h) ++ ">: " ++ err
       Right _  -> examineSplice [|| either error (UnsafeHashRep . packPinnedBytes) (decodeHexString hexStr n) ||]
 
+instance HashAlgorithm h => IsString (Code Q (Hash h a)) where
+  fromString = Code . fromString
 
 pattern UnsafeHash :: forall h a. HashAlgorithm h => ShortByteString -> Hash h a
 pattern UnsafeHash bytes <- UnsafeHashRep (unpackBytes -> bytes)

--- a/cardano-crypto-class/src/Cardano/Crypto/PinnedSizedBytes.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/PinnedSizedBytes.hs
@@ -58,7 +58,7 @@ import Foreign.Storable (Storable (..))
 import GHC.TypeLits (KnownNat, Nat, natVal)
 import NoThunks.Class (NoThunks, OnlyCheckWhnfNamed (..))
 import Language.Haskell.TH.Syntax (Q, TExp(..))
-import Language.Haskell.TH.Syntax.Compat (examineSplice)
+import Language.Haskell.TH.Syntax.Compat (Code(..), examineSplice)
 import Numeric (showHex)
 import System.IO.Unsafe (unsafeDupablePerformIO)
 
@@ -150,6 +150,8 @@ instance KnownNat n => IsString (Q (TExp (PinnedSizedBytes n))) where
         Left err -> fail $ "<PinnedSizedBytes>: " ++ err
         Right _  -> examineSplice [|| either error psbFromByteString (decodeHexString hexStr n) ||]
 
+instance KnownNat n => IsString (Code Q (PinnedSizedBytes n)) where
+  fromString = Code . fromString
 
 -- | See 'psbFromBytes'.
 psbToBytes :: PinnedSizedBytes n -> [Word8]


### PR DESCRIPTION
Upgrade to GHC-9.2 requires `IsString (Code Q (Hash h a)) instance`, otherwise `IsString` instance for `Hash`es as described in the haddock doesn't work 