### PR TITLE
Fix incorrect lower bound on io-classes and bump up the version.

### DIFF
--- a/cardano-crypto-tests/cardano-crypto-tests.cabal
+++ b/cardano-crypto-tests/cardano-crypto-tests.cabal
@@ -1,7 +1,7 @@
 cabal-version: 2.2
 
 name:                cardano-crypto-tests
-version:             2.2.0.0
+version:             2.2.0.1
 synopsis:            Tests for cardano-crypto-class and -praos
 description:         Tests for cardano-crypto-class and -praos
 license:             Apache-2.0
@@ -74,7 +74,7 @@ library
                       , contra-tracer ==0.1.0.1
                       , deepseq
                       , formatting
-                      , io-classes
+                      , io-classes >= 1.1
                       , mtl
                       , nothunks
                       , pretty-show

--- a/flake.lock
+++ b/flake.lock
@@ -339,11 +339,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1682036591,
-        "narHash": "sha256-QPrmInnsudgOP+bpJKzosItR0H1C5F54SmPLV8AlFPg=",
+        "lastModified": 1689553923,
+        "narHash": "sha256-B5pnktSnsj+sci6zEFmg52gWhmYmMUzyOTIbf9b1VAY=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "9d83fdf40d77bc15719c6e498da98dbd0714dfa4",
+        "rev": "6debf045a11c4bcdd816ba0c7561d82abdf9c8dc",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Lower bound was missing for `io-classes` and flakes was outdated, which resulted an older version being picked, which in turn resulted in a build error.

This PR fixes this problem

```
src/Test/Crypto/Util.hs:133:1: error:
    Could not find module ‘Control.Concurrent.Class.MonadMVar’
    Perhaps you meant
      Control.Concurrent.Class.MonadSTM (from io-classes-1.0.0.1)
      Control.Concurrent.Class.MonadSTM.TVar (from io-classes-1.0.0.1)
      Control.Concurrent.Class.MonadSTM.TMVar (from io-classes-1.0.0.1)
    Use -v (or `:set -v` in ghci) to see a list of the files searched for.
    |
133 | import Control.Concurrent.Class.MonadMVar (MVar, withMVar, newMVar)
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Error: cabal: Failed to build cardano-crypto-tests-2.2.0.0.
```