### PR TITLE
Absorb `cardano-ledger-binary` `ToExpr` and `Arbitrary` instances

### DIFF
--- a/cardano-binary/CHANGELOG.md
+++ b/cardano-binary/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog for `cardano-binary`
 
+## 1.7.2.0
+
+* New `Test.Cardano.Binary.TreeDiff` module extracted from
+  `cardano-ledger-binary`. It lives in a new public sublibrary `testlib`.
+
 ## 1.7.1.0
 
 * Add `FromCBOR` instance for `TermToken`

--- a/cardano-binary/cardano-binary.cabal
+++ b/cardano-binary/cardano-binary.cabal
@@ -1,7 +1,7 @@
-cabal-version: 2.2
+cabal-version: 3.0
 
 name:                cardano-binary
-version:             1.7.1.0
+version:             1.7.2.0
 synopsis:            Binary serialization for Cardano
 description:         This package includes the binary serialization format for Cardano
 license:             Apache-2.0
@@ -53,6 +53,20 @@ library
                       , time
                       , vector
 
+library testlib
+  import:               base, project-config
+  visibility:           public
+  hs-source-dirs:       testlib
+  exposed-modules:      Test.Cardano.Binary.TreeDiff
+  build-depends:        base
+                      , bytestring
+                      , base16-bytestring
+                      , cardano-binary
+                      , cborg
+                      , formatting
+                      , tree-diff
+
+
 test-suite test
   import:               base, project-config
   hs-source-dirs:       test
@@ -85,4 +99,3 @@ test-suite test
 
   ghc-options:          -threaded
                         -rtsopts
-

--- a/cardano-binary/testlib/Test/Cardano/Binary/TreeDiff.hs
+++ b/cardano-binary/testlib/Test/Cardano/Binary/TreeDiff.hs
@@ -1,0 +1,114 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE LambdaCase #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Test.Cardano.Binary.TreeDiff where
+
+import qualified Cardano.Binary as Plain
+import qualified Codec.CBOR.Read as CBOR
+import qualified Codec.CBOR.Term as CBOR
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Base16 as Base16
+import qualified Data.ByteString.Char8 as BS8
+import qualified Data.ByteString.Lazy as BSL
+import Data.Bifunctor (bimap)
+import Data.TreeDiff
+import Formatting (build, formatToString)
+import qualified Formatting.Buildable as B (Buildable (..))
+
+showDecoderError :: B.Buildable e => e -> String
+showDecoderError = formatToString build
+
+showExpr :: ToExpr a => a -> String
+showExpr = show . ansiWlExpr . toExpr
+
+-- | Wraps regular ByteString, but shows and diffs it as hex
+newtype HexBytes = HexBytes {unHexBytes :: BS.ByteString}
+  deriving (Eq)
+
+instance Show HexBytes where
+  show = showExpr
+
+instance ToExpr HexBytes where
+  toExpr = App "HexBytes" . hexByteStringExpr . unHexBytes
+
+newtype CBORBytes = CBORBytes {unCBORBytes :: BS.ByteString}
+  deriving (Eq)
+
+instance Show CBORBytes where
+  show = showExpr
+
+instance ToExpr CBORBytes where
+  toExpr (CBORBytes bytes) =
+    case CBOR.deserialiseFromBytes CBOR.decodeTerm (BSL.fromStrict bytes) of
+      Left err ->
+        App
+          "CBORBytesError"
+          [ toExpr @String "Error decoding CBOR, showing as Hex:"
+          , toExpr (HexBytes bytes)
+          , toExpr $ show err
+          ]
+      Right (leftOver, term)
+        | BSL.null leftOver -> App "CBORBytes" [toExpr term]
+        | otherwise ->
+            case Plain.decodeFullDecoder "Term" CBOR.decodeTerm leftOver of
+              Right leftOverTerm ->
+                App
+                  "CBORBytesError"
+                  [ toExpr @String "Error decoding CBOR fully:"
+                  , toExpr term
+                  , toExpr @String "Leftover:"
+                  , toExpr (leftOverTerm :: CBOR.Term)
+                  ]
+              Left err ->
+                App
+                  "CBORBytesError"
+                  [ toExpr @String "Error decoding CBOR fully:"
+                  , toExpr term
+                  , toExpr @String "Leftover as Hex, due to inabilty to decode as Term:"
+                  , toExpr $ HexBytes $ BSL.toStrict leftOver
+                  , toExpr $ showDecoderError err
+                  ]
+
+instance ToExpr CBOR.Term where
+  toExpr =
+    \case
+      CBOR.TInt i -> App "TInt" [toExpr i]
+      CBOR.TInteger i -> App "TInteger" [toExpr i]
+      CBOR.TBytes bs -> App "TBytes" $ hexByteStringExpr bs
+      CBOR.TBytesI bs -> App "TBytesI" $ hexByteStringExpr $ BSL.toStrict bs
+      CBOR.TString s -> App "TString" [toExpr s]
+      CBOR.TStringI s -> App "TStringI" [toExpr s]
+      CBOR.TList xs -> App "TList" [Lst (map toExpr xs)]
+      CBOR.TListI xs -> App "TListI" [Lst (map toExpr xs)]
+      CBOR.TMap xs -> App "TMap" [Lst (map (toExpr . bimap toExpr toExpr) xs)]
+      CBOR.TMapI xs -> App "TMapI" [Lst (map (toExpr . bimap toExpr toExpr) xs)]
+      CBOR.TTagged 24 (CBOR.TBytes x) -> App "CBOR-in-CBOR" [toExpr (CBORBytes x)]
+      CBOR.TTagged t x -> App "TTagged" [toExpr t, toExpr x]
+      CBOR.TBool x -> App "TBool" [toExpr x]
+      CBOR.TNull -> App "TNull" []
+      CBOR.TSimple x -> App "TSimple" [toExpr x]
+      CBOR.THalf x -> App "THalf" [toExpr x]
+      CBOR.TFloat x -> App "TFloat" [toExpr x]
+      CBOR.TDouble x -> App "TDouble" [toExpr x]
+
+hexByteStringExpr :: BS.ByteString -> [Expr]
+hexByteStringExpr bs =
+  [ toExpr (BS.length bs)
+  , Lst (map toExpr $ showHexBytesGrouped bs)
+  ]
+
+-- | Show a ByteString as hex groups of 8bytes each. This is a slightly more
+-- useful form for debugging, rather than bunch of escaped characters.
+showHexBytesGrouped :: BS.ByteString -> [String]
+showHexBytesGrouped bs
+  | BS.null bs = []
+  | otherwise =
+      ("0x" <> BS8.unpack (BS.take 128 bs16))
+        : [ "  " <> BS8.unpack (BS.take 128 $ BS.drop i bs16)
+          | i <- [128, 256 .. BS.length bs16 - 1]
+          ]
+  where
+    bs16 = Base16.encode bs

--- a/cardano-slotting/CHANGELOG.md
+++ b/cardano-slotting/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog for `cardano-slotting`
 
-## 0.1.1.2
+## 0.1.2.0
 
-*
+* New `Test.Cardano.Slotting.TreeDiff` module extracted from
+  `cardano-ledger-binary`. It lives in a new public sublibrary `testlib`.
 
 ## 0.1.1.1
 
@@ -20,4 +21,3 @@
 ## 0.1.0.1
 
 * Initial release
-

--- a/cardano-slotting/cardano-slotting.cabal
+++ b/cardano-slotting/cardano-slotting.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                cardano-slotting
-version:             0.1.1.1
+version:             0.1.2.0
 synopsis:            Key slotting types for cardano libraries
 license:             Apache-2.0
 license-files:
@@ -46,6 +46,17 @@ library
                       , quiet
                       , serialise
                       , time
+
+library testlib
+  import:               base, project-config
+  visibility:           public
+  hs-source-dirs:       testlib
+  exposed-modules:      Test.Cardano.Slotting.Arbitrary
+                        Test.Cardano.Slotting.TreeDiff
+  build-depends:        base
+                      , cardano-slotting
+                      , QuickCheck
+                      , tree-diff
 
 test-suite tests
   import:               base, project-config

--- a/cardano-slotting/testlib/Test/Cardano/Slotting/Arbitrary.hs
+++ b/cardano-slotting/testlib/Test/Cardano/Slotting/Arbitrary.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE StandaloneDeriving #-}
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Test.Cardano.Slotting.Arbitrary () where
+
+import Test.QuickCheck
+import Cardano.Slotting.Slot
+
+instance Arbitrary SlotNo where
+  arbitrary = SlotNo <$>
+                ((getPositive <$> arbitrary)
+                   `suchThat`
+                 (\n -> n < maxBound - 2^(32 :: Int)))
+               -- need some room, we're assuming we'll never wrap around 64bits
+
+  shrink (SlotNo n) = [ SlotNo n' | n' <- shrink n, n' > 0 ]
+
+deriving newtype instance Arbitrary EpochNo

--- a/cardano-slotting/testlib/Test/Cardano/Slotting/TreeDiff.hs
+++ b/cardano-slotting/testlib/Test/Cardano/Slotting/TreeDiff.hs
@@ -1,0 +1,17 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Test.Cardano.Slotting.TreeDiff where
+
+import Cardano.Slotting.Slot
+import Cardano.Slotting.Block
+import Data.TreeDiff
+
+instance ToExpr x => ToExpr (WithOrigin x)
+
+instance ToExpr SlotNo
+
+instance ToExpr BlockNo
+
+instance ToExpr EpochNo
+
+instance ToExpr EpochSize


### PR DESCRIPTION
In order to implement input-output-hk/ouroboros-consensus#517 we need to move these instances upstream from cardano-ledger-binary into cardano-base.