### PR TITLE
Expose safe API from Cardano.Crypto.PackedBytes

### DIFF
--- a/cardano-crypto-class/CHANGELOG.md
+++ b/cardano-crypto-class/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.3.0.0
 
+* Expose `Cardano.Crypto.PackedBytes` module with a safe API
 * Remove `Serialise` instance for `PackedBytes` as unused
 * Switch `OutputVRF` to use `ByteArray` instead of `ByteString`. Change field accessor name to `getOutputVRFByteArray`
 * Add `byteArrayToNatural`, `naturalToByteArray` and `byteArrayToInteger`.

--- a/cardano-crypto-class/cardano-crypto-class.cabal
+++ b/cardano-crypto-class/cardano-crypto-class.cabal
@@ -105,6 +105,7 @@ library
     Cardano.Crypto.Libsodium.Memory
     Cardano.Crypto.Libsodium.Memory.Internal
     Cardano.Crypto.Libsodium.UnsafeC
+    Cardano.Crypto.PackedBytes
     Cardano.Crypto.PinnedSizedBytes
     Cardano.Crypto.Seed
     Cardano.Crypto.Util
@@ -116,7 +117,7 @@ library
     Cardano.Foreign
 
   other-modules:
-    Cardano.Crypto.PackedBytes
+    Cardano.Crypto.PackedBytes.Internal
 
   build-depends:
     FailT,

--- a/cardano-crypto-class/src/Cardano/Crypto/Hash/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Hash/Class.hs
@@ -90,7 +90,7 @@ import Control.DeepSeq (NFData)
 import NoThunks.Class (NoThunks)
 
 import Cardano.Binary (Encoding, FromCBOR (..), ToCBOR (..), serialize')
-import Cardano.Crypto.PackedBytes
+import Cardano.Crypto.PackedBytes.Internal
 import Cardano.Crypto.Util (decodeHexString)
 import Cardano.HeapWords (HeapWords (..))
 

--- a/cardano-crypto-class/src/Cardano/Crypto/PackedBytes.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/PackedBytes.hs
@@ -1,0 +1,11 @@
+module Cardano.Crypto.PackedBytes (
+  PackedBytes,
+  packByteString,
+  packShortByteString,
+  packShortByteStringWithOffset,
+  unpackBytes,
+  unpackAsByteArray,
+  unpackPinnedBytes,
+) where
+
+import Cardano.Crypto.PackedBytes.Internal

--- a/cardano-crypto-class/src/Cardano/Crypto/PackedBytes/Internal.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/PackedBytes/Internal.hs
@@ -12,7 +12,7 @@
 {-# LANGUAGE UnboxedTuples #-}
 
 {- FOURMOLU_DISABLE -}
-module Cardano.Crypto.PackedBytes
+module Cardano.Crypto.PackedBytes.Internal
   ( PackedBytes(..)
   , packBytes
   , packBytesMaybe


### PR DESCRIPTION
# Description

Due to the [removal](https://github.com/IntersectMBO/cardano-ledger/pull/5532) of the default `DecCBOR` implementation in Ledger, we need to expose `PackedBytes` and a few facilities to create/extract them. Unsafe functionality has been moved to the `Internal` module, which stays hidden.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#changelogmd))
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process))
- [x] Self-reviewed the diff
