### PR TITLE
More strict newTVarWithInvariant, newTVarWithInvariantIO and newMVarWithInvariant

### DIFF
--- a/strict-checked-vars/CHANGELOG.md
+++ b/strict-checked-vars/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Revision history of strict-checked-vars
 
+## 0.1.0.2
+
+* Make `newTVarWithInvariant`, `newTVarWithInvariantIO` and `newMVarWithInvariant` strict.
+
 ## 0.1.0.1
 
 * Export `checkInvariant`.

--- a/strict-checked-vars/src/Control/Concurrent/Class/MonadMVar/Strict/Checked.hs
+++ b/strict-checked-vars/src/Control/Concurrent/Class/MonadMVar/Strict/Checked.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns  #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeFamilies  #-}
 {-# LANGUAGE TypeOperators #-}
@@ -99,7 +100,7 @@ newMVarWithInvariant :: (HasCallStack, MonadMVar m)
                      => (a -> Maybe String)
                      -> a
                      -> m (StrictMVar m a)
-newMVarWithInvariant inv a =
+newMVarWithInvariant inv !a =
   checkInvariant (inv a) $
   StrictMVar inv <$> Strict.newMVar a
 

--- a/strict-checked-vars/src/Control/Concurrent/Class/MonadSTM/Strict/TVar/Checked.hs
+++ b/strict-checked-vars/src/Control/Concurrent/Class/MonadSTM/Strict/TVar/Checked.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns  #-}
 {-# LANGUAGE TypeFamilies  #-}
 {-# LANGUAGE TypeOperators #-}
 
@@ -85,7 +86,7 @@ newTVarWithInvariant :: (MonadSTM m, HasCallStack)
                      => (a -> Maybe String)
                      -> a
                      -> STM m (StrictTVar m a)
-newTVarWithInvariant  inv a =
+newTVarWithInvariant inv !a =
     checkInvariant (inv a) $
     StrictTVar inv <$> Strict.newTVar a
 
@@ -93,7 +94,7 @@ newTVarWithInvariantIO :: (MonadSTM m, HasCallStack)
                        => (a -> Maybe String)
                        -> a
                        -> m (StrictTVar m a)
-newTVarWithInvariantIO  inv a =
+newTVarWithInvariantIO inv !a =
     checkInvariant (inv a) $
     StrictTVar inv <$> Strict.newTVarIO a
 

--- a/strict-checked-vars/strict-checked-vars.cabal
+++ b/strict-checked-vars/strict-checked-vars.cabal
@@ -1,6 +1,6 @@
 cabal-version:   3.0
 name:            strict-checked-vars
-version:         0.1.0.1
+version:         0.1.0.2
 synopsis:
   Strict MVars and TVars with invariant checking for IO and IOSim
 


### PR DESCRIPTION
Although the underlying mutable variable is strict, we execute the
invariant on the initial data, for this reason we have to evaluate it
before writing it to the variable.
