### PR TITLE
Add missing from json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ stack-local.yaml
 
 # Test artefacts
 /result-*
+cardano-crypto-class/output
+cardano-crypto-praos/output
 
 # ghcid
 **/.ghcid

--- a/cardano-slotting/CHANGELOG.md
+++ b/cardano-slotting/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## 0.1.1.0
 
 * Remove `development` flag: #372
-* Addition of `ToJSON` instances for `WithOrigin`.
 * Addition of `ToJSON`/`FromJSON` instances for:
+  * `WithOrigin`
   * `BlockNo`
   * `SystemStart`
   * `RelativeTime` and `SlotLength`

--- a/cardano-slotting/src/Cardano/Slotting/Slot.hs
+++ b/cardano-slotting/src/Cardano/Slotting/Slot.hs
@@ -23,7 +23,7 @@ where
 import Cardano.Binary (FromCBOR (..), ToCBOR (..))
 import Codec.Serialise (Serialise (..))
 import Control.DeepSeq (NFData (rnf))
-import Data.Aeson (FromJSON, ToJSON (..), Value (String))
+import Data.Aeson (FromJSON (..), ToJSON (..), Value (String))
 import Data.Typeable (Typeable)
 import Data.Word (Word64)
 import GHC.Generics (Generic)
@@ -78,6 +78,11 @@ instance ToJSON a => ToJSON (WithOrigin a) where
   toJSON = \case
     Origin -> String "origin"
     At n -> toJSON n
+
+instance FromJSON a => FromJSON (WithOrigin a) where
+  parseJSON = \case
+    String "origin" -> pure Origin
+    value -> At <$> parseJSON value
 
 at :: t -> WithOrigin t
 at = At


### PR DESCRIPTION
Turns out FromJSON instance for WithOrigin is also needed in cardano-node. This PR adds it.

Also adds paths that are created during testing to `.gitignore`