### PR TITLE
Fix `cardano-slotting` version

### DIFF
--- a/cardano-slotting/CHANGELOG.md
+++ b/cardano-slotting/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog for `cardano-slotting`
 
+## 0.2.1.0
+
+* Bump version to reflect breaking changes added in `0.2.0.2`
+
 ## 0.2.0.2
+
+*Deprecated*
 
 * Add `Arbitrary` instances for `BlockNo`, `EpochInterval`, `EpochSize`, `SystemStart`, `WithOrigin`
 * Use `Hspec` instead of `Tasty`

--- a/cardano-slotting/cardano-slotting.cabal
+++ b/cardano-slotting/cardano-slotting.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-slotting
-version: 0.2.0.2
+version: 0.2.1.0
 synopsis: Key slotting types for cardano libraries
 license: Apache-2.0
 license-files:


### PR DESCRIPTION
# Description

Version `0.2.0.2` of `cardano-slotting` contained breaking changes but the version wasn't increased appropriately.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#changelogmd))
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process))
- [x] Self-reviewed the diff
