### PR TITLE
Make writeTVar more strict

### DIFF
--- a/strict-checked-vars/src/Control/Concurrent/Class/MonadSTM/Strict/TVar/Checked.hs
+++ b/strict-checked-vars/src/Control/Concurrent/Class/MonadSTM/Strict/TVar/Checked.hs
@@ -105,7 +105,7 @@ readTVarIO :: MonadSTM m => StrictTVar m a -> m a
 readTVarIO = Strict.readTVarIO . tvar
 
 writeTVar :: (MonadSTM m, HasCallStack) => StrictTVar m a -> a -> STM m ()
-writeTVar v a =
+writeTVar v !a =
     checkInvariant (invariant v a) $
     Strict.writeTVar (tvar v) a
 

--- a/strict-checked-vars/strict-checked-vars.cabal
+++ b/strict-checked-vars/strict-checked-vars.cabal
@@ -1,6 +1,6 @@
 cabal-version:   3.0
 name:            strict-checked-vars
-version:         0.1.0.2
+version:         0.1.0.3
 synopsis:
   Strict MVars and TVars with invariant checking for IO and IOSim
 


### PR DESCRIPTION
It needs to evaluate the argument to WHNF before passing it to
`checkInvariant`.
