### PR TITLE
Fixup time related instances

### DIFF
--- a/cardano-binary/CHANGELOG.md
+++ b/cardano-binary/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog for `cardano-binary`
 
+## 1.7.0.0
+
+* Remove `To/FromCBOR` instances for `NominalDiffTime`, since they did rounding.  Newly
+  added functions `encodeNominalDiffTimeMicro`/`decodedNominalDiffTimeMicro` can be used
+  to recover previous behavior. Correct instances that do not perform any rounding will
+  be added in some future version, for now `decodeNominalDiffTime` and
+  `encodeNominalDiffTime` can be used.
+* Add `decodeNominalDiffTime` and `encodeNominalDiffTime`
+* Add `To/FromCBOR` for all `Fixed a`, not just `Nano` and `Pico`
+
 ## 1.6.0.0
 
 * Removed `Cardano.Binary.Annotated` and `Cardano.Binary.Drop` modules. They have been

--- a/cardano-binary/cardano-binary.cabal
+++ b/cardano-binary/cardano-binary.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.2
 
 name:                cardano-binary
-version:             1.6.0.0
+version:             1.7.0.0
 synopsis:            Binary serialization for Cardano
 description:         This package includes the binary serialization format for Cardano
 license:             Apache-2.0

--- a/cardano-binary/src/Cardano/Binary/FromCBOR.hs
+++ b/cardano-binary/src/Cardano/Binary/FromCBOR.hs
@@ -17,6 +17,8 @@ module Cardano.Binary.FromCBOR
   , decodeNullMaybe
   , decodeSeq
   , decodeListWith
+  , decodeNominalDiffTime
+  , decodeNominalDiffTimeMicro
     -- * Helper tools to build instances
   , decodeMapSkel
   , decodeCollection
@@ -39,7 +41,7 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as BSL
 import qualified Data.ByteString.Short as SBS
 import Data.ByteString.Short.Internal (ShortByteString (SBS))
-import Data.Fixed (Fixed(..), Nano, Pico)
+import Data.Fixed (Fixed(..))
 import Data.Int (Int32, Int64)
 import Data.List.NonEmpty (NonEmpty, nonEmpty)
 import qualified Data.Map as M
@@ -51,7 +53,7 @@ import Data.Tagged (Tagged(..))
 import Data.Text (Text)
 import qualified Data.Text  as T
 import Data.Time.Calendar.OrdinalDate ( fromOrdinalDate )
-import Data.Time.Clock (NominalDiffTime, UTCTime(..), picosecondsToDiffTime)
+import Data.Time.Clock (NominalDiffTime, UTCTime(..), secondsToNominalDiffTime, picosecondsToDiffTime)
 import Data.Typeable ( Typeable, typeRep, Proxy )
 import qualified Data.Vector as Vector
 import qualified Data.Vector.Generic as Vector.Generic
@@ -218,15 +220,15 @@ instance FromCBOR Rational where
       then cborError $ DecoderErrorCustom "Rational" "invalid denominator"
       else return $! n % d
 
-instance FromCBOR Nano where
+instance Typeable a => FromCBOR (Fixed a) where
   fromCBOR = MkFixed <$> fromCBOR
 
-instance FromCBOR Pico where
-  fromCBOR = MkFixed <$> fromCBOR
+decodeNominalDiffTime :: Decoder s NominalDiffTime
+decodeNominalDiffTime = secondsToNominalDiffTime <$> fromCBOR
 
 -- | For backwards compatibility we round pico precision to micro
-instance FromCBOR NominalDiffTime where
-  fromCBOR = fromRational . (% 1e6) <$> fromCBOR
+decodeNominalDiffTimeMicro :: Decoder s NominalDiffTime
+decodeNominalDiffTimeMicro = fromRational . (% 1e6) <$> fromCBOR
 
 instance FromCBOR Natural where
   fromCBOR = do

--- a/cardano-slotting/CHANGELOG.md
+++ b/cardano-slotting/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Changelog for `cardano-slotting`
+
+## 0.1.1.0
+
+* Addition of `ToJSON`/`FromJSON` instances for `SystemStart`
+* Addition of `ToCBOR`/`FromCBOR` instances for `RelativeTime` and `SlotLength`
+
 ## 0.1.0.1
 
 * Initial release

--- a/cardano-slotting/cardano-slotting.cabal
+++ b/cardano-slotting/cardano-slotting.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                cardano-slotting
-version:             0.1.0.2
+version:             0.1.1.0
 synopsis:            Key slotting types for cardano libraries
 license:             Apache-2.0
 license-files:


### PR DESCRIPTION
`To/FromCBOR` instance for `NominalDiffTime` is pretty broken, since there is loss of precision on roundtripping. This PR fixes it by removing the instance altogether in favor of helper functions that can do the same job, but they are more explicit.

Also moving orphan `To/FromJSON` instances for `SystemStart` from `cardano-node`

Adding a couple of other potentially useful instances