### PR TITLE
Support depending on Haskell libraries instead of pkg-depends

### DIFF
--- a/cardano-crypto-class/cardano-crypto-class.cabal
+++ b/cardano-crypto-class/cardano-crypto-class.cabal
@@ -39,6 +39,15 @@ flag secp256k1-support
   default: True
   manual: True
 
+flag use-haskell-clibs
+  description:
+    Use Haskell *-clib packages (blst-clib, sodium-clib, secp256k1-clib) instead
+    of system-provided C libraries via pkg-config. Don't enable this flag when
+    building cardano-node! It is there for less sensitive clients, such as
+    Plinth.
+  default: False
+  manual: True
+
 common base
   build-depends: base >=4.18 && <5
 
@@ -143,13 +152,19 @@ library
     th-compat,
     transformers,
     vector,
+  if flag(use-haskell-clibs)
+    build-depends:
+      blst-clib >=0.3.14,
+      sodium-clib
+    ghc-options: -Wno-unused-packages
+  else
+    pkgconfig-depends:
+      libblst,
+      libsodium
 
   if impl(ghc <9.0.0)
     build-depends:
       integer-gmp
-  pkgconfig-depends:
-    libblst >=0.3.14,
-    libsodium,
 
   c-sources: cbits/blst_util.c
   include-dirs: cbits
@@ -161,7 +176,10 @@ library
       Cardano.Crypto.SECP256K1.C
       Cardano.Crypto.SECP256K1.Constants
 
-    pkgconfig-depends: libsecp256k1
+    if flag(use-haskell-clibs)
+      build-depends: secp256k1-clib
+    else
+      pkgconfig-depends: libsecp256k1
     cpp-options: -DSECP256K1_ENABLED
 
 library testlib

--- a/cardano-crypto-praos/cardano-crypto-praos.cabal
+++ b/cardano-crypto-praos/cardano-crypto-praos.cabal
@@ -60,6 +60,14 @@ flag external-libsodium-vrf
   default: True
   manual: True
 
+flag use-haskell-clibs
+  description:
+    Use Haskell *-clib packages (sodium-clib) instead of system-provided C
+    libraries via pkg-config. Don't enable this flag when building cardano-node!
+    It is there for less sensitive clients, such as Plinth.
+  default: False
+  manual: True
+
 common base
   build-depends: base >=4.18 && <5
 
@@ -91,7 +99,11 @@ library
     nothunks,
     primitive,
 
-  pkgconfig-depends: libsodium
+  if flag(use-haskell-clibs)
+    build-depends: sodium-clib
+    ghc-options: -Wno-unused-packages
+  else
+    pkgconfig-depends: libsodium
 
   if !flag(external-libsodium-vrf)
     c-sources:


### PR DESCRIPTION
# Description

This MR allows the use of Haskell crypto libraries (blst-clib, sodium-clib, secp256k1-clib) instead of globally installed ones.

Pro:
- building from sources becomes very easy even on weird systems (e.g. Windows' WSL) and https://github.com/IntersectMBO/cardano-base/blob/master/INSTALL.md#option-3-building-from-source could be modified to be only:
```
cabal update
cabal build all
cabal test all
```
- we have more control on our dependencies (e.g. secp256k1's enabled modules), even without using nix

Con:
- the Cabal libraries are experimental: I've replaced the upstream build systems with a .cabal file, and in some cases (libsodium...) it wasn't trivial. Maybe they regress in some aspects for now (perf, portability...)
 
I'm opening this MR because it's already been helpful to someone on Windows. It might become the recommended way to build cardano-base in the future but I'd like to have some benchmarks to ensure that performance doesn't regress while switching to the cabal-built packages.

# Checklist

- [ ] Benchmark for regressions
- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process))
- [ ] Self-reviewed the diff