### PR TITLE
Bring back c-sources: cbits/blst_util.c

### DIFF
--- a/cardano-crypto-class/cardano-crypto-class.cabal
+++ b/cardano-crypto-class/cardano-crypto-class.cabal
@@ -124,6 +124,7 @@ library
       integer-gmp
 
   pkgconfig-depends: libsodium, libblst
+  c-sources: cbits/blst_util.c
 
   if flag(secp256k1-support)
     exposed-modules:


### PR DESCRIPTION
In #255 we somehow removed the
```
c-sources: cbits/blst_util.c
```
from the library. This included the symbol: `size_blst_p1`, which _is_ used in `cardano-crypto-class` 😱 .

E.g. https://github.com/input-output-hk/cardano-base/blob/e48f2ec561713f7a0863e58e34004b8099079cab/cardano-crypto-class/src/Cardano/Crypto/EllipticCurve/BLS12_381/Internal.hs#L372

And thus we now run into undefined symbols issues 🤯