### PR TITLE
Add a lower bound on cardano-binary for cardano-crypto-class

### DIFF
--- a/cardano-crypto-class/cardano-crypto-class.cabal
+++ b/cardano-crypto-class/cardano-crypto-class.cabal
@@ -91,7 +91,7 @@ library
     , base
     , base16-bytestring  >=1
     , bytestring
-    , cardano-binary
+    , cardano-binary >= 1.6
     , cardano-strict-containers
     , cryptonite
     , deepseq


### PR DESCRIPTION
It's needed, and prevents cabal from trying to pick the old
cardano-binary sometimes.
