### PR TITLE
Bump haskell.nix and share nixpkgs

### DIFF
--- a/nix/sources.json
+++ b/nix/sources.json
@@ -48,18 +48,5 @@
         "type": "tarball",
         "url": "https://github.com/input-output-hk/iohk-nix/archive/67967ced6a40dce4721bc3fcc163c1809398c3c0.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
-    },
-    "nixpkgs": {
-        "branch": "nixpkgs-unstable",
-        "builtin": true,
-        "description": "Nix Packages collection",
-        "homepage": "",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "c9ece0059f42e0ab53ac870104ca4049df41b133",
-        "sha256": "1qrb99vbwb3xdc0860z7izy0x7p1mbnyg5lrwsr3yn5i73zcwcf4",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/c9ece0059f42e0ab53ac870104ca4049df41b133.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
The bump is to support cabal file revisions on CHaP which are necessary to get our packages to build without all those manual constraints we have in cabal.project.

I am opening a draft PR to test the waters and warm up the chaces ahead of time since it's relatively big change in haskell.nix. I'll make sure everything works and then mark it as ready.
