### PR TITLE
Add typeclass for multi-part hashing, and an implementation for Blake2b

### DIFF
--- a/cardano-crypto-class/CHANGELOG.md
+++ b/cardano-crypto-class/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog for `cardano-crypto-class`
 
-## 2.3.1.1
+## 2.3.2.0
 
-*
+* Add `psbToPackedBytes` to `Cardano.Crypto.PinnedSizedBytes`
+* Add `IncrementalHashAlgorithm` typeclass with `Blake2b_224` and `Blake2b_256` instances
+* Add `withHashContext` and `withHashContextST` for resource management when incremental hashing
+* Add `psbCreateSizedAligned` and `psbCreateSizedResultAligned` to `Cardano.Crypto.PinnedSizedBytes`
+* Deprecate `CRYPTO_BLAKE2B_256_STATE_SIZE`; add `CRYPTO_BLAKE2B_STATE_SIZE` in its place
 
 ## 2.3.1.0
 

--- a/cardano-crypto-class/cardano-crypto-class.cabal
+++ b/cardano-crypto-class/cardano-crypto-class.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-crypto-class
-version: 2.3.1.0
+version: 2.3.2.0
 synopsis:
   Type classes abstracting over cryptography primitives for Cardano
 

--- a/cardano-crypto-class/src/Cardano/Crypto/Hash/Blake2b.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Hash/Blake2b.hs
@@ -1,4 +1,6 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
@@ -10,17 +12,43 @@ module Cardano.Crypto.Hash.Blake2b (
 )
 where
 
-import Cardano.Crypto.Libsodium.C (c_crypto_generichash_blake2b)
 import Control.Monad (unless)
-
-import Cardano.Crypto.Hash.Class (HashAlgorithm (..), HashSize, digest, hashAlgorithmName)
+import Control.Monad.Class.MonadST (MonadST)
+import Data.Proxy (Proxy (..))
 import Foreign.C.Error (errnoToIOError, getErrno)
+import Foreign.C.Types (CSize, CULLong)
 import Foreign.Ptr (castPtr, nullPtr)
 import GHC.IO.Exception (ioException)
 
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Internal as BI
-import Foreign.C.Types (CSize, CULLong)
+import qualified Data.ByteString.Unsafe as B
+
+import Cardano.Crypto.Hash.Class (
+  Hash,
+  HashAlgorithm (..),
+  HashSize,
+  IncrementalHashAlgorithm (..),
+  digest,
+  hashAlgorithmName,
+  hashFromPackedBytes,
+  hashSize,
+ )
+import Cardano.Crypto.Libsodium.C (
+  CRYPTO_BLAKE2B_STATE_SIZE,
+  c_crypto_generichash_blake2b,
+  c_crypto_generichash_blake2b_final,
+  c_crypto_generichash_blake2b_init,
+  c_crypto_generichash_blake2b_update,
+ )
+import Cardano.Crypto.Libsodium.Memory.Internal (unsafeIOToMonadST)
+import Cardano.Crypto.PinnedSizedBytes (
+  PinnedSizedBytes,
+  psbCreateLen,
+  psbCreateSizedAligned,
+  psbToPackedBytes,
+  psbUseAsSizedPtr,
+ )
 
 data Blake2b_224
 data Blake2b_256
@@ -34,6 +62,88 @@ instance HashAlgorithm Blake2b_256 where
   type HashSize Blake2b_256 = 32
   hashAlgorithmName _ = "blake2b_256"
   digest _ = blake2b_libsodium 32
+
+instance IncrementalHashAlgorithm Blake2b_224 where
+  data HashContext Blake2b_224 s
+    = Blake2b224Context (PinnedSizedBytes CRYPTO_BLAKE2B_STATE_SIZE)
+  hashInit = Blake2b224Context <$> blake2bInitContext @Blake2b_224
+  hashUpdate (Blake2b224Context psb) = blake2bUpdateContext psb
+  hashFinalize (Blake2b224Context psb) = blake2bFinalizeHash @Blake2b_224 psb
+
+instance IncrementalHashAlgorithm Blake2b_256 where
+  data HashContext Blake2b_256 s
+    = Blake2b256Context (PinnedSizedBytes CRYPTO_BLAKE2B_STATE_SIZE)
+  hashInit = Blake2b256Context <$> blake2bInitContext @Blake2b_256
+  hashUpdate (Blake2b256Context psb) = blake2bUpdateContext psb
+  hashFinalize (Blake2b256Context psb) = blake2bFinalizeHash @Blake2b_256 psb
+
+-------------------------------------------------------------------------------
+-- Shared helpers for incremental Blake2b hashing
+-------------------------------------------------------------------------------
+
+{-# INLINE blake2bInitContext #-}
+blake2bInitContext ::
+  forall h m.
+  (HashAlgorithm h, MonadST m) =>
+  m (PinnedSizedBytes CRYPTO_BLAKE2B_STATE_SIZE)
+blake2bInitContext = do
+  let outLen = fromIntegral @Word @CSize (hashSize (Proxy @h))
+  -- libsodium source notes (in crypto_generichash.h) that "the state address should be 64-bytes aligned"
+  unsafeIOToMonadST $
+    psbCreateSizedAligned 64 $ \sizedPtr -> do
+      res <-
+        c_crypto_generichash_blake2b_init
+          sizedPtr
+          nullPtr -- no key
+          0 -- key length
+          outLen
+      unless (res == 0) $ do
+        errno <- getErrno
+        ioException $
+          errnoToIOError "blake2bInitContext: c_crypto_generichash_blake2b_init" errno Nothing Nothing
+
+{-# INLINE blake2bUpdateContext #-}
+blake2bUpdateContext ::
+  MonadST m => PinnedSizedBytes CRYPTO_BLAKE2B_STATE_SIZE -> B.ByteString -> m ()
+blake2bUpdateContext psb chunk =
+  unsafeIOToMonadST $
+    psbUseAsSizedPtr psb $ \sizedPtr ->
+      B.unsafeUseAsCStringLen chunk $ \(inPtr, inLen) -> do
+        res <-
+          c_crypto_generichash_blake2b_update
+            sizedPtr
+            (castPtr inPtr)
+            (fromIntegral @Int @CULLong inLen)
+        unless (res == 0) $ do
+          errno <- getErrno
+          ioException $
+            errnoToIOError "blake2bUpdateContext: c_crypto_generichash_blake2b_update" errno Nothing Nothing
+
+{-# INLINE blake2bFinalizeHash #-}
+blake2bFinalizeHash ::
+  forall h a m.
+  (HashAlgorithm h, MonadST m) =>
+  PinnedSizedBytes CRYPTO_BLAKE2B_STATE_SIZE ->
+  m (Hash h a)
+blake2bFinalizeHash psb = do
+  psbHash :: PinnedSizedBytes (HashSize h) <-
+    unsafeIOToMonadST $
+      psbUseAsSizedPtr psb $ \sizedPtr ->
+        psbCreateLen $ \outPtr outLen -> do
+          res <-
+            c_crypto_generichash_blake2b_final
+              sizedPtr
+              outPtr
+              outLen
+          unless (res == 0) $ do
+            errno <- getErrno
+            ioException $
+              errnoToIOError "blake2bFinalizeHash: c_crypto_generichash_blake2b_final" errno Nothing Nothing
+  pure $ hashFromPackedBytes $ psbToPackedBytes psbHash
+
+-------------------------------------------------------------------------------
+-- Single-shot Blake2b
+-------------------------------------------------------------------------------
 
 blake2b_libsodium :: Int -> B.ByteString -> B.ByteString
 blake2b_libsodium size input =

--- a/cardano-crypto-class/src/Cardano/Crypto/Hash/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Hash/Class.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -6,6 +7,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE MagicHash #-}
 {-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TemplateHaskell #-}
@@ -17,6 +19,9 @@
 -- | Abstract hashing functionality.
 module Cardano.Crypto.Hash.Class (
   HashAlgorithm (..),
+  IncrementalHashAlgorithm (..),
+  withHashContext,
+  withHashContextST,
   hashSize,
   ByteString,
   Hash (UnsafeHash),
@@ -60,6 +65,9 @@ module Cardano.Crypto.Hash.Class (
 )
 where
 
+import Control.Monad.Class.MonadST (MonadST)
+import Control.Monad.Primitive (PrimState)
+import Control.Monad.ST (ST, runST)
 import Control.Monad.Trans.Fail.String (errorFail)
 import Data.Array.Byte (ByteArray)
 import Data.ByteString (ByteString)
@@ -377,3 +385,38 @@ getHashBytesAsHex = hashToBytesAsHex
 xor :: Hash h a -> Hash h a -> Hash h a
 xor (UnsafeHashRep x) (UnsafeHashRep y) = UnsafeHashRep (xorPackedBytes x y)
 {-# INLINE xor #-}
+
+-- | Hash algorithms that support incremental (multi-part) hashing.
+--
+-- The context MUST NOT be used after calling 'hashFinalize'.
+class HashAlgorithm h => IncrementalHashAlgorithm h where
+  data HashContext h s
+
+  -- | Allocate and initialize a new hash context.
+  hashInit :: MonadST m => m (HashContext h (PrimState m))
+
+  -- | Feed a chunk of data into the hash context.
+  hashUpdate :: MonadST m => HashContext h (PrimState m) -> ByteString -> m ()
+
+  -- | Finalize the hash context, returning the typed 'Hash'.
+  --
+  -- The context MUST NOT be used after calling this function.
+  hashFinalize :: MonadST m => HashContext h (PrimState m) -> m (Hash h a)
+
+withHashContext ::
+  forall h a b m.
+  (IncrementalHashAlgorithm h, MonadST m) =>
+  (HashContext h (PrimState m) -> m a) ->
+  m (a, Hash h b)
+withHashContext f = do
+  ctx <- hashInit
+  res <- f ctx
+  h <- hashFinalize ctx
+  pure (res, h)
+
+withHashContextST ::
+  forall h a b.
+  IncrementalHashAlgorithm h =>
+  (forall s. HashContext h s -> ST s a) ->
+  (a, Hash h b)
+withHashContextST f = runST $ withHashContext f

--- a/cardano-crypto-class/src/Cardano/Crypto/Libsodium/C.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Libsodium/C.hs
@@ -47,6 +47,7 @@ module Cardano.Crypto.Libsodium.C (
   CRYPTO_BLAKE2B_256_BYTES,
   CRYPTO_SHA256_STATE_SIZE,
   CRYPTO_SHA512_STATE_SIZE,
+  CRYPTO_BLAKE2B_STATE_SIZE,
   CRYPTO_BLAKE2B_256_STATE_SIZE,
   CRYPTO_SIGN_ED25519_BYTES,
   CRYPTO_SIGN_ED25519_SEEDBYTES,
@@ -148,17 +149,17 @@ foreign import capi unsafe "sodium.h crypto_generichash_blake2b"
 -- | @int crypto_generichash_blake2b_init(crypto_generichash_blake2b_state *state, const unsigned char *key, const size_t keylen, const size_t outlen);@
 foreign import capi unsafe "sodium.h crypto_generichash_blake2b_init"
   c_crypto_generichash_blake2b_init ::
-    SizedPtr CRYPTO_BLAKE2B_256_STATE_SIZE -> Ptr key -> CSize -> CSize -> IO Int
+    SizedPtr CRYPTO_BLAKE2B_STATE_SIZE -> Ptr key -> CSize -> CSize -> IO Int
 
 -- | @int crypto_generichash_blake2b_update(crypto_generichash_blake2b_state *state, const unsigned char *in, unsigned long long inlen);@
 foreign import capi unsafe "sodium.h crypto_generichash_blake2b_update"
   c_crypto_generichash_blake2b_update ::
-    SizedPtr CRYPTO_BLAKE2B_256_STATE_SIZE -> Ptr CUChar -> CULLong -> IO Int
+    SizedPtr CRYPTO_BLAKE2B_STATE_SIZE -> Ptr CUChar -> CULLong -> IO Int
 
 -- | @int crypto_generichash_blake2b_final(crypto_generichash_blake2b_state *state, unsigned char *out, const size_t outlen);@
 foreign import capi unsafe "sodium.h crypto_generichash_blake2b_final"
   c_crypto_generichash_blake2b_final ::
-    SizedPtr CRYPTO_BLAKE2B_256_STATE_SIZE -> Ptr out -> CSize -> IO Int
+    SizedPtr CRYPTO_BLAKE2B_STATE_SIZE -> Ptr out -> CSize -> IO Int
 
 -------------------------------------------------------------------------------
 -- Signing: ED25519

--- a/cardano-crypto-class/src/Cardano/Crypto/Libsodium/Constants.hsc
+++ b/cardano-crypto-class/src/Cardano/Crypto/Libsodium/Constants.hsc
@@ -5,6 +5,7 @@ module Cardano.Crypto.Libsodium.Constants (
     CRYPTO_BLAKE2B_256_BYTES,
     CRYPTO_SHA256_STATE_SIZE,
     CRYPTO_SHA512_STATE_SIZE,
+    CRYPTO_BLAKE2B_STATE_SIZE,
     CRYPTO_BLAKE2B_256_STATE_SIZE,
     CRYPTO_SIGN_ED25519_BYTES,
     CRYPTO_SIGN_ED25519_SEEDBYTES,
@@ -23,7 +24,10 @@ type CRYPTO_BLAKE2B_256_BYTES = #{const crypto_generichash_blake2b_BYTES}
 
 type CRYPTO_SHA256_STATE_SIZE = #{size crypto_hash_sha256_state}
 type CRYPTO_SHA512_STATE_SIZE = #{size crypto_hash_sha512_state}
-type CRYPTO_BLAKE2B_256_STATE_SIZE = #{size crypto_generichash_blake2b_state}
+type CRYPTO_BLAKE2B_STATE_SIZE = #{size crypto_generichash_blake2b_state}
+
+{-# DEPRECATED CRYPTO_BLAKE2B_256_STATE_SIZE "Use CRYPTO_BLAKE2B_STATE_SIZE instead" #-}
+type CRYPTO_BLAKE2B_256_STATE_SIZE = CRYPTO_BLAKE2B_STATE_SIZE
 
 type CRYPTO_SIGN_ED25519_BYTES = #{const crypto_sign_ed25519_BYTES}
 type CRYPTO_SIGN_ED25519_SEEDBYTES = #{const crypto_sign_ed25519_SEEDBYTES}

--- a/cardano-crypto-class/src/Cardano/Crypto/Libsodium/Hash/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Libsodium/Hash/Class.hs
@@ -45,9 +45,6 @@ class HashAlgorithm h => SodiumHashAlgorithm h where
     Int ->
     IO (MLockedSizedBytes (HashSize h))
 
--- TODO: provide interface for multi-part?
--- That will be useful to hashing ('1' <> oldseed).
-
 digestMLockedStorable ::
   forall h a proxy.
   (SodiumHashAlgorithm h, Storable a) =>

--- a/cardano-crypto-class/src/Cardano/Crypto/PinnedSizedBytes.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/PinnedSizedBytes.hs
@@ -34,7 +34,10 @@ module Cardano.Crypto.PinnedSizedBytes (
   psbCreateResult,
   psbCreateResultLen,
   psbCreateSizedResult,
+  psbCreateSizedAligned,
+  psbCreateSizedResultAligned,
   ptrPsbToSizedPtr,
+  psbToPackedBytes,
 ) where
 
 import Cardano.Binary (FromCBOR (..), Size, ToCBOR (..))
@@ -51,6 +54,7 @@ import Data.Primitive.ByteArray (
   copyByteArrayToAddr,
   foldrByteArray,
   mutableByteArrayContents,
+  newAlignedPinnedByteArray,
   newPinnedByteArray,
   unsafeFreezeByteArray,
   writeByteArray,
@@ -75,8 +79,10 @@ import qualified Data.ByteString as BS
 import qualified Data.Primitive as Prim
 
 import Cardano.Crypto.Libsodium.C (c_sodium_compare)
+import Cardano.Crypto.PackedBytes.Internal (PackedBytes, packBytes)
 import Cardano.Crypto.Util (decodeHexString)
 import Cardano.Foreign
+import Data.MemPack.Buffer (byteArrayToShortByteString)
 
 {- HLINT ignore "Reduce duplication" -}
 
@@ -189,6 +195,9 @@ psbToBytes (PSB ba) = foldrByteArray (:) [] ba
 
 psbToByteString :: PinnedSizedBytes n -> BS.ByteString
 psbToByteString = BS.pack . psbToBytes
+
+psbToPackedBytes :: KnownNat n => PinnedSizedBytes n -> PackedBytes n
+psbToPackedBytes (PSB ba) = packBytes (byteArrayToShortByteString ba) 0
 
 -- | See @'IsString' ('PinnedSizedBytes' n)@ instance.
 --
@@ -403,6 +412,35 @@ psbCreateSizedResult ::
   (SizedPtr n -> m r) ->
   m (PinnedSizedBytes n, r)
 psbCreateSizedResult f = psbCreateResult (f . SizedPtr . castPtr)
+
+-- | As 'psbCreateSized', but with a specified alignment (in bytes) for the
+-- underlying pinned memory.
+{-# INLINE psbCreateSizedAligned #-}
+psbCreateSizedAligned ::
+  forall (n :: Nat) (m :: Type -> Type).
+  (KnownNat n, MonadST m) =>
+  Int ->
+  (SizedPtr n -> m ()) ->
+  m (PinnedSizedBytes n)
+psbCreateSizedAligned al k = fst <$> psbCreateSizedResultAligned al k
+
+-- | As 'psbCreateSizedResult', but with a specified alignment (in bytes) for the
+-- underlying pinned memory.
+-- The same caveats apply to this function as to 'psbCreateSizedResult': the
+-- 'SizedPtr' given to the function argument /must not/ be returned as @r@.
+{-# INLINE psbCreateSizedResultAligned #-}
+psbCreateSizedResultAligned ::
+  forall (n :: Nat) (r :: Type) (m :: Type -> Type).
+  (KnownNat n, MonadST m) =>
+  Int ->
+  (SizedPtr n -> m r) ->
+  m (PinnedSizedBytes n, r)
+psbCreateSizedResultAligned al f = do
+  let len = fromIntegral @Integer @Int . natVal $ Proxy @n
+  mpba <- stToIO (newAlignedPinnedByteArray len al)
+  res <- f (SizedPtr $ castPtr $ mutableByteArrayContents mpba)
+  arr <- stToIO (unsafeFreezeByteArray mpba)
+  pure (PSB arr, res)
 
 ptrPsbToSizedPtr :: Ptr (PinnedSizedBytes n) -> SizedPtr n
 ptrPsbToSizedPtr = SizedPtr . castPtr

--- a/cardano-crypto-class/testlib/Test/Crypto/Hash.hs
+++ b/cardano-crypto-class/testlib/Test/Crypto/Hash.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -20,6 +21,7 @@ import Data.MemPack
 import Data.Proxy (Proxy (..))
 import Data.String (fromString)
 import GHC.TypeLits
+import Test.Cardano.Base.Bytes (genByteString)
 import Test.Crypto.Util (
   Lock,
   prop_bad_cbor_bytes,
@@ -49,6 +51,8 @@ tests lock =
     testHashAlgorithm (Proxy :: Proxy Keccak256)
     testSodiumHashAlgorithm lock (Proxy :: Proxy SHA256)
     testSodiumHashAlgorithm lock (Proxy :: Proxy Blake2b_256)
+    testIncrementalHashAlgorithm (Proxy :: Proxy Blake2b_224)
+    testIncrementalHashAlgorithm (Proxy :: Proxy Blake2b_256)
     testHashAlgorithm (Proxy :: Proxy SHA512)
     testHashAlgorithm (Proxy :: Proxy SHA3_512)
     testPackedBytes
@@ -183,6 +187,41 @@ prop_libsodium_model lock p bs = ioProperty . withLock lock $ do
   return (expected === actual)
   where
     expected = digest p bs
+
+testIncrementalHashAlgorithm ::
+  forall proxy h.
+  IncrementalHashAlgorithm h =>
+  proxy h ->
+  Spec
+testIncrementalHashAlgorithm p =
+  describe (hashAlgorithmName p ++ " incremental") $ do
+    prop "chunked equivalence" $ prop_incremental_chunked @h
+
+-- | Incremental hashing produces the same result as single-shot.
+prop_incremental_chunked ::
+  forall h.
+  IncrementalHashAlgorithm h =>
+  Property
+prop_incremental_chunked =
+  forAll genInput $ \bs ->
+    forAll (chop bs) $ \chunks -> do
+      let ((), actual) = withHashContextST @h $ \ctx ->
+            mapM_ (hashUpdate ctx) chunks
+      counterexample ("input length: " ++ show (BS.length bs)) $
+        counterexample ("chunks: " ++ show (map BS.length chunks)) $
+          actual === hashWith @h id bs
+  where
+    -- arbitrary bytestrings are too short to cross the hash algorithm block size
+    -- (e.g. Blake2b uses 128 bytes)
+    genInput = choose (0, 4096) >>= genByteString
+
+    chop :: BS.ByteString -> Gen [BS.ByteString]
+    chop bs
+      | BS.null bs = pure [BS.empty]
+      | otherwise = do
+          n <- choose (0, BS.length bs)
+          let (chunk, rest) = BS.splitAt n bs
+          (chunk :) <$> chop rest
 
 --
 -- Arbitrary instances


### PR DESCRIPTION
# Description

This PR exposes multi-part hashing into the API of the `cardano-crypto-class` package.
We already have the FFI functionality to libsodium, but lacked a convenient way to use it.
I put together an implementation in https://github.com/IntersectMBO/cardano-ledger/pull/5572, but this really is the right place for it so we can implement this functionality for all hashing algos that allow it.

This patch includes a typeclass for incremental hashing, and an implementation for `Blake2b`. Adding an implementation for SHA afterwards should be straightforward. 

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#changelogmd))
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process))
- [x] Self-reviewed the diff
