### PR TITLE
WHNF tests for `strict-checked-vars`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -12,7 +12,7 @@ repository cardano-haskell-packages
 -- The hackage index-state
 index-state: 2023-07-31T10:10:32Z
 -- The CHaP index-state
-index-state: cardano-haskell-packages 2023-07-31T10:10:32Z
+index-state: cardano-haskell-packages 2023-08-08T14:32:15Z
 
 packages:
   base-deriving-via

--- a/cabal.project
+++ b/cabal.project
@@ -37,11 +37,3 @@ benchmarks: true
 
 program-options
   ghc-options: -Werror
-
-if impl(ghc >= 9.6)
-  allow-newer:
-    , *:base
-    , protolude:ghc-prim
-    , protolude:binary
-    , protolude:bytestring
-    , protolude:text

--- a/strict-checked-vars/src/Control/Concurrent/Class/MonadMVar/Strict/Checked.hs
+++ b/strict-checked-vars/src/Control/Concurrent/Class/MonadMVar/Strict/Checked.hs
@@ -96,6 +96,10 @@ newEmptyMVarWithInvariant inv = StrictMVar inv <$> Strict.newEmptyMVar
 newMVar :: MonadMVar m => a -> m (StrictMVar m a)
 newMVar a = StrictMVar (const Nothing) <$> Strict.newMVar a
 
+-- | Create a 'StrictMVar' with an invariant.
+--
+-- Contrary to functions that modify a 'StrictMVar', this function checks the
+-- invariant /before/ putting the value in a new 'StrictMVar'.
 newMVarWithInvariant :: (HasCallStack, MonadMVar m)
                      => (a -> Maybe String)
                      -> a

--- a/strict-checked-vars/strict-checked-vars.cabal
+++ b/strict-checked-vars/strict-checked-vars.cabal
@@ -73,12 +73,16 @@ test-suite test
   main-is:          Main.hs
   other-modules:
     Test.Control.Concurrent.Class.MonadMVar.Strict.Checked
+    Test.Control.Concurrent.Class.MonadMVar.Strict.Checked.WHNF
+    Test.Control.Concurrent.Class.MonadSTM.Strict.TVar.Checked.WHNF
     Test.Utils
 
   default-language: Haskell2010
   build-depends:
     , base                 >=4.9 && <4.19
+    , io-classes
     , io-sim
+    , nothunks
     , QuickCheck
     , strict-checked-vars
     , tasty

--- a/strict-checked-vars/test/Main.hs
+++ b/strict-checked-vars/test/Main.hs
@@ -1,9 +1,11 @@
 module Main where
 
-import qualified Test.Control.Concurrent.Class.MonadMVar.Strict.Checked as Checked
-import           Test.Tasty
+import qualified Test.Control.Concurrent.Class.MonadMVar.Strict.Checked as Test.StrictMVar.Checked
+import qualified Test.Control.Concurrent.Class.MonadSTM.Strict.TVar.Checked.WHNF as Test.StrictTVar.Checked
+import           Test.Tasty (defaultMain, testGroup)
 
 main :: IO ()
 main = defaultMain $ testGroup "strict-checked-vars" [
-      Checked.tests
+      Test.StrictMVar.Checked.tests
+    , Test.StrictTVar.Checked.tests
     ]

--- a/strict-checked-vars/test/Test/Control/Concurrent/Class/MonadMVar/Strict/Checked.hs
+++ b/strict-checked-vars/test/Test/Control/Concurrent/Class/MonadMVar/Strict/Checked.hs
@@ -3,6 +3,7 @@
 module Test.Control.Concurrent.Class.MonadMVar.Strict.Checked where
 
 import           Control.Concurrent.Class.MonadMVar.Strict.Checked
+import qualified Test.Control.Concurrent.Class.MonadMVar.Strict.Checked.WHNF as Test.WHNF
 import           Test.QuickCheck.Monadic
 import           Test.Tasty
 import           Test.Tasty.QuickCheck
@@ -23,6 +24,7 @@ tests = testGroup "Test.Control.Concurrent.Class.MonadMVar.Strict" [
             , testProperty "prop_invariantShouldNotFail" $
                 once                 $ monadicSim prop_invariantShouldNotFail
             ]
+        , Test.WHNF.tests
         ]
     ]
 

--- a/strict-checked-vars/test/Test/Control/Concurrent/Class/MonadMVar/Strict/Checked/WHNF.hs
+++ b/strict-checked-vars/test/Test/Control/Concurrent/Class/MonadMVar/Strict/Checked/WHNF.hs
@@ -13,8 +13,7 @@ import           NoThunks.Class (OnlyCheckWhnf (..), unsafeNoThunks)
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (Fun, Property, applyFun, counterexample,
                      ioProperty, property, testProperty, (.&&.))
-import           Test.Utils (Invariant (..), noInvariant, trivialInvariant,
-                     whnfInvariant, (..:))
+import           Test.Utils (Invariant (..), (..:))
 
 {-------------------------------------------------------------------------------
   Main test tree
@@ -22,58 +21,50 @@ import           Test.Utils (Invariant (..), noInvariant, trivialInvariant,
 
 tests :: TestTree
 tests = testGroup "WHNF" [
-      testGroup "IO" [
-          testIO    "No invariant"      noInvariant
-        , testIO    "Trivial invariant" trivialInvariant
-        , testIO    "WHNF invariant"    whnfInvariant
-        ]
-    , testGroup "IOSim" [
-          testIOSim "No invariant"      noInvariant
-        , testIOSim "Trivial invariant" trivialInvariant
-        , testIOSim "WHNF invariant"    whnfInvariant
-        ]
+      testGroup "IO"    testIO
+    , testGroup "IOSim" testIOSim
     ]
   where
-    testIO name inv = testGroup name [
-          testProperty "prop_IO_newMVarWithInvariant" $
-            prop_IO_newMVarWithInvariant inv
-        , testProperty "prop_IO_putMVar" $
-            prop_IO_putMVar inv
-        , testProperty "prop_IO_swapMVar" $
-            prop_IO_swapMVar inv
-        , testProperty "prop_IO_tryPutMVarJust" $
-            prop_IO_tryPutMVarJust inv
-        , testProperty "prop_IO_tryPutMVarNothing" $
-            prop_IO_tryPutMVarNothing inv
-        , testProperty "prop_IO_modifyMVar_" $
-            prop_IO_modifyMVar_ inv
-        , testProperty "prop_IO_modifyMVar" $
-            prop_IO_modifyMVar inv
-        , testProperty "prop_IO_modifyMVarMasked_" $
-            prop_IO_modifyMVarMasked_ inv
-        , testProperty "prop_IO_modifyMVarMasked" $
-            prop_IO_modifyMVarMasked inv
+    testIO = [
+          testProperty "prop_IO_newMVarWithInvariant"
+            prop_IO_newMVarWithInvariant
+        , testProperty "prop_IO_putMVar"
+            prop_IO_putMVar
+        , testProperty "prop_IO_swapMVar"
+            prop_IO_swapMVar
+        , testProperty "prop_IO_tryPutMVarJust"
+            prop_IO_tryPutMVarJust
+        , testProperty "prop_IO_tryPutMVarNothing"
+            prop_IO_tryPutMVarNothing
+        , testProperty "prop_IO_modifyMVar_"
+            prop_IO_modifyMVar_
+        , testProperty "prop_IO_modifyMVar"
+            prop_IO_modifyMVar
+        , testProperty "prop_IO_modifyMVarMasked_"
+            prop_IO_modifyMVarMasked_
+        , testProperty "prop_IO_modifyMVarMasked"
+            prop_IO_modifyMVarMasked
         ]
 
-    testIOSim name inv = testGroup name [
-          testProperty "prop_IOSim_newMVarWithInvariant" $
-            prop_IOSim_newMVarWithInvariant inv
-        , testProperty "prop_IOSim_putMVar" $
-            prop_IOSim_putMVar inv
-        , testProperty "prop_IOSim_swapMVar" $
-            prop_IOSim_swapMVar inv
-        , testProperty "prop_IOSim_tryPutMVarJust" $
-            prop_IOSim_tryPutMVarJust inv
-        , testProperty "prop_IOSim_tryPutMVarNothing" $
-            prop_IOSim_tryPutMVarNothing inv
-        , testProperty "prop_IOSim_modifyMVar_" $
-            prop_IOSim_modifyMVar_ inv
-        , testProperty "prop_IOSim_modifyMVar" $
-            prop_IOSim_modifyMVar inv
-        , testProperty "prop_IOSim_modifyMVarMasked_" $
-            prop_IOSim_modifyMVarMasked_ inv
-        , testProperty "prop_IOSim_modifyMVarMasked" $
-            prop_IOSim_modifyMVarMasked inv
+    testIOSim = [
+          testProperty "prop_IOSim_newMVarWithInvariant"
+            prop_IOSim_newMVarWithInvariant
+        , testProperty "prop_IOSim_putMVar"
+            prop_IOSim_putMVar
+        , testProperty "prop_IOSim_swapMVar"
+            prop_IOSim_swapMVar
+        , testProperty "prop_IOSim_tryPutMVarJust"
+            prop_IOSim_tryPutMVarJust
+        , testProperty "prop_IOSim_tryPutMVarNothing"
+            prop_IOSim_tryPutMVarNothing
+        , testProperty "prop_IOSim_modifyMVar_"
+            prop_IOSim_modifyMVar_
+        , testProperty "prop_IOSim_modifyMVar"
+            prop_IOSim_modifyMVar
+        , testProperty "prop_IOSim_modifyMVarMasked_"
+            prop_IOSim_modifyMVarMasked_
+        , testProperty "prop_IOSim_modifyMVarMasked"
+            prop_IOSim_modifyMVarMasked
         ]
 
 {-------------------------------------------------------------------------------
@@ -91,15 +82,15 @@ isInWHNF v = do
 -- | Wrapper around 'Checked.newMVar' and 'Checked.newMVarWithInvariant'.
 newMVarWithInvariant :: MonadMVar m => Invariant a -> a -> m (StrictMVar m a)
 newMVarWithInvariant = \case
-    NoInvariant   -> Checked.newMVar
-    Invariant inv -> Checked.newMVarWithInvariant inv
+    NoInvariant     -> Checked.newMVar
+    Invariant _ inv -> Checked.newMVarWithInvariant inv
 
 -- | Wrapper around 'Checked.newEmptyMVar' and
 -- 'Checked.newEmptyMVarWithInvariant'.
 newEmptyMVarWithInvariant :: MonadMVar m => Invariant a -> m (StrictMVar m a)
 newEmptyMVarWithInvariant = \case
-    NoInvariant   -> Checked.newEmptyMVar
-    Invariant inv -> Checked.newEmptyMVarWithInvariant inv
+    NoInvariant     -> Checked.newEmptyMVar
+    Invariant _ inv -> Checked.newEmptyMVarWithInvariant inv
 
 {-------------------------------------------------------------------------------
   Properties
@@ -152,7 +143,6 @@ prop_IOSim_putMVar :: Invariant Int -> Int -> Fun Int Int -> Property
 prop_IOSim_putMVar inv x f = runSimOrThrow $
     prop_M_putMVar inv x f
 
-
 --
 -- swapMVar
 --
@@ -175,6 +165,7 @@ prop_IO_swapMVar = ioProperty ..:
 prop_IOSim_swapMVar :: Invariant Int -> Int -> Fun Int Int -> Property
 prop_IOSim_swapMVar inv x f = runSimOrThrow $
     prop_M_swapMVar inv x f
+
 --
 -- tryPutMVar
 --

--- a/strict-checked-vars/test/Test/Control/Concurrent/Class/MonadMVar/Strict/Checked/WHNF.hs
+++ b/strict-checked-vars/test/Test/Control/Concurrent/Class/MonadMVar/Strict/Checked/WHNF.hs
@@ -7,14 +7,14 @@ import           Control.Concurrent.Class.MonadMVar.Strict.Checked hiding
                      newMVarWithInvariant)
 import qualified Control.Concurrent.Class.MonadMVar.Strict.Checked as Checked
 import           Control.Monad (void)
+import           Control.Monad.IOSim (runSimOrThrow)
 import           Data.Typeable (Typeable)
-import           NoThunks.Class (OnlyCheckWhnf (OnlyCheckWhnf), unsafeNoThunks)
-import           Test.QuickCheck.Monadic (PropertyM, monadicIO, monitor, run)
+import           NoThunks.Class (OnlyCheckWhnf (..), unsafeNoThunks)
 import           Test.Tasty (TestTree, testGroup)
-import           Test.Tasty.QuickCheck (Fun, applyFun, counterexample,
-                     testProperty)
-import           Test.Utils (Invariant (..), monadicSim, noInvariant,
-                     trivialInvariant, whnfInvariant, (.:))
+import           Test.Tasty.QuickCheck (Fun, Property, applyFun, counterexample,
+                     ioProperty, property, testProperty, (.&&.))
+import           Test.Utils (Invariant (..), noInvariant, trivialInvariant,
+                     whnfInvariant, (..:))
 
 {-------------------------------------------------------------------------------
   Main test tree
@@ -35,58 +35,58 @@ tests = testGroup "WHNF" [
     ]
   where
     testIO name inv = testGroup name [
-          testProperty "prop_newMVarWithInvariant" $
-            monadicIO .: prop_newMVarWithInvariant inv
-        , testProperty "prop_putMVar" $
-            monadicIO .: prop_putMVar inv
-        , testProperty "prop_swapMVar" $
-            monadicIO .: prop_swapMVar inv
-        , testProperty "prop_tryPutMVarJust" $
-            monadicIO .: prop_tryPutMVarNothing inv
-        , testProperty "prop_tryPutMVarNothing" $
-            monadicIO .: prop_tryPutMVarNothing inv
-        , testProperty "prop_modifyMVar_" $
-            monadicIO .: prop_modifyMVar_ inv
-        , testProperty "prop_modifyMVar" $
-            monadicIO .: prop_modifyMVar inv
-        , testProperty "prop_modifyMVarMasked_" $
-            monadicIO .: prop_modifyMVarMasked_ inv
-        , testProperty "prop_modifyMVarMasked" $
-            monadicIO .: prop_modifyMVarMasked inv
+          testProperty "prop_IO_newMVarWithInvariant" $
+            prop_IO_newMVarWithInvariant inv
+        , testProperty "prop_IO_putMVar" $
+            prop_IO_putMVar inv
+        , testProperty "prop_IO_swapMVar" $
+            prop_IO_swapMVar inv
+        , testProperty "prop_IO_tryPutMVarJust" $
+            prop_IO_tryPutMVarJust inv
+        , testProperty "prop_IO_tryPutMVarNothing" $
+            prop_IO_tryPutMVarNothing inv
+        , testProperty "prop_IO_modifyMVar_" $
+            prop_IO_modifyMVar_ inv
+        , testProperty "prop_IO_modifyMVar" $
+            prop_IO_modifyMVar inv
+        , testProperty "prop_IO_modifyMVarMasked_" $
+            prop_IO_modifyMVarMasked_ inv
+        , testProperty "prop_IO_modifyMVarMasked" $
+            prop_IO_modifyMVarMasked inv
         ]
 
     testIOSim name inv = testGroup name [
-          testProperty "prop_newMVarWithInvariant" $ \x f ->
-            monadicSim $ prop_newMVarWithInvariant inv x f
-        , testProperty "prop_putMVar" $ \x f ->
-            monadicSim $ prop_putMVar inv x f
-        , testProperty "prop_swapMVar" $ \x f ->
-            monadicSim $ prop_swapMVar inv x f
-        , testProperty "prop_tryPutMVarJust" $ \x f ->
-            monadicSim $ prop_tryPutMVarJust inv x f
-        , testProperty "prop_tryPutMVarNothing" $ \x f ->
-            monadicSim $ prop_tryPutMVarNothing inv x f
-        , testProperty "prop_modifyMVar_" $ \x f ->
-            monadicSim $ prop_modifyMVar_ inv x f
-        , testProperty "prop_modifyMVar" $ \x f ->
-            monadicSim $ prop_modifyMVar inv x f
-        , testProperty "prop_modifyMVarMasked_" $ \x f ->
-            monadicSim $ prop_modifyMVarMasked_ inv x f
-        , testProperty "prop_modifyMVarMasked" $ \x f ->
-            monadicSim $ prop_modifyMVarMasked inv x f
+          testProperty "prop_IOSim_newMVarWithInvariant" $
+            prop_IOSim_newMVarWithInvariant inv
+        , testProperty "prop_IOSim_putMVar" $
+            prop_IOSim_putMVar inv
+        , testProperty "prop_IOSim_swapMVar" $
+            prop_IOSim_swapMVar inv
+        , testProperty "prop_IOSim_tryPutMVarJust" $
+            prop_IOSim_tryPutMVarJust inv
+        , testProperty "prop_IOSim_tryPutMVarNothing" $
+            prop_IOSim_tryPutMVarNothing inv
+        , testProperty "prop_IOSim_modifyMVar_" $
+            prop_IOSim_modifyMVar_ inv
+        , testProperty "prop_IOSim_modifyMVar" $
+            prop_IOSim_modifyMVar inv
+        , testProperty "prop_IOSim_modifyMVarMasked_" $
+            prop_IOSim_modifyMVarMasked_ inv
+        , testProperty "prop_IOSim_modifyMVarMasked" $
+            prop_IOSim_modifyMVarMasked inv
         ]
 
 {-------------------------------------------------------------------------------
   Utilities
 -------------------------------------------------------------------------------}
 
-isInWHNF :: (MonadMVar m, Typeable a) => StrictMVar m a -> PropertyM m Bool
+isInWHNF :: (MonadMVar m, Typeable a) => StrictMVar m a -> m Property
 isInWHNF v = do
-    x <- run $ readMVar v
-    case unsafeNoThunks (OnlyCheckWhnf x) of
-      Nothing    -> pure True
-      Just tinfo -> monitor (counterexample $ "Not in WHNF: " ++ show tinfo)
-                 >> pure False
+    x <- readMVar v
+    pure $ case unsafeNoThunks (OnlyCheckWhnf x) of
+      Nothing    -> property True
+      Just tinfo -> counterexample ("Not in WHNF: " ++ show tinfo)
+                  $ property False
 
 -- | Wrapper around 'Checked.newMVar' and 'Checked.newMVarWithInvariant'.
 newMVarWithInvariant :: MonadMVar m => Invariant a -> a -> m (StrictMVar m a)
@@ -105,104 +105,208 @@ newEmptyMVarWithInvariant = \case
   Properties
 -------------------------------------------------------------------------------}
 
+--
+-- newMVarWithInvariant
+--
+
 -- | Test 'newMVarWithInvariant', not to be confused with
 -- 'Checked.newMVarWithInvariant'.
-prop_newMVarWithInvariant ::
+prop_M_newMVarWithInvariant ::
      MonadMVar m
   => Invariant Int
   -> Int
   -> Fun Int Int
-  -> PropertyM m Bool
-prop_newMVarWithInvariant inv x f = do
-    v <- run $ newMVarWithInvariant inv (applyFun f x)
+  -> m Property
+prop_M_newMVarWithInvariant inv x f = do
+    v <- newMVarWithInvariant inv (applyFun f x)
     isInWHNF v
 
-prop_putMVar ::
+prop_IO_newMVarWithInvariant :: Invariant Int -> Int -> Fun Int Int -> Property
+prop_IO_newMVarWithInvariant = ioProperty ..:
+    prop_M_newMVarWithInvariant
+
+prop_IOSim_newMVarWithInvariant :: Invariant Int -> Int -> Fun Int Int -> Property
+prop_IOSim_newMVarWithInvariant inv x f = runSimOrThrow $
+    prop_M_newMVarWithInvariant inv x f
+
+--
+-- putMVar
+--
+
+prop_M_putMVar ::
      MonadMVar m
   => Invariant Int
   -> Int
   -> Fun Int Int
-  -> PropertyM m Bool
-prop_putMVar inv x f = do
-    v <- run $ newEmptyMVarWithInvariant inv
-    run $ putMVar v (applyFun f x)
+  -> m Property
+prop_M_putMVar inv x f = do
+    v <- newEmptyMVarWithInvariant inv
+    putMVar v (applyFun f x)
     isInWHNF v
 
-prop_swapMVar ::
+prop_IO_putMVar :: Invariant Int -> Int -> Fun Int Int -> Property
+prop_IO_putMVar = ioProperty ..:
+    prop_M_putMVar
+
+prop_IOSim_putMVar :: Invariant Int -> Int -> Fun Int Int -> Property
+prop_IOSim_putMVar inv x f = runSimOrThrow $
+    prop_M_putMVar inv x f
+
+
+--
+-- swapMVar
+--
+
+prop_M_swapMVar ::
      MonadMVar m
   => Invariant Int
   -> Int
   -> Fun Int Int
-  -> PropertyM m Bool
-prop_swapMVar inv x f = do
-    v <- run $ newMVarWithInvariant inv x
-    void $ run $ swapMVar v (applyFun f x)
+  -> m Property
+prop_M_swapMVar inv x f = do
+    v <- newMVarWithInvariant inv x
+    void $ swapMVar v (applyFun f x)
     isInWHNF v
 
-prop_tryPutMVarJust ::
+prop_IO_swapMVar :: Invariant Int -> Int -> Fun Int Int -> Property
+prop_IO_swapMVar = ioProperty ..:
+    prop_M_swapMVar
+
+prop_IOSim_swapMVar :: Invariant Int -> Int -> Fun Int Int -> Property
+prop_IOSim_swapMVar inv x f = runSimOrThrow $
+    prop_M_swapMVar inv x f
+--
+-- tryPutMVar
+--
+
+prop_M_tryPutMVarJust ::
      MonadMVar m
   => Invariant Int
   -> Int
   -> Fun Int Int
-  -> PropertyM m Bool
-prop_tryPutMVarJust inv x f = do
-    v <- run $ newEmptyMVarWithInvariant inv
-    b <- run $ tryPutMVar v (applyFun f x)
+  -> m Property
+prop_M_tryPutMVarJust inv x f = do
+    v <- newEmptyMVarWithInvariant inv
+    b <- tryPutMVar v (applyFun f x)
     b' <- isInWHNF v
-    pure (b && b')
+    pure (property b .&&. b')
 
-prop_tryPutMVarNothing ::
+prop_IO_tryPutMVarJust :: Invariant Int -> Int -> Fun Int Int -> Property
+prop_IO_tryPutMVarJust = ioProperty ..:
+    prop_M_tryPutMVarJust
+
+prop_IOSim_tryPutMVarJust :: Invariant Int -> Int -> Fun Int Int -> Property
+prop_IOSim_tryPutMVarJust inv x f = runSimOrThrow $
+    prop_M_tryPutMVarJust inv x f
+
+prop_M_tryPutMVarNothing ::
      MonadMVar m
   => Invariant Int
   -> Int
   -> Fun Int Int
-  -> PropertyM m Bool
-prop_tryPutMVarNothing inv x f = do
-    v <- run $ newMVarWithInvariant inv x
-    b <- run $ tryPutMVar v (applyFun f x)
+  -> m Property
+prop_M_tryPutMVarNothing inv x f = do
+    v <- newMVarWithInvariant inv x
+    b <- tryPutMVar v (applyFun f x)
     b' <- isInWHNF v
-    pure (not b && b')
+    pure (property (not b) .&&. b')
 
-prop_modifyMVar_ ::
+prop_IO_tryPutMVarNothing :: Invariant Int -> Int -> Fun Int Int -> Property
+prop_IO_tryPutMVarNothing = ioProperty ..:
+    prop_M_tryPutMVarNothing
+prop_IOSim_tryPutMVarNothing :: Invariant Int -> Int -> Fun Int Int -> Property
+
+prop_IOSim_tryPutMVarNothing inv x f = runSimOrThrow $
+    prop_M_tryPutMVarNothing inv x f
+
+--
+-- modifyMVar_
+--
+
+prop_M_modifyMVar_ ::
      MonadMVar m
   => Invariant Int
   -> Int
   -> Fun Int Int
-  -> PropertyM m Bool
-prop_modifyMVar_ inv x f = do
-    v <-  run $ newMVarWithInvariant inv x
-    run $ modifyMVar_ v (pure . applyFun f)
+  -> m Property
+prop_M_modifyMVar_ inv x f = do
+    v <-  newMVarWithInvariant inv x
+    modifyMVar_ v (pure . applyFun f)
     isInWHNF v
 
-prop_modifyMVar ::
+prop_IO_modifyMVar_ :: Invariant Int -> Int -> Fun Int Int -> Property
+prop_IO_modifyMVar_ = ioProperty ..:
+    prop_M_modifyMVar_
+
+prop_IOSim_modifyMVar_ :: Invariant Int -> Int -> Fun Int Int -> Property
+prop_IOSim_modifyMVar_ inv x f = runSimOrThrow $
+    prop_M_modifyMVar_ inv x f
+
+--
+-- modifyMVar_
+--
+
+prop_M_modifyMVar ::
      MonadMVar m
   => Invariant Int
   -> Int
   -> Fun Int (Int, Char)
-  -> PropertyM m Bool
-prop_modifyMVar inv x f =do
-    v <-  run $ newMVarWithInvariant inv x
-    void $ run $ modifyMVar v (pure . applyFun f)
+  -> m Property
+prop_M_modifyMVar inv x f =do
+    v <-  newMVarWithInvariant inv x
+    void $ modifyMVar v (pure . applyFun f)
     isInWHNF v
 
-prop_modifyMVarMasked_ ::
+prop_IO_modifyMVar :: Invariant Int -> Int -> Fun Int (Int, Char) -> Property
+prop_IO_modifyMVar = ioProperty ..:
+    prop_M_modifyMVar
+
+prop_IOSim_modifyMVar :: Invariant Int -> Int -> Fun Int (Int, Char) -> Property
+prop_IOSim_modifyMVar inv x f = runSimOrThrow $
+    prop_M_modifyMVar inv x f
+
+--
+-- modifyMVarMasked_
+--
+
+prop_M_modifyMVarMasked_ ::
      MonadMVar m
   => Invariant Int
   -> Int
   -> Fun Int Int
-  -> PropertyM m Bool
-prop_modifyMVarMasked_ inv x f =do
-    v <-  run $ newMVarWithInvariant inv x
-    void $ run $ modifyMVarMasked_ v (pure . applyFun f)
+  -> m Property
+prop_M_modifyMVarMasked_ inv x f =do
+    v <- newMVarWithInvariant inv x
+    void $  modifyMVarMasked_ v (pure . applyFun f)
     isInWHNF v
 
-prop_modifyMVarMasked ::
+prop_IO_modifyMVarMasked_ :: Invariant Int -> Int -> Fun Int Int -> Property
+prop_IO_modifyMVarMasked_ = ioProperty ..:
+    prop_M_modifyMVarMasked_
+
+prop_IOSim_modifyMVarMasked_ :: Invariant Int -> Int -> Fun Int Int -> Property
+prop_IOSim_modifyMVarMasked_ inv x f = runSimOrThrow $
+    prop_M_modifyMVarMasked_ inv x f
+
+--
+-- modifyMVarMasked
+--
+
+prop_M_modifyMVarMasked ::
      MonadMVar m
   => Invariant Int
   -> Int
   -> Fun Int (Int, Char)
-  -> PropertyM m Bool
-prop_modifyMVarMasked inv x f =do
-    v <-  run $ newMVarWithInvariant inv x
-    void $ run $ modifyMVarMasked v (pure . applyFun f)
+  -> m Property
+prop_M_modifyMVarMasked inv x f = do
+    v <-newMVarWithInvariant inv x
+    void $ modifyMVarMasked v (pure . applyFun f)
     isInWHNF v
+
+prop_IO_modifyMVarMasked :: Invariant Int -> Int -> Fun Int (Int, Char) -> Property
+prop_IO_modifyMVarMasked = ioProperty ..:
+    prop_M_modifyMVarMasked
+
+prop_IOSim_modifyMVarMasked :: Invariant Int -> Int -> Fun Int (Int, Char) -> Property
+prop_IOSim_modifyMVarMasked inv x f = runSimOrThrow $
+    prop_M_modifyMVarMasked inv x f

--- a/strict-checked-vars/test/Test/Control/Concurrent/Class/MonadMVar/Strict/Checked/WHNF.hs
+++ b/strict-checked-vars/test/Test/Control/Concurrent/Class/MonadMVar/Strict/Checked/WHNF.hs
@@ -1,0 +1,208 @@
+{-# LANGUAGE LambdaCase #-}
+
+module Test.Control.Concurrent.Class.MonadMVar.Strict.Checked.WHNF where
+
+import           Control.Concurrent.Class.MonadMVar.Strict.Checked hiding
+                     (newEmptyMVar, newEmptyMVarWithInvariant, newMVar,
+                     newMVarWithInvariant)
+import qualified Control.Concurrent.Class.MonadMVar.Strict.Checked as Checked
+import           Control.Monad (void)
+import           Data.Typeable (Typeable)
+import           NoThunks.Class (OnlyCheckWhnf (OnlyCheckWhnf), unsafeNoThunks)
+import           Test.QuickCheck.Monadic (PropertyM, monadicIO, monitor, run)
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.QuickCheck (Fun, applyFun, counterexample,
+                     testProperty)
+import           Test.Utils (Invariant (..), monadicSim, noInvariant,
+                     trivialInvariant, whnfInvariant, (.:))
+
+{-------------------------------------------------------------------------------
+  Main test tree
+-------------------------------------------------------------------------------}
+
+tests :: TestTree
+tests = testGroup "WHNF" [
+      testGroup "IO" [
+          testIO    "No invariant"      noInvariant
+        , testIO    "Trivial invariant" trivialInvariant
+        , testIO    "WHNF invariant"    whnfInvariant
+        ]
+    , testGroup "IOSim" [
+          testIOSim "No invariant"      noInvariant
+        , testIOSim "Trivial invariant" trivialInvariant
+        , testIOSim "WHNF invariant"    whnfInvariant
+        ]
+    ]
+  where
+    testIO name inv = testGroup name [
+          testProperty "prop_newMVarWithInvariant" $
+            monadicIO .: prop_newMVarWithInvariant inv
+        , testProperty "prop_putMVar" $
+            monadicIO .: prop_putMVar inv
+        , testProperty "prop_swapMVar" $
+            monadicIO .: prop_swapMVar inv
+        , testProperty "prop_tryPutMVarJust" $
+            monadicIO .: prop_tryPutMVarNothing inv
+        , testProperty "prop_tryPutMVarNothing" $
+            monadicIO .: prop_tryPutMVarNothing inv
+        , testProperty "prop_modifyMVar_" $
+            monadicIO .: prop_modifyMVar_ inv
+        , testProperty "prop_modifyMVar" $
+            monadicIO .: prop_modifyMVar inv
+        , testProperty "prop_modifyMVarMasked_" $
+            monadicIO .: prop_modifyMVarMasked_ inv
+        , testProperty "prop_modifyMVarMasked" $
+            monadicIO .: prop_modifyMVarMasked inv
+        ]
+
+    testIOSim name inv = testGroup name [
+          testProperty "prop_newMVarWithInvariant" $ \x f ->
+            monadicSim $ prop_newMVarWithInvariant inv x f
+        , testProperty "prop_putMVar" $ \x f ->
+            monadicSim $ prop_putMVar inv x f
+        , testProperty "prop_swapMVar" $ \x f ->
+            monadicSim $ prop_swapMVar inv x f
+        , testProperty "prop_tryPutMVarJust" $ \x f ->
+            monadicSim $ prop_tryPutMVarJust inv x f
+        , testProperty "prop_tryPutMVarNothing" $ \x f ->
+            monadicSim $ prop_tryPutMVarNothing inv x f
+        , testProperty "prop_modifyMVar_" $ \x f ->
+            monadicSim $ prop_modifyMVar_ inv x f
+        , testProperty "prop_modifyMVar" $ \x f ->
+            monadicSim $ prop_modifyMVar inv x f
+        , testProperty "prop_modifyMVarMasked_" $ \x f ->
+            monadicSim $ prop_modifyMVarMasked_ inv x f
+        , testProperty "prop_modifyMVarMasked" $ \x f ->
+            monadicSim $ prop_modifyMVarMasked inv x f
+        ]
+
+{-------------------------------------------------------------------------------
+  Utilities
+-------------------------------------------------------------------------------}
+
+isInWHNF :: (MonadMVar m, Typeable a) => StrictMVar m a -> PropertyM m Bool
+isInWHNF v = do
+    x <- run $ readMVar v
+    case unsafeNoThunks (OnlyCheckWhnf x) of
+      Nothing    -> pure True
+      Just tinfo -> monitor (counterexample $ "Not in WHNF: " ++ show tinfo)
+                 >> pure False
+
+-- | Wrapper around 'Checked.newMVar' and 'Checked.newMVarWithInvariant'.
+newMVarWithInvariant :: MonadMVar m => Invariant a -> a -> m (StrictMVar m a)
+newMVarWithInvariant = \case
+    NoInvariant   -> Checked.newMVar
+    Invariant inv -> Checked.newMVarWithInvariant inv
+
+-- | Wrapper around 'Checked.newEmptyMVar' and
+-- 'Checked.newEmptyMVarWithInvariant'.
+newEmptyMVarWithInvariant :: MonadMVar m => Invariant a -> m (StrictMVar m a)
+newEmptyMVarWithInvariant = \case
+    NoInvariant   -> Checked.newEmptyMVar
+    Invariant inv -> Checked.newEmptyMVarWithInvariant inv
+
+{-------------------------------------------------------------------------------
+  Properties
+-------------------------------------------------------------------------------}
+
+-- | Test 'newMVarWithInvariant', not to be confused with
+-- 'Checked.newMVarWithInvariant'.
+prop_newMVarWithInvariant ::
+     MonadMVar m
+  => Invariant Int
+  -> Int
+  -> Fun Int Int
+  -> PropertyM m Bool
+prop_newMVarWithInvariant inv x f = do
+    v <- run $ newMVarWithInvariant inv (applyFun f x)
+    isInWHNF v
+
+prop_putMVar ::
+     MonadMVar m
+  => Invariant Int
+  -> Int
+  -> Fun Int Int
+  -> PropertyM m Bool
+prop_putMVar inv x f = do
+    v <- run $ newEmptyMVarWithInvariant inv
+    run $ putMVar v (applyFun f x)
+    isInWHNF v
+
+prop_swapMVar ::
+     MonadMVar m
+  => Invariant Int
+  -> Int
+  -> Fun Int Int
+  -> PropertyM m Bool
+prop_swapMVar inv x f = do
+    v <- run $ newMVarWithInvariant inv x
+    void $ run $ swapMVar v (applyFun f x)
+    isInWHNF v
+
+prop_tryPutMVarJust ::
+     MonadMVar m
+  => Invariant Int
+  -> Int
+  -> Fun Int Int
+  -> PropertyM m Bool
+prop_tryPutMVarJust inv x f = do
+    v <- run $ newEmptyMVarWithInvariant inv
+    b <- run $ tryPutMVar v (applyFun f x)
+    b' <- isInWHNF v
+    pure (b && b')
+
+prop_tryPutMVarNothing ::
+     MonadMVar m
+  => Invariant Int
+  -> Int
+  -> Fun Int Int
+  -> PropertyM m Bool
+prop_tryPutMVarNothing inv x f = do
+    v <- run $ newMVarWithInvariant inv x
+    b <- run $ tryPutMVar v (applyFun f x)
+    b' <- isInWHNF v
+    pure (not b && b')
+
+prop_modifyMVar_ ::
+     MonadMVar m
+  => Invariant Int
+  -> Int
+  -> Fun Int Int
+  -> PropertyM m Bool
+prop_modifyMVar_ inv x f = do
+    v <-  run $ newMVarWithInvariant inv x
+    run $ modifyMVar_ v (pure . applyFun f)
+    isInWHNF v
+
+prop_modifyMVar ::
+     MonadMVar m
+  => Invariant Int
+  -> Int
+  -> Fun Int (Int, Char)
+  -> PropertyM m Bool
+prop_modifyMVar inv x f =do
+    v <-  run $ newMVarWithInvariant inv x
+    void $ run $ modifyMVar v (pure . applyFun f)
+    isInWHNF v
+
+prop_modifyMVarMasked_ ::
+     MonadMVar m
+  => Invariant Int
+  -> Int
+  -> Fun Int Int
+  -> PropertyM m Bool
+prop_modifyMVarMasked_ inv x f =do
+    v <-  run $ newMVarWithInvariant inv x
+    void $ run $ modifyMVarMasked_ v (pure . applyFun f)
+    isInWHNF v
+
+prop_modifyMVarMasked ::
+     MonadMVar m
+  => Invariant Int
+  -> Int
+  -> Fun Int (Int, Char)
+  -> PropertyM m Bool
+prop_modifyMVarMasked inv x f =do
+    v <-  run $ newMVarWithInvariant inv x
+    void $ run $ modifyMVarMasked v (pure . applyFun f)
+    isInWHNF v

--- a/strict-checked-vars/test/Test/Control/Concurrent/Class/MonadSTM/Strict/TVar/Checked/WHNF.hs
+++ b/strict-checked-vars/test/Test/Control/Concurrent/Class/MonadSTM/Strict/TVar/Checked/WHNF.hs
@@ -15,8 +15,7 @@ import           NoThunks.Class (OnlyCheckWhnf (..), unsafeNoThunks)
 import           Test.Tasty (TestTree, testGroup)
 import           Test.Tasty.QuickCheck (Fun, Property, applyFun, counterexample,
                      ioProperty, property, testProperty)
-import           Test.Utils (Invariant (..), noInvariant, trivialInvariant,
-                     whnfInvariant, (..:))
+import           Test.Utils (Invariant (..), (..:))
 
 {-------------------------------------------------------------------------------
   Main test tree
@@ -24,46 +23,38 @@ import           Test.Utils (Invariant (..), noInvariant, trivialInvariant,
 
 tests :: TestTree
 tests = testGroup "Test.Control.Concurrent.Class.MonadSTM.Strict.TVar.Checked.WHNF" [
-      testGroup "IO" [
-          testIO    "No invariant"      noInvariant
-        , testIO    "Trivial invariant" trivialInvariant
-        , testIO    "WHNF invariant"    whnfInvariant
-        ]
-    , testGroup "IOSim" [
-          testIOSim "No invariant"      noInvariant
-        , testIOSim "Trivial invariant" trivialInvariant
-        , testIOSim "WHNF invariant"    whnfInvariant
-        ]
+      testGroup "IO"    testIO
+    , testGroup "IOSim" testIOSim
     ]
   where
-    testIO name inv = testGroup name [
-          testProperty "prop_newTVarWithInvariant_IO" $
-            prop_newTVarWithInvariant_IO inv
-        , testProperty "prop_newTVarWithInvariantIO_IO" $
-            prop_newTVarWithInvariantIO_IO inv
-        , testProperty "prop_writeTVar_IO" $
-            prop_writeTVar_IO inv
-        , testProperty "prop_modifyTVar_IO" $
-            prop_modifyTVar_IO inv
-        , testProperty "prop_stateTVar_IO" $
-            prop_stateTVar_IO inv
-        , testProperty "prop_swapTVar_IO" $
-            prop_swapTVar_IO inv
+    testIO = [
+          testProperty "prop_newTVarWithInvariant_IO"
+            prop_newTVarWithInvariant_IO
+        , testProperty "prop_newTVarWithInvariantIO_IO"
+            prop_newTVarWithInvariantIO_IO
+        , testProperty "prop_writeTVar_IO"
+            prop_writeTVar_IO
+        , testProperty "prop_modifyTVar_IO"
+            prop_modifyTVar_IO
+        , testProperty "prop_stateTVar_IO"
+            prop_stateTVar_IO
+        , testProperty "prop_swapTVar_IO"
+            prop_swapTVar_IO
         ]
 
-    testIOSim name inv = testGroup name [
-          testProperty "prop_newTVarWithInvariant_IOSim" $
-            prop_newTVarWithInvariant_IOSim inv
-        , testProperty "prop_newTVarWithInvariantIO_IOSim" $
-            prop_newTVarWithInvariantIO_IOSim inv
-        , testProperty "prop_writeTVar_IOSim" $
-            prop_writeTVar_IOSim inv
-        , testProperty "prop_modifyTVar_IOSim" $
-            prop_modifyTVar_IOSim inv
-        , testProperty "prop_stateTVar" $
-            prop_stateTVar_IOSim inv
-        , testProperty "prop_swapTVar" $
-            prop_swapTVar_IOSim inv
+    testIOSim = [
+          testProperty "prop_newTVarWithInvariant_IOSim"
+            prop_newTVarWithInvariant_IOSim
+        , testProperty "prop_newTVarWithInvariantIO_IOSim"
+            prop_newTVarWithInvariantIO_IOSim
+        , testProperty "prop_writeTVar_IOSim"
+            prop_writeTVar_IOSim
+        , testProperty "prop_modifyTVar_IOSim"
+            prop_modifyTVar_IOSim
+        , testProperty "prop_stateTVar"
+            prop_stateTVar_IOSim
+        , testProperty "prop_swapTVar"
+            prop_swapTVar_IOSim
         ]
 
 {-------------------------------------------------------------------------------
@@ -81,14 +72,14 @@ isInWHNF v = do
 -- | Wrapper around 'Checked.newTVar' and 'Checked.newTVarWithInvariant'.
 newTVarWithInvariant :: MonadSTM m => Invariant a -> a -> STM m (StrictTVar m a)
 newTVarWithInvariant = \case
-    NoInvariant   -> Checked.newTVar
-    Invariant inv -> Checked.newTVarWithInvariant inv
+    NoInvariant     -> Checked.newTVar
+    Invariant _ inv -> Checked.newTVarWithInvariant inv
 
 -- | Wrapper around 'Checked.newTVarIO' and 'Checked.newTVarWithInvariantIO'.
 newTVarWithInvariantIO :: MonadSTM m => Invariant a -> a -> m (StrictTVar m a)
 newTVarWithInvariantIO = \case
-    NoInvariant   -> Checked.newTVarIO
-    Invariant inv -> Checked.newTVarWithInvariantIO inv
+    NoInvariant     -> Checked.newTVarIO
+    Invariant _ inv -> Checked.newTVarWithInvariantIO inv
 
 -- | The 'isInWHNF' check fails when running tests in 'IOSim', since 'IOSim'
 -- runs in the lazy 'ST' monad. 'withSanityCheckWhnf' can be used to perform the

--- a/strict-checked-vars/test/Test/Control/Concurrent/Class/MonadSTM/Strict/TVar/Checked/WHNF.hs
+++ b/strict-checked-vars/test/Test/Control/Concurrent/Class/MonadSTM/Strict/TVar/Checked/WHNF.hs
@@ -1,0 +1,192 @@
+{-# LANGUAGE LambdaCase    #-}
+{-# LANGUAGE TupleSections #-}
+
+module Test.Control.Concurrent.Class.MonadSTM.Strict.TVar.Checked.WHNF where
+
+import           Control.Concurrent.Class.MonadSTM (MonadSTM, STM, atomically)
+import           Control.Concurrent.Class.MonadSTM.Strict.TVar.Checked hiding
+                     (newTVar, newTVarIO, newTVarWithInvariant,
+                     newTVarWithInvariantIO)
+import qualified Control.Concurrent.Class.MonadSTM.Strict.TVar.Checked as Checked
+import           Control.Monad (void)
+import           Data.Typeable (Typeable)
+import           NoThunks.Class (OnlyCheckWhnf (OnlyCheckWhnf), unsafeNoThunks)
+import           Test.QuickCheck.Monadic (PropertyM, monadicIO, monitor, run)
+import           Test.Tasty (TestTree, testGroup)
+import           Test.Tasty.QuickCheck (Fun, applyFun, counterexample,
+                     testProperty)
+import           Test.Utils (Invariant (..), monadicSim, noInvariant,
+                     trivialInvariant, whnfInvariant, (.:))
+
+{-------------------------------------------------------------------------------
+  Main test tree
+-------------------------------------------------------------------------------}
+
+tests :: TestTree
+tests = testGroup "Test.Control.Concurrent.Class.MonadSTM.Strict.TVar.Checked.WHNF" [
+      testGroup "IO" [
+          testIO    "No invariant"      sanityCheckWhnf   noInvariant
+        , testIO    "Trivial invariant" sanityCheckWhnf   trivialInvariant
+        , testIO    "WHNF invariant"    sanityCheckWhnf   whnfInvariant
+        ]
+      -- Sanity checks for WHNF fail in IOSim because IOSim runs in the lazy ST
+      -- monad, so we turn off sanity checks here.
+    , testGroup "IOSim" [
+          testIOSim "No invariant"      noSanityCheckWhnf noInvariant
+        , testIOSim "Trivial invariant" noSanityCheckWhnf trivialInvariant
+        , testIOSim "WHNF invariant"    noSanityCheckWhnf whnfInvariant
+        ]
+    ]
+  where
+    testIO name check inv = testGroup name [
+          testProperty "prop_newTVarWithInvariant" $
+            monadicIO .: prop_newTVarWithInvariant check inv
+        , testProperty "prop_newTVarWithInvariantIO" $
+            monadicIO .: prop_newTVarWithInvariantIO check inv
+        , testProperty "prop_writeTVar" $
+            monadicIO .: prop_writeTVar check inv
+        , testProperty "prop_modifyTVar" $
+            monadicIO .: prop_modifyTVar check inv
+        , testProperty "prop_stateTVar" $
+            monadicIO .: prop_stateTVar check inv
+        , testProperty "prop_swapTVar" $
+            monadicIO .: prop_swapTVar check inv
+        ]
+
+    testIOSim name check inv = testGroup name [
+          testProperty "prop_newTVarWithInvariant" $ \x f ->
+            monadicSim $ prop_newTVarWithInvariant check inv x f
+        , testProperty "prop_newTVarWithInvariantIO" $ \x f ->
+            monadicSim $ prop_newTVarWithInvariantIO check inv x f
+        , testProperty "prop_writeTVar" $ \x f ->
+            monadicSim $ prop_writeTVar check inv x f
+        , testProperty "prop_modifyTVar" $ \x f ->
+            monadicSim $ prop_modifyTVar check inv x f
+        , testProperty "prop_stateTVar" $ \x f ->
+            monadicSim $ prop_stateTVar check inv x f
+        , testProperty "prop_swapTVar" $ \x f ->
+            monadicSim $ prop_swapTVar check inv x f
+        ]
+
+{-------------------------------------------------------------------------------
+  Utilities
+-------------------------------------------------------------------------------}
+
+
+isInWHNF :: (MonadSTM m, Typeable a) => StrictTVar m a -> PropertyM m Bool
+isInWHNF v = do
+    x <- run $ readTVarIO v
+    case unsafeNoThunks (OnlyCheckWhnf x) of
+      Nothing    -> pure True
+      Just tinfo -> monitor (counterexample $ "Not in WHNF: " ++ show tinfo)
+                 >> pure False
+
+-- | Wrapper around 'Checked.newTVar' and 'Checked.newTVarWithInvariant'.
+newTVarWithInvariant :: MonadSTM m => Invariant a -> a -> STM m (StrictTVar m a)
+newTVarWithInvariant = \case
+    NoInvariant   -> Checked.newTVar
+    Invariant inv -> Checked.newTVarWithInvariant inv
+
+-- | Wrapper around 'Checked.newTVarIO' and 'Checked.newTVarWithInvariantIO'.
+newTVarWithInvariantIO :: MonadSTM m => Invariant a -> a -> m (StrictTVar m a)
+newTVarWithInvariantIO = \case
+    NoInvariant   -> Checked.newTVarIO
+    Invariant inv -> Checked.newTVarWithInvariantIO inv
+
+newtype SanityCheckWhnf = SanityCheckWhnf { getSanityCheckWhnf :: Bool }
+  deriving (Show, Eq)
+
+noSanityCheckWhnf :: SanityCheckWhnf
+noSanityCheckWhnf = SanityCheckWhnf False
+
+sanityCheckWhnf :: SanityCheckWhnf
+sanityCheckWhnf = SanityCheckWhnf True
+
+withSanityCheckWhnf ::
+     (MonadSTM m, Typeable a)
+  => SanityCheckWhnf
+  -> StrictTVar m a
+  -> PropertyM m Bool
+withSanityCheckWhnf check v =
+    if getSanityCheckWhnf check then
+      isInWHNF v
+    else
+      pure True
+
+{-------------------------------------------------------------------------------
+  Properties
+-------------------------------------------------------------------------------}
+
+-- | Test 'newTVarWithInvariant', not to be confused with
+-- 'Checked.newTVarWithInvariant'.
+prop_newTVarWithInvariant ::
+     MonadSTM m
+  => SanityCheckWhnf
+  -> Invariant Int
+  -> Int
+  -> Fun Int Int
+  -> PropertyM m Bool
+prop_newTVarWithInvariant check inv x f = do
+    v <- run $ atomically $ newTVarWithInvariant inv (applyFun f x)
+    withSanityCheckWhnf check v
+
+-- | Test 'newTVarWithInvariantIO', not to be confused with
+-- 'Checked.newTVarWithInvariantIO'.
+prop_newTVarWithInvariantIO ::
+     MonadSTM m
+  => SanityCheckWhnf
+  -> Invariant Int
+  -> Int
+  -> Fun Int Int
+  -> PropertyM m Bool
+prop_newTVarWithInvariantIO check inv x f = do
+    v <- run $ newTVarWithInvariantIO inv (applyFun f x)
+    withSanityCheckWhnf check v
+
+prop_writeTVar ::
+     MonadSTM m
+  => SanityCheckWhnf
+  -> Invariant Int
+  -> Int
+  -> Fun Int Int
+  -> PropertyM m Bool
+prop_writeTVar check inv x f = do
+    v <- run $ newTVarWithInvariantIO inv x
+    run $ atomically $ writeTVar v (applyFun f x)
+    withSanityCheckWhnf check v
+
+prop_modifyTVar ::
+     MonadSTM m
+  => SanityCheckWhnf
+  -> Invariant Int
+  -> Int
+  -> Fun Int Int
+  -> PropertyM m Bool
+prop_modifyTVar check inv x f = do
+    v <- run $ newTVarWithInvariantIO inv x
+    run $ atomically $ modifyTVar v (applyFun f)
+    withSanityCheckWhnf check v
+
+prop_stateTVar ::
+     MonadSTM m
+  => SanityCheckWhnf
+  -> Invariant Int
+  -> Int
+  -> Fun Int Int
+  -> PropertyM m Bool
+prop_stateTVar check inv x f = do
+    v <- run $ newTVarWithInvariantIO inv x
+    run $ atomically $ stateTVar v (((),) . applyFun f)
+    withSanityCheckWhnf check v
+
+prop_swapTVar ::
+     MonadSTM m
+  => SanityCheckWhnf
+  -> Invariant Int
+  -> Int
+  -> Fun Int Int
+  -> PropertyM m Bool
+prop_swapTVar check inv x f = do
+    v <- run $ newTVarWithInvariantIO inv x
+    void $ run $ atomically $ swapTVar v (applyFun f x)
+    withSanityCheckWhnf check v

--- a/strict-checked-vars/test/Test/Control/Concurrent/Class/MonadSTM/Strict/TVar/Checked/WHNF.hs
+++ b/strict-checked-vars/test/Test/Control/Concurrent/Class/MonadSTM/Strict/TVar/Checked/WHNF.hs
@@ -9,14 +9,14 @@ import           Control.Concurrent.Class.MonadSTM.Strict.TVar.Checked hiding
                      newTVarWithInvariantIO)
 import qualified Control.Concurrent.Class.MonadSTM.Strict.TVar.Checked as Checked
 import           Control.Monad (void)
+import           Control.Monad.IOSim (runSimOrThrow)
 import           Data.Typeable (Typeable)
-import           NoThunks.Class (OnlyCheckWhnf (OnlyCheckWhnf), unsafeNoThunks)
-import           Test.QuickCheck.Monadic (PropertyM, monadicIO, monitor, run)
+import           NoThunks.Class (OnlyCheckWhnf (..), unsafeNoThunks)
 import           Test.Tasty (TestTree, testGroup)
-import           Test.Tasty.QuickCheck (Fun, applyFun, counterexample,
-                     testProperty)
-import           Test.Utils (Invariant (..), monadicSim, noInvariant,
-                     trivialInvariant, whnfInvariant, (.:))
+import           Test.Tasty.QuickCheck (Fun, Property, applyFun, counterexample,
+                     ioProperty, property, testProperty)
+import           Test.Utils (Invariant (..), noInvariant, trivialInvariant,
+                     whnfInvariant, (..:))
 
 {-------------------------------------------------------------------------------
   Main test tree
@@ -25,61 +25,58 @@ import           Test.Utils (Invariant (..), monadicSim, noInvariant,
 tests :: TestTree
 tests = testGroup "Test.Control.Concurrent.Class.MonadSTM.Strict.TVar.Checked.WHNF" [
       testGroup "IO" [
-          testIO    "No invariant"      sanityCheckWhnf   noInvariant
-        , testIO    "Trivial invariant" sanityCheckWhnf   trivialInvariant
-        , testIO    "WHNF invariant"    sanityCheckWhnf   whnfInvariant
+          testIO    "No invariant"      noInvariant
+        , testIO    "Trivial invariant" trivialInvariant
+        , testIO    "WHNF invariant"    whnfInvariant
         ]
-      -- Sanity checks for WHNF fail in IOSim because IOSim runs in the lazy ST
-      -- monad, so we turn off sanity checks here.
     , testGroup "IOSim" [
-          testIOSim "No invariant"      noSanityCheckWhnf noInvariant
-        , testIOSim "Trivial invariant" noSanityCheckWhnf trivialInvariant
-        , testIOSim "WHNF invariant"    noSanityCheckWhnf whnfInvariant
+          testIOSim "No invariant"      noInvariant
+        , testIOSim "Trivial invariant" trivialInvariant
+        , testIOSim "WHNF invariant"    whnfInvariant
         ]
     ]
   where
-    testIO name check inv = testGroup name [
-          testProperty "prop_newTVarWithInvariant" $
-            monadicIO .: prop_newTVarWithInvariant check inv
-        , testProperty "prop_newTVarWithInvariantIO" $
-            monadicIO .: prop_newTVarWithInvariantIO check inv
-        , testProperty "prop_writeTVar" $
-            monadicIO .: prop_writeTVar check inv
-        , testProperty "prop_modifyTVar" $
-            monadicIO .: prop_modifyTVar check inv
-        , testProperty "prop_stateTVar" $
-            monadicIO .: prop_stateTVar check inv
-        , testProperty "prop_swapTVar" $
-            monadicIO .: prop_swapTVar check inv
+    testIO name inv = testGroup name [
+          testProperty "prop_newTVarWithInvariant_IO" $
+            prop_newTVarWithInvariant_IO inv
+        , testProperty "prop_newTVarWithInvariantIO_IO" $
+            prop_newTVarWithInvariantIO_IO inv
+        , testProperty "prop_writeTVar_IO" $
+            prop_writeTVar_IO inv
+        , testProperty "prop_modifyTVar_IO" $
+            prop_modifyTVar_IO inv
+        , testProperty "prop_stateTVar_IO" $
+            prop_stateTVar_IO inv
+        , testProperty "prop_swapTVar_IO" $
+            prop_swapTVar_IO inv
         ]
 
-    testIOSim name check inv = testGroup name [
-          testProperty "prop_newTVarWithInvariant" $ \x f ->
-            monadicSim $ prop_newTVarWithInvariant check inv x f
-        , testProperty "prop_newTVarWithInvariantIO" $ \x f ->
-            monadicSim $ prop_newTVarWithInvariantIO check inv x f
-        , testProperty "prop_writeTVar" $ \x f ->
-            monadicSim $ prop_writeTVar check inv x f
-        , testProperty "prop_modifyTVar" $ \x f ->
-            monadicSim $ prop_modifyTVar check inv x f
-        , testProperty "prop_stateTVar" $ \x f ->
-            monadicSim $ prop_stateTVar check inv x f
-        , testProperty "prop_swapTVar" $ \x f ->
-            monadicSim $ prop_swapTVar check inv x f
+    testIOSim name inv = testGroup name [
+          testProperty "prop_newTVarWithInvariant_IOSim" $
+            prop_newTVarWithInvariant_IOSim inv
+        , testProperty "prop_newTVarWithInvariantIO_IOSim" $
+            prop_newTVarWithInvariantIO_IOSim inv
+        , testProperty "prop_writeTVar_IOSim" $
+            prop_writeTVar_IOSim inv
+        , testProperty "prop_modifyTVar_IOSim" $
+            prop_modifyTVar_IOSim inv
+        , testProperty "prop_stateTVar" $
+            prop_stateTVar_IOSim inv
+        , testProperty "prop_swapTVar" $
+            prop_swapTVar_IOSim inv
         ]
 
 {-------------------------------------------------------------------------------
   Utilities
 -------------------------------------------------------------------------------}
 
-
-isInWHNF :: (MonadSTM m, Typeable a) => StrictTVar m a -> PropertyM m Bool
+isInWHNF :: (MonadSTM m, Typeable a) => StrictTVar m a -> m Property
 isInWHNF v = do
-    x <- run $ readTVarIO v
-    case unsafeNoThunks (OnlyCheckWhnf x) of
-      Nothing    -> pure True
-      Just tinfo -> monitor (counterexample $ "Not in WHNF: " ++ show tinfo)
-                 >> pure False
+    x <- readTVarIO v
+    pure $ case unsafeNoThunks (OnlyCheckWhnf x) of
+      Nothing    -> property True
+      Just tinfo -> counterexample ("Not in WHNF: " ++ show tinfo)
+                  $ property False
 
 -- | Wrapper around 'Checked.newTVar' and 'Checked.newTVarWithInvariant'.
 newTVarWithInvariant :: MonadSTM m => Invariant a -> a -> STM m (StrictTVar m a)
@@ -93,100 +90,214 @@ newTVarWithInvariantIO = \case
     NoInvariant   -> Checked.newTVarIO
     Invariant inv -> Checked.newTVarWithInvariantIO inv
 
-newtype SanityCheckWhnf = SanityCheckWhnf { getSanityCheckWhnf :: Bool }
-  deriving (Show, Eq)
-
-noSanityCheckWhnf :: SanityCheckWhnf
-noSanityCheckWhnf = SanityCheckWhnf False
-
-sanityCheckWhnf :: SanityCheckWhnf
-sanityCheckWhnf = SanityCheckWhnf True
-
+-- | The 'isInWHNF' check fails when running tests in 'IOSim', since 'IOSim'
+-- runs in the lazy 'ST' monad. 'withSanityCheckWhnf' can be used to perform the
+-- test conditionally.
 withSanityCheckWhnf ::
      (MonadSTM m, Typeable a)
-  => SanityCheckWhnf
+  => Bool
   -> StrictTVar m a
-  -> PropertyM m Bool
+  -> m Property
 withSanityCheckWhnf check v =
-    if getSanityCheckWhnf check then
+    if check then
       isInWHNF v
     else
-      pure True
+      pure $ property True
 
 {-------------------------------------------------------------------------------
   Properties
 -------------------------------------------------------------------------------}
 
+--
+-- newTVarWithInvariant
+--
+
 -- | Test 'newTVarWithInvariant', not to be confused with
 -- 'Checked.newTVarWithInvariant'.
-prop_newTVarWithInvariant ::
+prop_newTVarWithInvariant_M ::
      MonadSTM m
-  => SanityCheckWhnf
+  => Bool
   -> Invariant Int
   -> Int
   -> Fun Int Int
-  -> PropertyM m Bool
-prop_newTVarWithInvariant check inv x f = do
-    v <- run $ atomically $ newTVarWithInvariant inv (applyFun f x)
+  -> m Property
+prop_newTVarWithInvariant_M check inv x f = do
+    v <- atomically $ newTVarWithInvariant inv (applyFun f x)
     withSanityCheckWhnf check v
+
+prop_newTVarWithInvariant_IO ::
+     Invariant Int
+  -> Int
+  -> Fun Int Int
+  -> Property
+prop_newTVarWithInvariant_IO = ioProperty ..:
+    prop_newTVarWithInvariant_M True
+
+prop_newTVarWithInvariant_IOSim ::
+     Invariant Int
+  -> Int
+  -> Fun Int Int
+  -> Property
+prop_newTVarWithInvariant_IOSim inv x f = runSimOrThrow $
+    prop_newTVarWithInvariant_M False inv x f
+
+--
+-- newTVarWithInvariantIO
+--
 
 -- | Test 'newTVarWithInvariantIO', not to be confused with
 -- 'Checked.newTVarWithInvariantIO'.
-prop_newTVarWithInvariantIO ::
+prop_newTVarWithInvariantIO_M ::
      MonadSTM m
-  => SanityCheckWhnf
+  => Bool
   -> Invariant Int
   -> Int
   -> Fun Int Int
-  -> PropertyM m Bool
-prop_newTVarWithInvariantIO check inv x f = do
-    v <- run $ newTVarWithInvariantIO inv (applyFun f x)
+  -> m Property
+prop_newTVarWithInvariantIO_M check inv x f = do
+    v <- newTVarWithInvariantIO inv (applyFun f x)
     withSanityCheckWhnf check v
 
-prop_writeTVar ::
+prop_newTVarWithInvariantIO_IO ::
+     Invariant Int
+  -> Int
+  -> Fun Int Int
+  -> Property
+prop_newTVarWithInvariantIO_IO = ioProperty ..:
+    prop_newTVarWithInvariantIO_M True
+
+prop_newTVarWithInvariantIO_IOSim ::
+     Invariant Int
+  -> Int
+  -> Fun Int Int
+  -> Property
+prop_newTVarWithInvariantIO_IOSim inv x f = runSimOrThrow $
+    prop_newTVarWithInvariantIO_M False inv x f
+
+--
+-- writeTVar
+--
+
+prop_writeTVar_M ::
      MonadSTM m
-  => SanityCheckWhnf
+  => Bool
   -> Invariant Int
   -> Int
   -> Fun Int Int
-  -> PropertyM m Bool
-prop_writeTVar check inv x f = do
-    v <- run $ newTVarWithInvariantIO inv x
-    run $ atomically $ writeTVar v (applyFun f x)
+  -> m Property
+prop_writeTVar_M check inv x f = do
+    v <- newTVarWithInvariantIO inv x
+    atomically $ writeTVar v (applyFun f x)
     withSanityCheckWhnf check v
 
-prop_modifyTVar ::
+prop_writeTVar_IO ::
+     Invariant Int
+  -> Int
+  -> Fun Int Int
+  -> Property
+prop_writeTVar_IO = ioProperty ..:
+    prop_writeTVar_M True
+
+prop_writeTVar_IOSim ::
+     Invariant Int
+  -> Int
+  -> Fun Int Int
+  -> Property
+prop_writeTVar_IOSim inv x f = runSimOrThrow $
+    prop_writeTVar_M False inv x f
+
+--
+-- modifyTVar
+--
+
+prop_modifyTVar_M ::
      MonadSTM m
-  => SanityCheckWhnf
+  => Bool
   -> Invariant Int
   -> Int
   -> Fun Int Int
-  -> PropertyM m Bool
-prop_modifyTVar check inv x f = do
-    v <- run $ newTVarWithInvariantIO inv x
-    run $ atomically $ modifyTVar v (applyFun f)
+  -> m Property
+prop_modifyTVar_M check inv x f = do
+    v <- newTVarWithInvariantIO inv x
+    atomically $ modifyTVar v (applyFun f)
     withSanityCheckWhnf check v
 
-prop_stateTVar ::
+prop_modifyTVar_IO ::
+     Invariant Int
+  -> Int
+  -> Fun Int Int
+  -> Property
+prop_modifyTVar_IO = ioProperty ..:
+    prop_modifyTVar_M True
+
+prop_modifyTVar_IOSim ::
+     Invariant Int
+  -> Int
+  -> Fun Int Int
+  -> Property
+prop_modifyTVar_IOSim inv x f = runSimOrThrow $
+    prop_modifyTVar_M False inv x f
+
+--
+-- stateTVar
+--
+
+prop_stateTVar_M ::
      MonadSTM m
-  => SanityCheckWhnf
+  => Bool
   -> Invariant Int
   -> Int
   -> Fun Int Int
-  -> PropertyM m Bool
-prop_stateTVar check inv x f = do
-    v <- run $ newTVarWithInvariantIO inv x
-    run $ atomically $ stateTVar v (((),) . applyFun f)
+  -> m Property
+prop_stateTVar_M check inv x f = do
+    v <- newTVarWithInvariantIO inv x
+    atomically $ stateTVar v (((),) . applyFun f)
     withSanityCheckWhnf check v
 
-prop_swapTVar ::
+prop_stateTVar_IO ::
+     Invariant Int
+  -> Int
+  -> Fun Int Int
+  -> Property
+prop_stateTVar_IO = ioProperty ..:
+    prop_stateTVar_M True
+
+prop_stateTVar_IOSim ::
+     Invariant Int
+  -> Int
+  -> Fun Int Int
+  -> Property
+prop_stateTVar_IOSim inv x f = runSimOrThrow $
+    prop_stateTVar_M False inv x f
+
+--
+-- swapTVar
+--
+
+prop_swapTVar_M ::
      MonadSTM m
-  => SanityCheckWhnf
+  => Bool
   -> Invariant Int
   -> Int
   -> Fun Int Int
-  -> PropertyM m Bool
-prop_swapTVar check inv x f = do
-    v <- run $ newTVarWithInvariantIO inv x
-    void $ run $ atomically $ swapTVar v (applyFun f x)
+  -> m Property
+prop_swapTVar_M check inv x f = do
+    v <- newTVarWithInvariantIO inv x
+    void $ atomically $ swapTVar v (applyFun f x)
     withSanityCheckWhnf check v
+
+prop_swapTVar_IO ::
+     Invariant Int
+  -> Int
+  -> Fun Int Int
+  -> Property
+prop_swapTVar_IO = ioProperty ..:
+    prop_swapTVar_M True
+
+prop_swapTVar_IOSim ::
+     Invariant Int
+  -> Int
+  -> Fun Int Int
+  -> Property
+prop_swapTVar_IOSim inv x f = runSimOrThrow $
+    prop_swapTVar_M False inv x f

--- a/strict-checked-vars/test/Test/Utils.hs
+++ b/strict-checked-vars/test/Test/Utils.hs
@@ -5,7 +5,7 @@ module Test.Utils (
     monadicSim
   , runSimGen
     -- * Function composition
-  , (.:)
+  , (..:)
     -- * Invariants
   , Invariant (..)
   , noInvariant
@@ -36,10 +36,10 @@ monadicSim m = property (runSimGen (monadic' m))
   Function composition
 -------------------------------------------------------------------------------}
 
-infixr 9 .:
+infixr 9 ..:
 
-(.:) :: (y -> z) -> (x0 -> x1 -> y) -> (x0 -> x1 -> z)
-(.:) g f x0 x1 = g (f x0 x1)
+(..:) :: (y -> z) -> (x0 -> x1 -> x2 -> y) -> (x0 -> x1 -> x2 -> z)
+(..:) g f x0 x1 x2 = g (f x0 x1 x2)
 
 {-------------------------------------------------------------------------------
   Invariants

--- a/strict-checked-vars/test/Test/Utils.hs
+++ b/strict-checked-vars/test/Test/Utils.hs
@@ -1,11 +1,21 @@
 {-# LANGUAGE RankNTypes #-}
 
 module Test.Utils (
+    -- * Property runners
     monadicSim
   , runSimGen
+    -- * Function composition
+  , (.:)
+    -- * Invariants
+  , Invariant (..)
+  , noInvariant
+  , trivialInvariant
+  , whnfInvariant
   ) where
 
 import           Control.Monad.IOSim (IOSim, runSimOrThrow)
+import           Data.Typeable (Typeable)
+import           NoThunks.Class (OnlyCheckWhnf (..), unsafeNoThunks)
 import           Test.QuickCheck (Gen, Property, Testable (..))
 import           Test.QuickCheck.Gen.Unsafe (Capture (..), capture)
 import           Test.QuickCheck.Monadic (PropertyM, monadic')
@@ -21,3 +31,33 @@ runSimGen f = do
 
 monadicSim :: Testable a => (forall s. PropertyM (IOSim s) a) -> Property
 monadicSim m = property (runSimGen (monadic' m))
+
+{-------------------------------------------------------------------------------
+  Function composition
+-------------------------------------------------------------------------------}
+
+infixr 9 .:
+
+(.:) :: (y -> z) -> (x0 -> x1 -> y) -> (x0 -> x1 -> z)
+(.:) g f x0 x1 = g (f x0 x1)
+
+{-------------------------------------------------------------------------------
+  Invariants
+-------------------------------------------------------------------------------}
+
+-- | Invariants
+--
+-- Testing with @'Invariant' (const Nothing)'@ /should/ be the same as testing
+-- with 'NoInvariant'.
+data Invariant a =
+    NoInvariant
+  | Invariant (a -> Maybe String)
+
+noInvariant :: Invariant a
+noInvariant = NoInvariant
+
+whnfInvariant :: Typeable a => Invariant a
+whnfInvariant = Invariant $ fmap show . unsafeNoThunks . OnlyCheckWhnf
+
+trivialInvariant :: Invariant a
+trivialInvariant = Invariant $ const Nothing


### PR DESCRIPTION
Adding these tests should safeguard against missing bang patterns and strictness annotations in the future.