### PR TITLE
Fix cardano-binary version

### DIFF
--- a/cardano-binary/CHANGELOG.md
+++ b/cardano-binary/CHANGELOG.md
@@ -1,12 +1,9 @@
 # Changelog for `cardano-binary`
 
-## 1.7.2.0
+## 1.7.1.0
 
 * New `Test.Cardano.Binary.TreeDiff` module extracted from
   `cardano-ledger-binary`. It lives in a new public sublibrary `testlib`.
-
-## 1.7.1.0
-
 * Add `FromCBOR` instance for `TermToken`
 
 ## 1.7.0.1

--- a/cardano-binary/cardano-binary.cabal
+++ b/cardano-binary/cardano-binary.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.0
 
 name:                cardano-binary
-version:             1.7.2.0
+version:             1.7.1.0
 synopsis:            Binary serialization for Cardano
 description:         This package includes the binary serialization format for Cardano
 license:             Apache-2.0


### PR DESCRIPTION
`cardano-binary-1.7.1.0` has not been released yet. Se we need to drop down the version back from `cardano-binary-1.7.2.0`