### PR TITLE
Add Cardano.Base.Proxy module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ result
 # Local development
 stack-local.yaml
 .nvimrc
+.direnv
+.envrc
 
 # Visual Studio Code
 /.vscode

--- a/cardano-base/CHANGELOG.md
+++ b/cardano-base/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog for `cardano-base`
 
-## 0.1.0.1
+## 0.1.1.0
 
-*
+* Added `Cardano.Base.Proxy`
 
 ## 0.1.0.0
 

--- a/cardano-base/cardano-base.cabal
+++ b/cardano-base/cardano-base.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-base
-version: 0.1.0.0
+version: 0.1.1.0
 synopsis: Various utilities for Cardano
 description: Various utilities for Cardano.
 category:
@@ -31,7 +31,10 @@ common project-config
 library
   import: project-config
   hs-source-dirs: src
-  exposed-modules: Cardano.Base.FeatureFlags
+  exposed-modules:
+    Cardano.Base.FeatureFlags
+    Cardano.Base.Proxy
+
   build-depends:
     aeson,
     nothunks,

--- a/cardano-base/src/Cardano/Base/Proxy.hs
+++ b/cardano-base/src/Cardano/Base/Proxy.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE RankNTypes #-}
+
+-- | Wrapper for Data.Proxy, plus convenience functions
+module Cardano.Base.Proxy (
+  module X,
+  asProxy,
+) where
+
+import Data.Proxy as X
+
+asProxy :: forall a. a -> Proxy a
+asProxy _ = Proxy


### PR DESCRIPTION
# Description

This patch adds the `Cardano.Base.Proxy` module that is just a re-export of `Data.Proxy` plus the newly added convenience function `asProxy`, [as suggested here](https://github.com/IntersectMBO/cardano-ledger/pull/5383#discussion_r2500308421)

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#changelogmd))
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process))
- [x] Self-reviewed the diff
