### PR TITLE
Move `blst_util.h` from `install-includes` to `extra-source-files`

### DIFF
--- a/cardano-crypto-class/cardano-crypto-class.cabal
+++ b/cardano-crypto-class/cardano-crypto-class.cabal
@@ -21,6 +21,9 @@ extra-doc-files:
   CHANGELOG.md
   README.md
 
+extra-source-files:
+  cbits/blst_util.h
+
 data-files:
   bls12-381-test-vectors/test_vectors/bls_sig_aug_test_vectors
   bls12-381-test-vectors/test_vectors/ec_operations_test_vectors
@@ -140,12 +143,8 @@ library
     libblst >=0.3.14,
     libsodium,
 
-  c-sources:
-    cbits/blst_util.c
-
+  c-sources: cbits/blst_util.c
   include-dirs: cbits
-  includes: blst_util.h
-  install-includes: blst_util.h
 
   if flag(secp256k1-support)
     exposed-modules:


### PR DESCRIPTION
# Description

Move `blst_util.h` from `install-includes` to `extra-source-files`
    
This avoids using the deprecated `includes` field and is more consistent with what we do in other packages. The only reason to put it in `install-includes` is for client code to be able to use it, but we want client code to use the Haskell bindings and not the C bindings.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process))
- [x] Self-reviewed the diff
