### PR TITLE
Add some missing functions to `Data.Sequence.Strict`

### DIFF
--- a/cardano-strict-containers/CHANGELOG.md
+++ b/cardano-strict-containers/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Changelog for `cardano-strict-containers`
 
-# 0.1.5.1
+# 0.1.6.0
 
-*
+* Added to `Data.Sequence.Strict`:
+  - `scanr`
+  - `tails`
+  - `inits`
+  - `breakl`
+  - `breakr`
 
 # 0.1.5.0
 

--- a/cardano-strict-containers/cardano-strict-containers.cabal
+++ b/cardano-strict-containers/cardano-strict-containers.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-strict-containers
-version: 0.1.5.0
+version: 0.1.6.0
 synopsis: Various strict container types
 license: Apache-2.0
 license-files:


### PR DESCRIPTION
# Description

These are all in the upstream library, and are both more efficient than their list equivalents and more convenient than converting to and from the wrapped `Seq`

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#changelogmd))
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process))
- [x] Self-reviewed the diff
