### PR TITLE
Fix max-success setting in `Test.Crypto.DSIGN`

### DIFF
--- a/cardano-crypto-tests/src/Test/Crypto/DSIGN.hs
+++ b/cardano-crypto-tests/src/Test/Crypto/DSIGN.hs
@@ -30,7 +30,7 @@ import Test.QuickCheck (
   counterexample,
   )
 import Test.Hspec (Spec, describe)
-import Test.Hspec.QuickCheck (prop, modifyMaxSize)
+import Test.Hspec.QuickCheck (prop, modifyMaxSuccess)
 
 import qualified Data.ByteString as BS
 import Cardano.Crypto.Libsodium
@@ -184,7 +184,7 @@ defaultSigGen = do
 -- Used for adjusting no of quick check tests
 -- By default up to 100 tests are performed which may not be enough to catch hidden bugs
 testEnough :: Spec -> Spec
-testEnough = modifyMaxSize (const 10_000)
+testEnough = modifyMaxSuccess (max 10_000)
 
 {- HLINT ignore "Use <$>" -}
 {- HLINT ignore "Reduce duplication" -}


### PR DESCRIPTION
# Description

This was defined incorrectly in #589 and resulted in property tests not being run the intended number of times

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#changelogmd))
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process))
- [x] Self-reviewed the diff
