### PR TITLE
Add `.h` file to `c-sources`

### DIFF
--- a/cardano-crypto-class/CHANGELOG.md
+++ b/cardano-crypto-class/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.2.4.0
 
+* Add `cbits/blst_util.h` to `c-sources`
 * Add `ToCBOR` and `FromCBOR` instances for `MessageHash`
 * Add `ToCBOR` and `FromCBOR` instances for `PinnedSizedBytes`
 * Add `ToCBOR` and `FromCBOR` instances for `PackedBytes`

--- a/cardano-crypto-class/cardano-crypto-class.cabal
+++ b/cardano-crypto-class/cardano-crypto-class.cabal
@@ -133,7 +133,10 @@ library
     libblst >=0.3.14,
     libsodium,
 
-  c-sources: cbits/blst_util.c
+  c-sources:
+    cbits/blst_util.c
+    cbits/blst_util.h
+
   include-dirs: cbits
   includes: blst_util.h
 


### PR DESCRIPTION
# Description

#586 made `blst_util.h` a requirement for building `cardano-crypto-class` but the file wasn't added to `c-sources` and so wasn't included in the source package. This made it impossible to build `cardano-crypto-class` from CHaP.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#changelogmd))
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process))
- [x] Self-reviewed the diff
