### PR TITLE
Include additional tests to BLS bindings

### DIFF
--- a/cardano-crypto-class/src/Cardano/Crypto/EllipticCurve/BLS12_381/Internal.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/EllipticCurve/BLS12_381/Internal.hs
@@ -790,13 +790,15 @@ affineInG affine = unsafePerformIO $
 blsGenerator :: BLS curve => Point curve
 blsGenerator = unsafePointFromPointPtr c_blst_generator
 
-blsZero :: forall curve. (BLS curve) => Point curve
+blsZero :: forall curve. BLS curve => Point curve
 blsZero =
-    let b = BS.pack (0xc0 : replicate ((compressedSizePoint (Proxy @curve)) - 1) 0x00) -- Compressed serialised G1 points are bytestrings of length 48: see CIP-0381.
-    in case blsUncompress b of
-        Left err       -> error $ "Unexpected failure deserialising point at infinity on BLS12_381.G1:  " ++ show err
-        Right infinity -> infinity  -- The zero point on this curve is chosen to be the point at infinity.
-
+  -- Compressed serialised G1 points are bytestrings of length 48: see CIP-0381.
+  let b = BS.pack (0xc0 : replicate (compressedSizePoint (Proxy @curve) - 1) 0x00)
+   in case blsUncompress b of
+        Left err       ->
+          error $ "Unexpected failure deserialising point at infinity on BLS12_381.G1: " ++ show err
+        Right infinity ->
+          infinity  -- The zero point on this curve is chosen to be the point at infinity.
 ---- Scalar / Fr operations
 
 scalarFromFr :: Fr -> IO Scalar

--- a/cardano-crypto-class/src/Cardano/Crypto/EllipticCurve/BLS12_381/Internal.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/EllipticCurve/BLS12_381/Internal.hs
@@ -146,6 +146,7 @@ module Cardano.Crypto.EllipticCurve.BLS12_381.Internal
   , blsHash
   , blsGenerator
   , blsIsInf
+  , blsZero
 
   , toAffine
   , fromAffine
@@ -788,6 +789,13 @@ affineInG affine = unsafePerformIO $
 
 blsGenerator :: BLS curve => Point curve
 blsGenerator = unsafePointFromPointPtr c_blst_generator
+
+blsZero :: forall curve. (BLS curve) => Point curve
+blsZero =
+    let b = BS.pack (0xc0 : replicate ((compressedSizePoint (Proxy @curve)) - 1) 0x00) -- Compressed serialised G1 points are bytestrings of length 48: see CIP-0381.
+    in case blsUncompress b of
+        Left err       -> error $ "Unexpected failure deserialising point at infinity on BLS12_381.G1:  " ++ show err
+        Right infinity -> infinity  -- The zero point on this curve is chosen to be the point at infinity.
 
 ---- Scalar / Fr operations
 

--- a/cardano-crypto-tests/src/Test/Crypto/EllipticCurve.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/EllipticCurve.hs
@@ -13,7 +13,6 @@ import Test.QuickCheck (
     (===),
     (==>),
     Arbitrary(..),
-    Gen,
     Property,
     choose,
     chooseAny,

--- a/cardano-crypto-tests/src/Test/Crypto/EllipticCurve.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/EllipticCurve.hs
@@ -209,8 +209,10 @@ prop_randomFailsFinalVerify a b c d =
     a /= b && c /= d ==>
     BLS.ptFinalVerify (BLS.millerLoop a c) (BLS.millerLoop b d) === False
 
-genBetterInteger :: Gen Integer
-genBetterInteger = oneof [arbitrary, chooseAny, choose (-2^(128 :: Integer), 2^(128 :: Integer))]
+newtype BigInteger = BigInteger Integer
+  deriving (Eq, Show)
+instance Arbitrary BigInteger where
+  arbitrary = BigInteger <$> oneof [arbitrary, chooseAny, choose (- 2 ^ (128 :: Int), 2 ^ (128 ::Int))]
 
 instance BLS.BLS curve => Arbitrary (BLS.Point curve) where
   arbitrary = do

--- a/cardano-crypto-tests/src/Test/Crypto/EllipticCurve.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/EllipticCurve.hs
@@ -149,6 +149,7 @@ testPairing name =
           (BLS.blsMult p a, BLS.blsMult q b)
     , testProperty "three pairings" prop_threePairings
     , testProperty "four pairings" prop_fourPairings
+    , testProperty "finalVerify fails on random inputs" prop_randomFailsFinalVerify
     ]
     where
       pairingCheck (a, b) (c, d) = BLS.ptFinalVerify (BLS.millerLoop a b) (BLS.millerLoop c d)
@@ -200,6 +201,11 @@ prop_fourPairings a1 a2 a3 b = BLS.ptFinalVerify tt t4
     t3 = BLS.millerLoop a3 b
     t4 = BLS.millerLoop (BLS.blsAddOrDouble (BLS.blsAddOrDouble a1 a2) a3) b
     tt = BLS.ptMult (BLS.ptMult t1 t2) t3
+
+prop_randomFailsFinalVerify :: BLS.Point1 -> BLS.Point1 -> BLS.Point2 -> BLS.Point2 -> Property
+prop_randomFailsFinalVerify a b c d =
+    a /= b && c /= d ==>
+    BLS.ptFinalVerify (BLS.millerLoop a c) (BLS.millerLoop b d) === False
 
 instance BLS.BLS curve => Arbitrary (BLS.Point curve) where
   arbitrary = do

--- a/cardano-crypto-tests/src/Test/Crypto/EllipticCurve.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/EllipticCurve.hs
@@ -106,17 +106,17 @@ testBLSCurve name _ =
         BLS.blsIsInf (BLS.blsMult a BLS.scalarPeriod)
     , testProperty "mult by p+1 is identity" $ \(a :: BLS.Point curve) ->
         BLS.blsMult a (BLS.scalarPeriod + 1) === a
-    , testProperty "scalar mult associative" $ \(a :: BLS.Point curve) (b :: genBetterInteger) (c :: genBetterInteger) ->
+    , testProperty "scalar mult associative" $ \(a :: BLS.Point curve) (BigInteger b) (BigInteger c) ->
         BLS.blsMult (BLS.blsMult a b) c === BLS.blsMult (BLS.blsMult a c) b
-    , testProperty "scalar mult distributive left" $ \(a :: BLS.Point curve) (b :: genBetterInteger) (c :: genBetterInteger) ->
+    , testProperty "scalar mult distributive left" $ \(a :: BLS.Point curve) (BigInteger b) (BigInteger c) ->
         BLS.blsMult a (b + c) === BLS.blsAddOrDouble (BLS.blsMult a b) (BLS.blsMult a c)
-    , testProperty "scalar mult distributive right" $ \ (a :: BLS.Point curve) (b :: BLS.Point curve) (c :: genBetterInteger) ->
+    , testProperty "scalar mult distributive right" $ \ (a :: BLS.Point curve) (b :: BLS.Point curve) (BigInteger c) ->
         BLS.blsMult (BLS.blsAddOrDouble a b) c === BLS.blsAddOrDouble (BLS.blsMult a c) (BLS.blsMult b c)
     , testProperty "mult by zero is inf" $ \(a :: BLS.Point curve) ->
         BLS.blsIsInf (BLS.blsMult a 0)
     , testProperty "mult by -1 is equal to neg" $ \(a :: BLS.Point curve) ->
         BLS.blsMult a (-1)  === BLS.blsNeg a
-    , testProperty "modular multiplication" $ \(a :: genBetterInteger) (b :: genBetterInteger) (p :: BLS.Point curve) ->
+    , testProperty "modular multiplication" $ \(BigInteger a) (BigInteger b) (p :: BLS.Point curve) ->
         BLS.blsMult p a === BLS.blsMult p (a + b * BLS.scalarPeriod)
     , testProperty "repeated addition" (prop_repeatedAddition @curve)
     , testCase "zero is inf" $ assertBool "Zero is at infinity" (BLS.blsIsInf (BLS.blsZero @curve))

--- a/cardano-crypto-tests/src/Test/Crypto/EllipticCurve.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/EllipticCurve.hs
@@ -1,5 +1,4 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
-{-# OPTIONS_GHC -fno-warn-type-defaults #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE LambdaCase #-}
@@ -211,7 +210,7 @@ prop_randomFailsFinalVerify a b c d =
     BLS.ptFinalVerify (BLS.millerLoop a c) (BLS.millerLoop b d) === False
 
 genBetterInteger :: Gen Integer
-genBetterInteger = oneof [arbitrary, chooseAny, choose (-2^128, 2^128)]
+genBetterInteger = oneof [arbitrary, chooseAny, choose (-2^(128 :: Integer), 2^(128 :: Integer))]
 
 instance BLS.BLS curve => Arbitrary (BLS.Point curve) where
   arbitrary = do


### PR DESCRIPTION
Including more unit tests to BLS bindings. This covers all tests included in the Plutus [PR#5231](https://github.com/input-output-hk/plutus/pull/5231), allowing the latter to reduce its test suite. 

Similarly we expose the zero element of both Group1 and Group2. 