### PR TITLE
Cborg lower bound

### DIFF
--- a/cardano-binary/cardano-binary.cabal
+++ b/cardano-binary/cardano-binary.cabal
@@ -41,7 +41,7 @@ library
 
   build-depends:        base
                       , bytestring
-                      , cborg              >= 0.2.2 && < 0.3
+                      , cborg              >= 0.2.9 && < 0.3
                       , containers
                       , data-fix
                       , formatting


### PR DESCRIPTION
Update lower bound for `cborg` package and update hackage and CHaP index-states