### PR TITLE
Move `Arbitrary` instances from `cardano-ledger` to `cardano-binary`

### DIFF
--- a/cardano-binary/CHANGELOG.md
+++ b/cardano-binary/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog for `cardano-binary`
 
+## 1.8.0.0
+
+*
+
+### `testlib`
+
+* Add `Arbitrary` instances for `ByteArray`, `SlicedByteArray` and `Term` from `cborg`
+
 ## 1.7.3.0
 
 * Change `DecoderError(DecoderErrorUnknownTag)` to use `Word` instead of `Word8`

--- a/cardano-binary/cardano-binary.cabal
+++ b/cardano-binary/cardano-binary.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-binary
-version: 1.7.3.0
+version: 1.8.0.0
 synopsis: Binary serialization for Cardano
 description: This package includes the binary serialization format for Cardano
 license: Apache-2.0
@@ -67,6 +67,7 @@ library testlib
   visibility: public
   hs-source-dirs: testlib
   exposed-modules:
+    Test.Cardano.Binary.Arbitrary
     Test.Cardano.Binary.Helpers
     Test.Cardano.Binary.Helpers.GoldenRoundTrip
     Test.Cardano.Binary.TreeDiff
@@ -76,11 +77,13 @@ library testlib
     base,
     base16-bytestring,
     bytestring,
+    cardano-base:testlib,
     cardano-binary,
     cardano-prelude-test,
     cborg,
     containers,
     formatting,
+    half,
     hedgehog,
     hspec,
     pretty-show,

--- a/cardano-binary/testlib/Test/Cardano/Binary/Arbitrary.hs
+++ b/cardano-binary/testlib/Test/Cardano/Binary/Arbitrary.hs
@@ -1,0 +1,102 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Test.Cardano.Binary.Arbitrary () where
+
+import qualified Codec.CBOR.ByteArray as CBOR
+import qualified Codec.CBOR.ByteArray.Sliced as CBOR
+import Codec.CBOR.Term
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as BSL
+import qualified Data.Text as T
+import qualified Data.Text.Lazy as TL
+import Data.Word
+import Numeric.Half
+import Test.Cardano.Base.Bytes (genByteArray, genByteString, genLazyByteString)
+import Test.QuickCheck
+import Test.QuickCheck.Instances ()
+
+firstUnreservedTag :: Word64
+firstUnreservedTag = 6
+
+-- | Simple values that are either unassigned or don't have a specialized type already
+simple :: [Word8]
+simple = [0 .. 19] ++ [23] ++ [32 ..]
+
+genHalf :: Gen Float
+genHalf = do
+  half <- Half <$> arbitrary
+  if isInfinite half || isDenormalized half || isNaN half
+    then genHalf
+    else pure $ fromHalf half
+
+instance Arbitrary Term where
+  arbitrary =
+    oneof
+      [ TInt <$> choose (minBound, maxBound)
+      , TInteger
+          <$> oneof
+            [ choose (toInteger (maxBound :: Int) + 1, toInteger (maxBound :: Word64))
+            , choose (negate (toInteger (maxBound :: Word64)), toInteger (minBound :: Int) - 1)
+            ]
+      , TBytes <$> (genByteString . getNonNegative =<< arbitrary)
+      , TBytesI <$> (genLazyByteString . getNonNegative =<< arbitrary)
+      , TString . T.pack <$> arbitrary
+      , TStringI . TL.pack <$> arbitrary
+      , TList <$> listOf smallerTerm
+      , TListI <$> listOf smallerTerm
+      , TMap <$> listOf smallerTerm
+      , TMapI <$> listOf smallerTerm
+      , TTagged <$> choose (firstUnreservedTag, maxBound :: Word64) <*> smallerTerm
+      , TBool <$> arbitrary
+      , pure TNull
+      , TSimple <$> elements simple
+      , THalf <$> genHalf
+      , TFloat <$> arbitrary
+      , TDouble <$> arbitrary
+      ]
+    where
+      smallerTerm :: Arbitrary a => Gen a
+      smallerTerm = scale (`div` 5) arbitrary
+
+  -- Shrinker was shamelessly stolen from cbor package.
+  shrink (TInt n) = [TInt n' | n' <- shrink n]
+  shrink (TInteger n) = [TInteger n' | n' <- shrink n]
+  shrink (TBytes ws) = [TBytes (BS.pack ws') | ws' <- shrink (BS.unpack ws)]
+  shrink (TBytesI wss) =
+    [ TBytesI (BSL.fromChunks (map BS.pack wss'))
+    | wss' <- shrink (map BS.unpack (BSL.toChunks wss))
+    ]
+  shrink (TString cs) = [TString (T.pack cs') | cs' <- shrink (T.unpack cs)]
+  shrink (TStringI css) =
+    [ TStringI (TL.fromChunks (map T.pack css'))
+    | css' <- shrink (map T.unpack (TL.toChunks css))
+    ]
+  shrink (TList xs@[x]) = x : [TList xs' | xs' <- shrink xs]
+  shrink (TList xs) = [TList xs' | xs' <- shrink xs]
+  shrink (TListI xs@[x]) = x : [TListI xs' | xs' <- shrink xs]
+  shrink (TListI xs) = [TListI xs' | xs' <- shrink xs]
+  shrink (TMap xys@[(x, y)]) = x : y : [TMap xys' | xys' <- shrink xys]
+  shrink (TMap xys) = [TMap xys' | xys' <- shrink xys]
+  shrink (TMapI xys@[(x, y)]) = x : y : [TMapI xys' | xys' <- shrink xys]
+  shrink (TMapI xys) = [TMapI xys' | xys' <- shrink xys]
+  shrink (TTagged w t) =
+    t : [TTagged w' t' | (w', t') <- shrink (w, t), fromIntegral w' >= firstUnreservedTag]
+  shrink (TBool _) = []
+  shrink TNull = []
+  shrink (TSimple w) = [TSimple w' | w' <- shrink w, w `elem` simple]
+  shrink (THalf _f) = []
+  shrink (TFloat f) = [TFloat f' | f' <- shrink f]
+  shrink (TDouble f) = [TDouble f' | f' <- shrink f]
+
+deriving instance Arbitrary CBOR.ByteArray
+
+instance Arbitrary CBOR.SlicedByteArray where
+  arbitrary = do
+    NonNegative off <- arbitrary
+    Positive count <- arbitrary
+    NonNegative slack <- arbitrary
+    let len = off + count + slack
+    ba <- genByteArray len
+    pure $ CBOR.SBA ba off count


### PR DESCRIPTION
# Description

The instances are for:

* `ByteArray`, `SlicedByteArray` and `Term` from `cborg`

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#changelogmd))
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process))
- [x] Self-reviewed the diff
