### PR TITLE
Set bounds for mempack dependency

### DIFF
--- a/cardano-crypto-class/cardano-crypto-class.cabal
+++ b/cardano-crypto-class/cardano-crypto-class.cabal
@@ -99,9 +99,7 @@ library
     Cardano.Crypto.VRF.Simple
     Cardano.Foreign
 
-  other-modules:
-    Cardano.Crypto.PackedBytes
-
+  other-modules: Cardano.Crypto.PackedBytes
   build-depends:
     aeson,
     base,
@@ -115,7 +113,7 @@ library
     io-classes >=1.4.1,
     memory,
     memory-pool,
-    mempack,
+    mempack >=0.1.2 && <0.2,
     mtl,
     nothunks,
     primitive >=0.8,
@@ -127,8 +125,7 @@ library
     vector,
 
   if impl(ghc <9.0.0)
-    build-depends:
-      integer-gmp
+    build-depends: integer-gmp
   pkgconfig-depends:
     libblst >=0.3.14,
     libsodium,


### PR DESCRIPTION
While trying to update dependencies in a package depending on cardano-crypto-class I found out it does not work with mempack 0.2.0.0. This PR sets strict bounds to ensure downstream consumers won't hit the same issue.

# Description

<!-- Add your description here, if this PR fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#changelogmd))
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process))
- [x] Self-reviewed the diff
