### PR TITLE
Make doctests a separate job in CI

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -147,11 +147,46 @@ jobs:
         MSYSTEM: MINGW64
       run: cabal test all --enable-tests --test-show-details=direct -j1
 
-    - name: Run doctests
-      if: runner.os == 'Linux'
+  doctests:
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ghc: ["9.6.7", "9.8.4", "9.10.2", "9.12.2"]
+
+    steps:
+    - name: Install Haskell
+      uses: input-output-hk/actions/haskell@latest
+      id: setup-haskell
+      with:
+        ghc-version: ${{ matrix.ghc }}
+        cabal-version: 3.14.1.0
+
+    - name: Install system dependencies
+      uses: input-output-hk/actions/base@latest
+      with:
+        use-sodium-vrf: false # default is true
+
+    - uses: actions/checkout@v4
+
+    - name: Cabal update
+      run: cabal update
+
+    - name: Configure build
+      shell: bash
       run: |
-        cabal install doctest --flag cabal-doctest --ignore-project --overwrite-policy=always
-        PATH="$(cabal path --installdir):$PATH"
+        cp ".github/workflows/cabal.project.local.ci.$(uname -s)" cabal.project.local
+        echo "# cabal.project.local"
+        cat cabal.project.local
+
+    - name: Run doctests
+      run: |
+        cabal build all --dry-run
         scripts/doctest.sh
 
   fourmolu:

--- a/scripts/doctest.sh
+++ b/scripts/doctest.sh
@@ -5,6 +5,9 @@ set -euo pipefail
 # Packages to run doctests for; defaults to all packages if none are specified
 PACKAGES=("$@")
 
+# Ensure the doctest executables can be found
+PATH=$(cabal path --installdir):$PATH
+
 # Install doctest's Cabal integration, if it's not present already
 if [[ -z "$(type -t cabal-doctest)" ]]
 then
@@ -28,9 +31,6 @@ then
   echo "  Doctest ghc: $(getExecutablePath "$doctest_ghc")" >&2
   exit 1
 fi
-
-# Ensure the cabal-doctest executable can be found
-PATH=$(cabal path --installdir):$PATH
 
 # Ensure other scripts (eg cabal-targets.hs) can be found
 case "$0" in


### PR DESCRIPTION
# Description

Since doctests use `ghci` they don't need the regular builld results and so can be done in a parallel job instead of lengthening the overall CI time.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process))
- [ ] Self-reviewed the diff
