### PR TITLE
Add VRF support for the SPO polling use case

### DIFF
--- a/cardano-crypto-class/cardano-crypto-class.cabal
+++ b/cardano-crypto-class/cardano-crypto-class.cabal
@@ -1,6 +1,6 @@
 cabal-version:      2.2
 name:               cardano-crypto-class
-version:            2.1.0.2
+version:            2.1.1.0
 synopsis:
   Type classes abstracting over cryptography primitives for Cardano
 

--- a/cardano-crypto-class/src/Cardano/Crypto/VRF/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/VRF/Class.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -125,8 +126,8 @@ class ( Typeable v
     => ContextVRF v
     -> VerKeyVRF v
     -> a
-    -> (OutputVRF v, CertVRF v)
-    -> Bool
+    -> CertVRF v
+    -> Maybe (OutputVRF v)
 
   --
   -- Key generation
@@ -334,7 +335,10 @@ verifyCertified
   -> a
   -> CertifiedVRF v a
   -> Bool
-verifyCertified ctxt vk a CertifiedVRF {..} = verifyVRF ctxt vk a (certifiedOutput, certifiedProof)
+verifyCertified ctxt vk a CertifiedVRF {certifiedOutput, certifiedProof} =
+    case verifyVRF ctxt vk a certifiedProof of
+      Nothing     -> False
+      Just output -> output == certifiedOutput
 
 --
 -- 'Size' expressions for 'ToCBOR' instances

--- a/cardano-crypto-class/src/Cardano/Crypto/VRF/Mock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/VRF/Mock.hs
@@ -58,7 +58,11 @@ instance VRFAlgorithm MockVRF where
 
   evalVRF () a sk = evalVRF' a sk
 
-  verifyVRF () (VerKeyMockVRF n) a c = evalVRF' a (SignKeyMockVRF n) == c
+  verifyVRF () (VerKeyMockVRF n) a c
+      | c == c'   = Just o
+      | otherwise = Nothing
+    where
+      (o, c') = evalVRF' a (SignKeyMockVRF n)
 
   sizeOutputVRF _ = sizeHash (Proxy :: Proxy ShortHash)
 

--- a/cardano-crypto-class/src/Cardano/Crypto/VRF/Simple.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/VRF/Simple.hs
@@ -152,19 +152,21 @@ instance VRFAlgorithm SimpleVRF where
         s = mod (r + k * fromIntegral (bytesToNatural c)) q
     in (OutputVRF y, CertSimpleVRF u (bytesToNatural c) s)
 
-  verifyVRF () (VerKeySimpleVRF v) a' (OutputVRF y, cert) =
+  verifyVRF () (VerKeySimpleVRF v) a' cert =
     let a = getSignableRepresentation a'
         u = certU cert
         c = certC cert
         c' = -fromIntegral c
         s = certS cert
-        b1 = y == h (toCBOR a <> toCBOR u)
+        o = h (toCBOR a <> toCBOR u)
         rhs =
           h $ toCBOR a <>
             toCBOR v <>
             toCBOR (pow s <> pow' v c') <>
             toCBOR (h' (toCBOR a) s <> pow' u c')
-    in b1 && c == bytesToNatural rhs
+    in if c == bytesToNatural rhs
+         then Just (OutputVRF o)
+         else Nothing
 
   sizeOutputVRF _ = sizeHash (Proxy :: Proxy H)
 

--- a/cardano-crypto-praos/cardano-crypto-praos.cabal
+++ b/cardano-crypto-praos/cardano-crypto-praos.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.2
 
 name:                cardano-crypto-praos
-version:             2.1.1.1
+version:             2.1.2.0
 synopsis:            Crypto primitives from libsodium
 description:         VRF (and KES, tba) primitives from libsodium.
 license:             Apache-2.0
@@ -67,7 +67,7 @@ library
   build-depends:        base
                       , bytestring
                       , cardano-binary
-                      , cardano-crypto-class >= 2.1
+                      , cardano-crypto-class >= 2.1.1
                       , deepseq
                       , nothunks
 

--- a/cardano-crypto-praos/src/Cardano/Crypto/VRF/Praos.hs
+++ b/cardano-crypto-praos/src/Cardano/Crypto/VRF/Praos.hs
@@ -77,7 +77,7 @@ import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Unsafe as BS
 import Data.Coerce (coerce)
-import Data.Maybe (fromMaybe, isJust)
+import Data.Maybe (fromMaybe)
 import Data.Proxy (Proxy (..))
 import Foreign.C.Types
 import Foreign.ForeignPtr
@@ -507,8 +507,8 @@ instance VRFAlgorithm PraosVRF where
         !output = maybe (error "Invalid Proof") outputBytes $ outputFromProof proof
      in (OutputVRF output, CertPraosVRF proof)
 
-  verifyVRF = \_ (VerKeyPraosVRF pk) msg (_, CertPraosVRF proof) ->
-    isJust $! verify pk proof (getSignableRepresentation msg)
+  verifyVRF = \_ (VerKeyPraosVRF pk) msg (CertPraosVRF proof) ->
+    (OutputVRF . outputBytes) <$> verify pk proof (getSignableRepresentation msg)
 
   sizeOutputVRF _ = fromIntegral crypto_vrf_outputbytes
   seedSizeVRF _ = fromIntegral crypto_vrf_seedbytes

--- a/cardano-crypto-praos/src/Cardano/Crypto/VRF/PraosBatchCompat.hs
+++ b/cardano-crypto-praos/src/Cardano/Crypto/VRF/PraosBatchCompat.hs
@@ -76,7 +76,7 @@ import Control.Monad (void)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import Data.Coerce (coerce)
-import Data.Maybe (isJust, fromMaybe)
+import Data.Maybe (fromMaybe)
 import Data.Proxy (Proxy (..))
 import Foreign.C.Types
 import Foreign.ForeignPtr
@@ -484,8 +484,8 @@ instance VRFAlgorithm PraosBatchCompatVRF where
     in output `seq` proof `seq`
            (OutputVRF (outputBytes output), CertPraosBatchCompatVRF proof)
 
-  verifyVRF = \_ (VerKeyPraosBatchCompatVRF pk) msg (_, CertPraosBatchCompatVRF proof) ->
-    isJust $! verify pk proof (getSignableRepresentation msg)
+  verifyVRF = \_ (VerKeyPraosBatchCompatVRF pk) msg (CertPraosBatchCompatVRF proof) ->
+    (OutputVRF . outputBytes) <$> verify pk proof (getSignableRepresentation msg)
 
   sizeOutputVRF _ = fromIntegral crypto_vrf_ietfdraft13_outputbytes
   seedSizeVRF _ = fromIntegral crypto_vrf_ietfdraft13_seedbytes

--- a/cardano-crypto-tests/src/Bench/Crypto/VRF.hs
+++ b/cardano-crypto-tests/src/Bench/Crypto/VRF.hs
@@ -49,9 +49,9 @@ benchVRF _ lbl =
         nf (evalVRF @v () typicalMsg) signKey
 
     , env (let (sk, vk) = genKeyPairVRF @v testSeed
-               (output, cert) = evalVRF @v () typicalMsg sk
-            in return (vk, output, cert)
-          ) $ \ ~(vk, output, cert) ->
+               (_output, cert) = evalVRF @v () typicalMsg sk
+            in return (vk, cert)
+          ) $ \ ~(vk, cert) ->
       bench "verify" $
-        nf (verifyVRF () vk typicalMsg) (output, cert)
+        nf (verifyVRF () vk typicalMsg) cert
     ]

--- a/cardano-crypto-tests/src/Test/Crypto/VRF.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/VRF.hs
@@ -162,7 +162,7 @@ prop_vrf_verify_pos
 prop_vrf_verify_pos a sk =
   let (y, c) = evalVRF () a sk
       vk = deriveVerKeyVRF sk
-  in verifyVRF () vk a (y, c)
+  in verifyVRF () vk a c == Just y
 
 prop_vrf_verify_neg
   :: forall v. (VRFAlgorithm v, Eq (SignKeyVRF v),
@@ -174,9 +174,9 @@ prop_vrf_verify_neg
 prop_vrf_verify_neg a sk sk' =
   sk /=
     sk' ==>
-    let (y, c) = evalVRF () a sk'
+    let (_y, c) = evalVRF () a sk'
         vk = deriveVerKeyVRF sk
-    in not $ verifyVRF () vk a (y, c)
+    in verifyVRF () vk a c == Nothing
 
 
 prop_vrf_output_size
@@ -250,7 +250,7 @@ prop_verKeyValidConversion sharedBytes msg =
     vkBatchCompat = vkToBatchCompat vkPraos
     (y, c) = evalVRF () msg skBatchCompat
   in
-    verifyVRF () vkBatchCompat msg (y, c)
+    verifyVRF () vkBatchCompat msg c == Just y
 
 --
 -- Praos <-> BatchCompatPraos SignKey compatibility. We check that a proof is validated with a
@@ -278,7 +278,7 @@ prop_outputValidConversion sharedBytes msg =
     (_out, c) = evalVRF () msg skBatchCompat
     outBatchCompat = outputToBatchCompat outPraos
   in
-    verifyVRF () vkBatchCompat msg (outBatchCompat, c)
+    verifyVRF () vkBatchCompat msg c == Just outBatchCompat
 
 --
 -- Praos <-> BatchCompatPraos compatibility. We check that a proof is validated with a
@@ -294,7 +294,7 @@ prop_fullValidConversion sharedBytes msg =
     vkBatchCompat = vkToBatchCompat vkPraos
     (_out, c) = evalVRF () msg skBatchCompat
     outBatchCompat = outputToBatchCompat outPraos
-  in verifyVRF () vkBatchCompat msg (outBatchCompat, c)
+  in verifyVRF () vkBatchCompat msg c == Just outBatchCompat
 
 --
 -- Arbitrary instances


### PR DESCRIPTION
There is a proposed CIP that uses the SPO VRF to verify SPO responses to questionnaires/polls.

This PR changes the VRF interface so that we can support this VRF use case.

It remains to be decided if we actually wish to support the VRF method for polls, but this at least makes is possible for us to do so later if we do decide we want it.