### PR TITLE
implement audit findings

### DIFF
--- a/cardano-crypto-class/CHANGELOG.md
+++ b/cardano-crypto-class/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.4.0.1
 
-*
+* Remove constructors of `BLS12381SignContext` from export; use `minSigPoPDST` or `minVerKeyPoPDST` for the standard PoP ciphersuites.
 
 ## 2.4.0.0
 

--- a/cardano-crypto-class/CHANGELOG.md
+++ b/cardano-crypto-class/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog for `cardano-crypto-class`
 
-## 2.4.0.1
+## 2.5.0.0
 
 * Remove constructors of `BLS12381SignContext` from export; use `minSigPoPDST` or `minVerKeyPoPDST` for the standard PoP ciphersuites.
 

--- a/cardano-crypto-class/bench/Bench/Crypto/DSIGN.hs
+++ b/cardano-crypto-class/bench/Bench/Crypto/DSIGN.hs
@@ -29,7 +29,7 @@ import Cardano.Crypto.Hash.Blake2b
 import Criterion
 
 import Bench.Crypto.BenchData
-import Cardano.Crypto.DSIGN.BLS12381 (BLS12381MinSigDSIGN, BLS12381MinVerKeyDSIGN, BLS12381DSIGN, BLS12381SignContext (..))
+import Cardano.Crypto.DSIGN.BLS12381.Internal (BLS12381MinSigDSIGN, BLS12381MinVerKeyDSIGN, BLS12381DSIGN, BLS12381SignContext (..))
 
 benchmarks :: Benchmark
 benchmarks = bgroup "DSIGN"

--- a/cardano-crypto-class/cardano-crypto-class.cabal
+++ b/cardano-crypto-class/cardano-crypto-class.cabal
@@ -63,7 +63,7 @@ library
   hs-source-dirs: src
   exposed-modules:
     Cardano.Crypto.DSIGN
-    Cardano.Crypto.DSIGN.BLS12381
+    Cardano.Crypto.DSIGN.BLS12381.Internal
     Cardano.Crypto.DSIGN.Class
     Cardano.Crypto.DSIGN.Ed25519
     Cardano.Crypto.DSIGN.Ed448

--- a/cardano-crypto-class/cardano-crypto-class.cabal
+++ b/cardano-crypto-class/cardano-crypto-class.cabal
@@ -63,6 +63,7 @@ library
   hs-source-dirs: src
   exposed-modules:
     Cardano.Crypto.DSIGN
+    Cardano.Crypto.DSIGN.BLS12381
     Cardano.Crypto.DSIGN.BLS12381.Internal
     Cardano.Crypto.DSIGN.Class
     Cardano.Crypto.DSIGN.Ed25519

--- a/cardano-crypto-class/cardano-crypto-class.cabal
+++ b/cardano-crypto-class/cardano-crypto-class.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-crypto-class
-version: 2.4.0.0
+version: 2.5.0.0
 synopsis:
   Type classes abstracting over cryptography primitives for Cardano
 

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/BLS12381.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/BLS12381.hs
@@ -90,7 +90,6 @@ import Cardano.Crypto.EllipticCurve.BLS12_381.Internal (
   blsIsInf,
   blsMult,
   blsUncompress,
-  blsZero,
   c_blst_keygen,
   compressedSizePoint,
   finalVerifyPairs,
@@ -493,27 +492,35 @@ instance
     deriving anyclass (NFData)
 
   {-# INLINE uncheckedAggregateVerKeysDSIGN #-}
-  uncheckedAggregateVerKeysDSIGN verKeys = do
-    -- Sum the verification keys as curve points
-    let aggrPoint =
-          F.foldl' blsAddOrDouble (blsZero @curve) (map verKeyToPoint verKeys)
-    -- Unlikely case, but best to reject infinity as an aggregate verification
-    -- key. This happens if, for every secret/verification key pair, the inverse
-    -- of each secret key (and thus also the verification key) is also present
-    -- in the list.
-    if blsIsInf @curve aggrPoint
-      then Left "aggregateVerKeysDSIGN: aggregated verification key is infinity"
-      else Right $ VerKeyBLS12381 aggrPoint
+  uncheckedAggregateVerKeysDSIGN verKeys =
+    -- Reject any input verification key that is the infinity point
+    if any (blsIsInf @curve . verKeyToPoint) verKeys
+      then Left "uncheckedAggregateVerKeysDSIGN: input verification key is infinity"
+      else case map verKeyToPoint verKeys of
+        [] -> Left "uncheckedAggregateVerKeysDSIGN: empty list of verification keys"
+        (p : ps) ->
+          let aggrPoint = F.foldl' blsAddOrDouble p ps
+           in -- Unlikely case, but best to reject infinity as an aggregate verification
+              -- key. This happens if, for every secret/verification key pair, the inverse
+              -- of each secret key (and thus also the verification key) is also present
+              -- in the list.
+              if blsIsInf @curve aggrPoint
+                then Left "uncheckedAggregateVerKeysDSIGN: aggregated verification key is infinity"
+                else Right $ VerKeyBLS12381 aggrPoint
 
   {-# INLINE aggregateSigsDSIGN #-}
-  aggregateSigsDSIGN sigs = do
-    -- Sum the signatures as curve points
-    let aggrPoint =
-          F.foldl' blsAddOrDouble (blsZero @(DualCurve curve)) (map sigToPoint sigs)
-    -- Unlikely case, but best to reject infinity as an aggregate signature
-    if blsIsInf @(DualCurve curve) aggrPoint
-      then Left "aggregateSigsDSIGN: aggregated signature is infinity"
-      else Right $ SigBLS12381 aggrPoint
+  aggregateSigsDSIGN sigs =
+    -- Reject any input signature that is the infinity point
+    if any (blsIsInf @(DualCurve curve) . sigToPoint) sigs
+      then Left "aggregateSigsDSIGN: input signature is infinity"
+      else case map sigToPoint sigs of
+        [] -> Left "aggregateSigsDSIGN: empty list of signatures"
+        (p : ps) ->
+          let aggrPoint = F.foldl' blsAddOrDouble p ps
+           in -- Unlikely case, but best to reject infinity as an aggregate signature
+              if blsIsInf @(DualCurve curve) aggrPoint
+                then Left "aggregateSigsDSIGN: aggregated signature is infinity"
+                else Right $ SigBLS12381 aggrPoint
 
   {-# INLINE createPossessionProofDSIGN #-}
   createPossessionProofDSIGN BLS12381SignContext {blsSignContextDst = dst, blsSignContextAug = aug} (SignKeyBLS12381 skScalar) =

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/BLS12381.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/BLS12381.hs
@@ -1,0 +1,8 @@
+module Cardano.Crypto.DSIGN.BLS12381 (
+  module X,
+  BLS12381SignContext,
+)
+where
+
+import Cardano.Crypto.DSIGN.BLS12381.Internal (BLS12381SignContext)
+import Cardano.Crypto.DSIGN.BLS12381.Internal as X hiding (BLS12381SignContext)

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/BLS12381.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/BLS12381.hs
@@ -382,7 +382,11 @@ instance
     -- That is, the deserialised point is in the subgroup of Curve1/Curve2.
     case blsUncompress @curve bs of
       Left _ -> Nothing
-      Right vkPsb -> Just (VerKeyBLS12381 vkPsb)
+      Right vkPsb ->
+        -- Reject the identity (point at infinity) as a verification key
+        if blsIsInf @curve vkPsb
+          then Nothing
+          else Just (VerKeyBLS12381 vkPsb)
 
   {-# INLINE rawDeserialiseSignKeyDSIGN #-}
   rawDeserialiseSignKeyDSIGN bs =
@@ -392,7 +396,11 @@ instance
     -- they are valid Scalars, i.e., less than the curve order (255 bits).
     case scalarFromBS bs of
       Left _ -> Nothing
-      Right skScalar -> Just (SignKeyBLS12381 skScalar)
+      Right skScalar ->
+        -- Reject the zero scalar as a signing key
+        if BS.all (== 0) (scalarToBS skScalar)
+          then Nothing
+          else Just (SignKeyBLS12381 skScalar)
 
   {-# INLINE rawDeserialiseSigDSIGN #-}
   rawDeserialiseSigDSIGN bs =

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/BLS12381.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/BLS12381.hs
@@ -500,11 +500,12 @@ instance
     deriving anyclass (NFData)
 
   {-# INLINE uncheckedAggregateVerKeysDSIGN #-}
-  uncheckedAggregateVerKeysDSIGN verKeys =
+  uncheckedAggregateVerKeysDSIGN verKeys = do
+    let verKeyPoints = map verKeyToPoint verKeys
     -- Reject any input verification key that is the infinity point
-    if any (blsIsInf @curve . verKeyToPoint) verKeys
+    if any (blsIsInf @curve) verKeyPoints
       then Left "uncheckedAggregateVerKeysDSIGN: input verification key is infinity"
-      else case map verKeyToPoint verKeys of
+      else case verKeyPoints of
         [] -> Left "uncheckedAggregateVerKeysDSIGN: empty list of verification keys"
         (p : ps) ->
           let aggrPoint = F.foldl' blsAddOrDouble p ps
@@ -517,11 +518,12 @@ instance
                 else Right $ VerKeyBLS12381 aggrPoint
 
   {-# INLINE aggregateSigsDSIGN #-}
-  aggregateSigsDSIGN sigs =
+  aggregateSigsDSIGN sigs = do
+    let sigPoints = map sigToPoint sigs
     -- Reject any input signature that is the infinity point
-    if any (blsIsInf @(DualCurve curve) . sigToPoint) sigs
+    if any (blsIsInf @(DualCurve curve)) sigPoints
       then Left "aggregateSigsDSIGN: input signature is infinity"
-      else case map sigToPoint sigs of
+      else case sigPoints of
         [] -> Left "aggregateSigsDSIGN: empty list of signatures"
         (p : ps) ->
           let aggrPoint = F.foldl' blsAddOrDouble p ps

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/BLS12381.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/BLS12381.hs
@@ -447,7 +447,10 @@ instance
           -- through the size checks.
           Right mu1Point <- pure $ blsUncompress @(DualCurve curve) mu1Bs
           Right mu2Point <- pure $ blsUncompress @(DualCurve curve) mu2Bs
-          Just $ PossessionProofBLS12381 mu1Point mu2Point
+          -- Reject the zero point (point at infinity) for both mu1 and mu2
+          if blsIsInf @(DualCurve curve) mu1Point || blsIsInf @(DualCurve curve) mu2Point
+            then Nothing
+            else Just $ PossessionProofBLS12381 mu1Point mu2Point
 
 deriving stock instance
   BLS (DualCurve curve) =>

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/BLS12381.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/BLS12381.hs
@@ -26,6 +26,8 @@ module Cardano.Crypto.DSIGN.BLS12381 (
   SigDSIGN (..),
   PossessionProofDSIGN (..),
   BLS12381SignContext (..),
+  minSigPoPDST,
+  minVerKeyPoPDST,
 ) where
 
 #include "blst_util.h"
@@ -130,16 +132,116 @@ data BLS12381DSIGN curve
 -- intended type safety:
 type role BLS12381DSIGN nominal
 
--- | Two versions of BLS12-381 DSIGN: one optimized for minimal verification key size,
--- the other for minimal signature size.
+-- | The BLS12-381 minimal verification key size variant
 type BLS12381MinVerKeyDSIGN = BLS12381DSIGN Curve1
 
+-- | The BLS12-381 minimal signature size variant
 type BLS12381MinSigDSIGN = BLS12381DSIGN Curve2
+
+-- | The BLS12381 signing context for the "PoP" based ciphersuite for the minimal signature size variant of bls signatures
+minSigPoPDST :: BLS12381SignContext
+minSigPoPDST = BLS12381SignContext (Just "BLS_SIG_BLS12381G1_XMD:SHA-256_SSWU_RO_POP_") Nothing
+
+-- | The BLS12381 signing context for the "PoP" based ciphersuite for the minimal verification key size variant of bls signatures
+minVerKeyPoPDST :: BLS12381SignContext
+minVerKeyPoPDST = BLS12381SignContext (Just "BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_") Nothing
 
 type family CurveVariant (c :: Type) :: Symbol where
   CurveVariant Curve1 = "BLS-Signature-Mininimal-Verification-Key-Size"
   CurveVariant Curve2 = "BLS-Signature-Mininimal-Signature-Size"
 
+-- | This module advicese to only the proof-of-possession (PoP) ciphersuite
+-- contexts:
+--
+-- * 'minSigPoPDST'
+-- * 'minVerKeyPoPDST'
+--
+-- even though the underlying signing and verification primitives can be used
+-- to realise the Basic (@NUL@) and message-augmentation (@AUG@) schemes as
+-- well.
+--
+-- == Why only the "PoP" ciphersuite is exported
+--
+-- The main reason is API clarity and safety.
+--
+-- The IETF BLS draft defines three schemes:
+--
+-- * __Basic__ (@NUL@): aggregation is safe only when all messages in an
+--   aggregate are distinct.
+--
+-- * __Message augmentation__ (@AUG@): aggregation is made safe by signing
+--   @PK || message@ instead of just @message@.
+--
+-- * __Proof of possession__ (@POP@): aggregation is made safe by requiring a
+--   separate proof that each public key owner knows the corresponding secret
+--   key.
+--
+-- In this module, the supported aggregation workflow is the PoP one:
+--
+-- * create a proof of possession with 'createPossessionProofDSIGN'
+-- * verify it with 'verifyPossessionProofDSIGN'
+-- * aggregate verification keys with 'uncheckedAggregateVerKeysDSIGN' only
+--   after the relevant proofs have been checked
+-- * aggregate signatures with 'aggregateSigsDSIGN'
+--
+-- By contrast, this module does /not/ provide the draft's general
+-- @AggregateVerify((PK_1, ..., PK_n), (message_1, ..., message_n), signature)@
+-- API for aggregation over different messages.  Exporting predefined Basic and
+-- AUG contexts would therefore suggest a broader aggregate-signature API than
+-- the module actually offers.
+--
+-- Restricting the public ciphersuite exports to PoP makes the intended usage
+-- explicit: this module supports ordinary BLS signing and verification, plus a
+-- PoP-based aggregation story.
+--
+-- == What the exported contexts mean
+--
+-- The exported values are standard BLS ciphersuite DSTs from
+-- draft-irtf-cfrg-bls-signature-06, Section 4.2:
+--
+-- * 'minSigPoPDST' selects the __minimal-signature-size__ variant:
+--   signatures live in G1 (48 bytes compressed), public keys in G2
+--   (96 bytes compressed).
+--
+-- * 'minVerKeyPoPDST' selects the __minimal-pubkey-size__ variant:
+--   public keys live in G1 (48 bytes compressed), signatures in G2
+--   (96 bytes compressed).
+--
+-- The draft recommends the minimal-pubkey-size variant for aggregation,
+-- because the size of @(PK_1, ..., PK_n, signature)@ is usually dominated by
+-- the public keys. Other protocols, like Leios, might favor minimal-signature-size.
+--
+-- == Example
+--
+-- A typical same-message aggregation workflow is:
+--
+-- @
+-- -- Minimal-pubkey-size PoP ciphersuite
+-- let ctx = minVerKeyPoPDST
+--
+-- -- Each participant has a signing key and derived verification key
+-- let vk1 = deriveVerKeyDSIGN sk1
+--     vk2 = deriveVerKeyDSIGN sk2
+--
+-- -- Each participant proves possession of its secret key
+-- let pop1 = createPossessionProofDSIGN ctx sk1
+--     pop2 = createPossessionProofDSIGN ctx sk2
+--
+-- verifyPossessionProofDSIGN ctx vk1 pop1
+-- verifyPossessionProofDSIGN ctx vk2 pop2
+--
+-- -- Once the proofs have been checked, it is safe to aggregate keys
+-- Right avk <- uncheckedAggregateVerKeysDSIGN [vk1, vk2]
+--
+-- -- Both participants sign the same message
+-- let sig1 = signDSIGN ctx msg sk1
+--     sig2 = signDSIGN ctx msg sk2
+--
+-- Right asig <- aggregateSigsDSIGN [sig1, sig2]
+--
+-- -- The aggregate signature can then be checked against the aggregate key
+-- verifyDSIGN ctx avk msg asig
+-- @
 data BLS12381SignContext = BLS12381SignContext
   { blsSignContextDst :: !(Maybe ByteString)
   , blsSignContextAug :: !(Maybe ByteString)

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/BLS12381/Internal.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/BLS12381/Internal.hs
@@ -149,7 +149,7 @@ type family CurveVariant (c :: Type) :: Symbol where
   CurveVariant Curve1 = "BLS-Signature-Mininimal-Verification-Key-Size"
   CurveVariant Curve2 = "BLS-Signature-Mininimal-Signature-Size"
 
--- | This module advicese to only the proof-of-possession (PoP) ciphersuite
+-- | This module provides support only for proof-of-possession (PoP) ciphersuite
 -- contexts:
 --
 -- * 'minSigPoPDST'

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/BLS12381/Internal.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/BLS12381/Internal.hs
@@ -16,7 +16,7 @@
 {-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-module Cardano.Crypto.DSIGN.BLS12381 (
+module Cardano.Crypto.DSIGN.BLS12381.Internal (
   BLS12381DSIGN,
   BLS12381MinVerKeyDSIGN,
   BLS12381MinSigDSIGN,

--- a/cardano-crypto-class/src/Cardano/Crypto/EllipticCurve/BLS12_381/Internal.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/EllipticCurve/BLS12_381/Internal.hs
@@ -856,7 +856,7 @@ foreign import ccall "cardano_blst_error_bad_scalar" c_blst_error_bad_scalar :: 
 
 ---- Utility functions
 
-foreign import ccall "memcmp" c_memcmp :: Ptr a -> Ptr a -> CSize -> IO CSize
+foreign import ccall "memcmp" c_memcmp :: Ptr a -> Ptr a -> CSize -> IO CInt
 foreign import ccall "blst_bendian_from_scalar"
   c_blst_bendian_from_scalar :: Ptr CChar -> ScalarPtr -> IO ()
 

--- a/cardano-crypto-class/src/Cardano/Crypto/EllipticCurve/BLS12_381/Internal.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/EllipticCurve/BLS12_381/Internal.hs
@@ -201,7 +201,7 @@ import Foreign.C.String
 import Foreign.C.Types
 import Foreign.ForeignPtr
 import Foreign.Marshal.Alloc (allocaBytes)
-import Foreign.Marshal.Utils (copyBytes)
+import Foreign.Marshal.Utils (copyBytes, fromBool, toBool)
 import Foreign.Ptr (Ptr, castPtr, nullPtr, plusPtr)
 import GHC.TypeLits (KnownNat, Nat, natVal)
 import NoThunks.Class (NoThunks (..))
@@ -495,11 +495,11 @@ class
   sizeAffine_ _ = fromInteger (natVal (Proxy @(AffineSize curve)))
 
 instance BLS Curve1 where
-  c_blst_on_curve = c_blst_p1_on_curve
+  c_blst_on_curve p = toBool <$> c_blst_p1_on_curve p
 
   c_blst_add_or_double = c_blst_p1_add_or_double
   c_blst_mult = c_blst_p1_mult
-  c_blst_cneg = c_blst_p1_cneg
+  c_blst_cneg p bool = c_blst_p1_cneg p (fromBool bool)
 
   c_blst_scratch_sizeof _ = c_blst_p1s_mult_pippenger_scratch_sizeof
   c_blst_to_affines = c_blst_p1s_to_affine
@@ -511,27 +511,26 @@ instance BLS Curve1 where
   c_blst_uncompress = c_blst_p1_uncompress
   c_blst_deserialize = c_blst_p1_deserialize
 
-  c_blst_in_g = c_blst_p1_in_g1
+  c_blst_in_g p = toBool <$> c_blst_p1_in_g1 p
   c_blst_to_affine = c_blst_p1_to_affine
   c_blst_from_affine = c_blst_p1_from_affine
-  c_blst_affine_in_g = c_blst_p1_affine_in_g1
+  c_blst_affine_in_g p = toBool <$> c_blst_p1_affine_in_g1 p
 
   c_blst_generator = c_blst_p1_generator
 
-  c_blst_p_is_equal = c_blst_p1_is_equal
-  c_blst_p_is_inf = c_blst_p1_is_inf
-  c_blst_core_verify = c_blst_core_verify_pk_in_g1
-
+  c_blst_p_is_equal p q = toBool <$> c_blst_p1_is_equal p q
+  c_blst_p_is_inf p = toBool <$> c_blst_p1_is_inf p
+  c_blst_core_verify p1 p2 bool = c_blst_core_verify_pk_in_g1 p1 p2 (fromBool bool)
   c_blst_sk_to_pk = c_blst_sk_to_pk_in_g1
   c_blst_sign = c_blst_sign_pk_in_g1
   millerSide (g1, g2) = millerLoop g1 g2
 
 instance BLS Curve2 where
-  c_blst_on_curve = c_blst_p2_on_curve
+  c_blst_on_curve p = toBool <$> c_blst_p2_on_curve p
 
   c_blst_add_or_double = c_blst_p2_add_or_double
   c_blst_mult = c_blst_p2_mult
-  c_blst_cneg = c_blst_p2_cneg
+  c_blst_cneg p bool = c_blst_p2_cneg p (fromBool bool)
 
   c_blst_scratch_sizeof _ = c_blst_p2s_mult_pippenger_scratch_sizeof
   c_blst_to_affines = c_blst_p2s_to_affine
@@ -543,19 +542,19 @@ instance BLS Curve2 where
   c_blst_uncompress = c_blst_p2_uncompress
   c_blst_deserialize = c_blst_p2_deserialize
 
-  c_blst_in_g = c_blst_p2_in_g2
+  c_blst_in_g p = toBool <$> c_blst_p2_in_g2 p
   c_blst_to_affine = c_blst_p2_to_affine
   c_blst_from_affine = c_blst_p2_from_affine
-  c_blst_affine_in_g = c_blst_p2_affine_in_g2
+  c_blst_affine_in_g p = toBool <$> c_blst_p2_affine_in_g2 p
 
   c_blst_generator = c_blst_p2_generator
 
-  c_blst_p_is_equal = c_blst_p2_is_equal
-  c_blst_p_is_inf = c_blst_p2_is_inf
+  c_blst_p_is_equal p q = toBool <$> c_blst_p2_is_equal p q
+  c_blst_p_is_inf p = toBool <$> c_blst_p2_is_inf p
 
   c_blst_sk_to_pk = c_blst_sk_to_pk_in_g2
   c_blst_sign = c_blst_sign_pk_in_g2
-  c_blst_core_verify = c_blst_core_verify_pk_in_g2
+  c_blst_core_verify p2 p1 bool = c_blst_core_verify_pk_in_g2 p2 p1 (fromBool bool)
   millerSide (g2, g1) = millerLoop g1 g2
 
 instance BLS curve => Eq (Affine curve) where
@@ -701,12 +700,12 @@ newtype ScratchPtr = ScratchPtr (Ptr Void)
 
 ---- Raw Scalar / Fr functions
 
-foreign import ccall "blst_scalar_fr_check" c_blst_scalar_fr_check :: ScalarPtr -> IO Bool
+foreign import ccall "blst_scalar_fr_check" c_blst_scalar_fr_check :: ScalarPtr -> IO CBool
 
 foreign import ccall "blst_scalar_from_fr" c_blst_scalar_from_fr :: ScalarPtr -> FrPtr -> IO ()
 foreign import ccall "blst_fr_from_scalar" c_blst_fr_from_scalar :: FrPtr -> ScalarPtr -> IO ()
 foreign import ccall "blst_scalar_from_be_bytes"
-  c_blst_scalar_from_be_bytes :: ScalarPtr -> Ptr CChar -> CSize -> IO Bool
+  c_blst_scalar_from_be_bytes :: ScalarPtr -> Ptr CChar -> CSize -> IO CBool
 foreign import ccall "blst_scalar_from_bendian"
   c_blst_scalar_from_bendian :: ScalarPtr -> Ptr CChar -> IO ()
 foreign import ccall "blst_keygen"
@@ -714,13 +713,13 @@ foreign import ccall "blst_keygen"
 
 ---- Raw Point1 functions
 
-foreign import ccall "blst_p1_on_curve" c_blst_p1_on_curve :: Point1Ptr -> IO Bool
+foreign import ccall "blst_p1_on_curve" c_blst_p1_on_curve :: Point1Ptr -> IO CBool
 
 foreign import ccall "blst_p1_add_or_double"
   c_blst_p1_add_or_double :: Point1Ptr -> Point1Ptr -> Point1Ptr -> IO ()
 foreign import ccall "blst_p1_mult"
   c_blst_p1_mult :: Point1Ptr -> Point1Ptr -> ScalarPtr -> CSize -> IO ()
-foreign import ccall "blst_p1_cneg" c_blst_p1_cneg :: Point1Ptr -> Bool -> IO ()
+foreign import ccall "blst_p1_cneg" c_blst_p1_cneg :: Point1Ptr -> CBool -> IO ()
 
 foreign import ccall "blst_hash_to_g1"
   c_blst_hash_to_g1 ::
@@ -731,12 +730,12 @@ foreign import ccall "blst_p1_uncompress" c_blst_p1_uncompress :: Affine1Ptr -> 
 foreign import ccall "blst_p1_deserialize"
   c_blst_p1_deserialize :: Affine1Ptr -> Ptr CChar -> IO CInt
 
-foreign import ccall "blst_p1_in_g1" c_blst_p1_in_g1 :: Point1Ptr -> IO Bool
+foreign import ccall "blst_p1_in_g1" c_blst_p1_in_g1 :: Point1Ptr -> IO CBool
 
 foreign import ccall "blst_p1_generator" c_blst_p1_generator :: Point1Ptr
 
-foreign import ccall "blst_p1_is_equal" c_blst_p1_is_equal :: Point1Ptr -> Point1Ptr -> IO Bool
-foreign import ccall "blst_p1_is_inf" c_blst_p1_is_inf :: Point1Ptr -> IO Bool
+foreign import ccall "blst_p1_is_equal" c_blst_p1_is_equal :: Point1Ptr -> Point1Ptr -> IO CBool
+foreign import ccall "blst_p1_is_inf" c_blst_p1_is_inf :: Point1Ptr -> IO CBool
 
 foreign import ccall "blst_sk_to_pk_in_g1"
   c_blst_sk_to_pk_in_g1 :: Point1Ptr -> ScalarPtr -> IO ()
@@ -753,13 +752,13 @@ foreign import ccall "blst_p1s_mult_pippenger"
 
 ---- Raw Point2 functions
 
-foreign import ccall "blst_p2_on_curve" c_blst_p2_on_curve :: Point2Ptr -> IO Bool
+foreign import ccall "blst_p2_on_curve" c_blst_p2_on_curve :: Point2Ptr -> IO CBool
 
 foreign import ccall "blst_p2_add_or_double"
   c_blst_p2_add_or_double :: Point2Ptr -> Point2Ptr -> Point2Ptr -> IO ()
 foreign import ccall "blst_p2_mult"
   c_blst_p2_mult :: Point2Ptr -> Point2Ptr -> ScalarPtr -> CSize -> IO ()
-foreign import ccall "blst_p2_cneg" c_blst_p2_cneg :: Point2Ptr -> Bool -> IO ()
+foreign import ccall "blst_p2_cneg" c_blst_p2_cneg :: Point2Ptr -> CBool -> IO ()
 
 foreign import ccall "blst_hash_to_g2"
   c_blst_hash_to_g2 ::
@@ -770,12 +769,12 @@ foreign import ccall "blst_p2_uncompress" c_blst_p2_uncompress :: Affine2Ptr -> 
 foreign import ccall "blst_p2_deserialize"
   c_blst_p2_deserialize :: Affine2Ptr -> Ptr CChar -> IO CInt
 
-foreign import ccall "blst_p2_in_g2" c_blst_p2_in_g2 :: Point2Ptr -> IO Bool
+foreign import ccall "blst_p2_in_g2" c_blst_p2_in_g2 :: Point2Ptr -> IO CBool
 
 foreign import ccall "blst_p2_generator" c_blst_p2_generator :: Point2Ptr
 
-foreign import ccall "blst_p2_is_equal" c_blst_p2_is_equal :: Point2Ptr -> Point2Ptr -> IO Bool
-foreign import ccall "blst_p2_is_inf" c_blst_p2_is_inf :: Point2Ptr -> IO Bool
+foreign import ccall "blst_p2_is_equal" c_blst_p2_is_equal :: Point2Ptr -> Point2Ptr -> IO CBool
+foreign import ccall "blst_p2_is_inf" c_blst_p2_is_inf :: Point2Ptr -> IO CBool
 
 foreign import ccall "blst_sk_to_pk_in_g2"
   c_blst_sk_to_pk_in_g2 :: Point2Ptr -> ScalarPtr -> IO ()
@@ -801,14 +800,14 @@ foreign import ccall "blst_p1_from_affine"
 foreign import ccall "blst_p2_from_affine"
   c_blst_p2_from_affine :: PointPtr Curve2 -> AffinePtr Curve2 -> IO ()
 
-foreign import ccall "blst_p1_affine_in_g1" c_blst_p1_affine_in_g1 :: AffinePtr Curve1 -> IO Bool
-foreign import ccall "blst_p2_affine_in_g2" c_blst_p2_affine_in_g2 :: AffinePtr Curve2 -> IO Bool
+foreign import ccall "blst_p1_affine_in_g1" c_blst_p1_affine_in_g1 :: AffinePtr Curve1 -> IO CBool
+foreign import ccall "blst_p2_affine_in_g2" c_blst_p2_affine_in_g2 :: AffinePtr Curve2 -> IO CBool
 
 ---- PT operations
 
 foreign import ccall "blst_fp12_mul" c_blst_fp12_mul :: PTPtr -> PTPtr -> PTPtr -> IO ()
-foreign import ccall "blst_fp12_is_equal" c_blst_fp12_is_equal :: PTPtr -> PTPtr -> IO Bool
-foreign import ccall "blst_fp12_finalverify" c_blst_fp12_finalverify :: PTPtr -> PTPtr -> IO Bool
+foreign import ccall "blst_fp12_is_equal" c_blst_fp12_is_equal :: PTPtr -> PTPtr -> IO CBool
+foreign import ccall "blst_fp12_finalverify" c_blst_fp12_finalverify :: PTPtr -> PTPtr -> IO CBool
 
 ---- Pairing
 
@@ -821,7 +820,7 @@ foreign import ccall "blst_core_verify_pk_in_g1"
   c_blst_core_verify_pk_in_g1 ::
     Affine1Ptr ->
     Affine2Ptr ->
-    Bool ->
+    CBool ->
     Ptr CChar ->
     CSize ->
     Ptr CChar ->
@@ -834,7 +833,7 @@ foreign import ccall "blst_core_verify_pk_in_g2"
   c_blst_core_verify_pk_in_g2 ::
     Affine2Ptr ->
     Affine1Ptr ->
-    Bool ->
+    CBool ->
     Ptr CChar ->
     CSize ->
     Ptr CChar ->
@@ -1078,7 +1077,7 @@ scalarFromBS bs = unsafePerformIO $ do
       then do
         (success, scalar) <- withNewScalar $ \scalarPtr ->
           c_blst_scalar_from_be_bytes scalarPtr cstr (fromIntegral @Int @CSize l)
-        if success
+        if toBool success
           then return $ Right scalar
           else return $ Left BLST_BAD_SCALAR
       else return $ Left BLST_BAD_SCALAR
@@ -1096,7 +1095,7 @@ scalarToBS scalar = BSI.fromForeignPtr (castForeignPtr ptr) 0 sizeScalar
 scalarCanonical :: Scalar -> Bool
 scalarCanonical scalar =
   unsafePerformIO $
-    withScalar scalar c_blst_scalar_fr_check
+    toBool <$> withScalar scalar c_blst_scalar_fr_check
 
 ---- MSM operations
 
@@ -1184,14 +1183,14 @@ ptMult a b = unsafePerformIO $
 ptEq :: PT -> PT -> Bool
 ptEq a b = unsafePerformIO $
   withPT a $ \ap ->
-    withPT b $ \bp ->
-      c_blst_fp12_is_equal ap bp
+    withPT b $
+      fmap toBool . c_blst_fp12_is_equal ap
 
 ptFinalVerify :: PT -> PT -> Bool
 ptFinalVerify a b = unsafePerformIO $
   withPT a $ \ap ->
-    withPT b $ \bp ->
-      c_blst_fp12_finalverify ap bp
+    withPT b $
+      fmap toBool . c_blst_fp12_finalverify ap
 
 instance Eq PT where
   (==) = ptEq

--- a/cardano-crypto-class/src/Cardano/Crypto/EllipticCurve/BLS12_381/Internal.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/EllipticCurve/BLS12_381/Internal.hs
@@ -117,7 +117,6 @@ module Cardano.Crypto.EllipticCurve.BLS12_381.Internal (
   withNewAffine_,
   withNewAffine',
   withPointArray,
-  withAffineBlockArrayPtr,
   sizePT,
   withPT,
   withNewPT,
@@ -188,7 +187,6 @@ where
 
 import Cardano.Crypto.PinnedSizedBytes (PinnedSizedBytes, psbCreate, psbCreateResult, psbUseAsCPtr)
 import Control.DeepSeq (NFData (..))
-import Control.Monad (forM_)
 import Data.Bits (shiftL, shiftR, (.|.))
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
@@ -224,7 +222,7 @@ type family DualCurve curve = dual | dual -> curve where
 -- | A pointer to a (projective) point one of the two elliptical curves
 newtype PointPtr curve = PointPtr (Ptr Word8)
 
--- | A pointer to a null-terminated array of pointers to points
+-- | A pointer to an array of pointers to points
 newtype PointArrayPtr curve = PointArrayPtr (Ptr Void)
 
 type Point1Ptr = PointPtr Curve1
@@ -239,7 +237,7 @@ newtype AffinePtr curve = AffinePtr (Ptr Word8)
 -- | A pointer to a contiguous array of affine points
 newtype AffineBlockPtr curve = AffineBlockPtr (Ptr Void)
 
--- | A pointer to a null-terminated array of pointers to affine points
+-- | A pointer to an array of pointers to affine points
 newtype AffineArrayPtr curve = AffineArrayPtr (Ptr Void)
 
 type Affine1Ptr = AffinePtr Curve1
@@ -385,36 +383,18 @@ withPointArray :: [Point curve] -> (Int -> PointArrayPtr curve -> IO a) -> IO a
 withPointArray points go = do
   let numPoints = length points
       sizeReference = sizeOf (nullPtr :: Ptr ())
-  -- Allocate space for the points and a null terminator
-  allocaBytes ((numPoints + 1) * sizeReference) $ \ptr ->
+  allocaBytes (numPoints * sizeReference) $ \ptr ->
     -- The accumulate function ensures that each `withPoint` call is properly nested.
     -- This guarantees that the foreign pointers remain valid while we populate `ptr`.
     -- If we instead used `zipWithM_` for example, the pointers could be finalized too early.
     -- By nesting `withPoint` calls in `accumulate`, we ensure they stay in scope until `go` is executed.
-    let accumulate curPtr [] = do
-          poke curPtr nullPtr
+    let accumulate _ [] =
           go numPoints (PointArrayPtr (castPtr ptr))
         accumulate curPtr (point : rest) =
           withPoint point $ \(PointPtr pPtr) -> do
             poke curPtr pPtr
             accumulate (curPtr `plusPtr` sizeReference) rest
      in accumulate ptr points
-
--- | Given a block of affine points and a count, produce a pointer array
-withAffineBlockArrayPtr ::
-  forall curve a.
-  BLS curve =>
-  Ptr Void ->
-  Int ->
-  (AffineArrayPtr curve -> IO a) ->
-  IO a
-withAffineBlockArrayPtr affinesBlockPtr numPoints go = do
-  allocaBytes (numPoints * sizeOf (nullPtr :: Ptr ())) $ \affineVectorPtr -> do
-    let ptrArray = castPtr affineVectorPtr :: Ptr (Ptr ())
-    forM_ [0 .. numPoints - 1] $ \i -> do
-      let ptr = affinesBlockPtr `plusPtr` (i * sizeAffine (Proxy @curve))
-      pokeElemOff ptrArray i ptr
-    go (AffineArrayPtr affineVectorPtr)
 
 withPT :: PT -> (PTPtr -> IO a) -> IO a
 withPT (PT psb) go = psbUseAsCPtr psb $ \ptr ->
@@ -617,14 +597,12 @@ withScalarArray :: [Scalar] -> (Int -> ScalarArrayPtr -> IO a) -> IO a
 withScalarArray scalars go = do
   let numScalars = length scalars
       sizeReference = sizeOf (undefined :: Ptr ())
-  -- Allocate space for the scalars and a null terminator
-  allocaBytes ((numScalars + 1) * sizeReference) $ \ptr ->
+  allocaBytes (numScalars * sizeReference) $ \ptr ->
     -- The accumulate function ensures that each `withScalar` call is properly nested.
     -- This guarantees that the foreign pointers remain valid while we populate `ptr`.
     -- If we instead used `zipWithM_` for example, the pointers could be finalized too early.
     -- By nesting `withScalar` calls in `accumulate`, we ensure they stay in scope until `go` is executed.
-    let accumulate curPtr [] = do
-          poke curPtr nullPtr
+    let accumulate _ [] =
           go numScalars (ScalarArrayPtr (castPtr ptr))
         accumulate curPtr (scalar : rest) =
           withScalar scalar $ \(ScalarPtr pPtr) -> do
@@ -715,8 +693,9 @@ scalarFromInteger n = do
 
 newtype ScalarPtr = ScalarPtr (Ptr Word8)
 
--- A pointer to a null-terminated array of pointers to scalars
+-- | A pointer to an array of pointers to scalars
 newtype ScalarArrayPtr = ScalarArrayPtr (Ptr Void)
+
 newtype FrPtr = FrPtr (Ptr Word8)
 newtype ScratchPtr = ScratchPtr (Ptr Void)
 
@@ -1173,7 +1152,17 @@ blsMSM ssAndps = unsafePerformIO $ do
                 scratchSize = fromIntegral @CSize @Int $ c_blst_scratch_sizeof (Proxy @curve) numPoints'
             allocaBytes (numPoints * sizeAffine (Proxy @curve)) $ \affinesBlockPtr -> do
               c_blst_to_affines (AffineBlockPtr affinesBlockPtr) pointArrayPtr numPoints'
-              withAffineBlockArrayPtr affinesBlockPtr numPoints $ \affineArrayPtr -> do
+              -- Mode 2: contiguous block — [ptr_to_block, null] is sufficient
+              -- The affinesBlockPtr is contiguous data, so we use the [block_start, null] calling
+              -- convention: the C function reads block_start on the first iteration,
+              -- then finds null on all subsequent iterations and walks forward via
+              -- point+1 through the contiguous block.
+              -- see: https://github.com/IntersectMBO/cardano-base/pull/635#issuecomment-4178160810
+              allocaBytes (2 * sizeOf (nullPtr :: Ptr ())) $ \affineVectorPtr -> do
+                let ptrArray = castPtr affineVectorPtr :: Ptr (Ptr ())
+                pokeElemOff ptrArray 0 (castPtr affinesBlockPtr)
+                pokeElemOff ptrArray 1 nullPtr
+                let affineArrayPtr = AffineArrayPtr affineVectorPtr
                 allocaBytes scratchSize $ \scratchPtr -> do
                   c_blst_mult_pippenger
                     resultPtr

--- a/cardano-crypto-class/testlib/Test/Crypto/DSIGN.hs
+++ b/cardano-crypto-class/testlib/Test/Crypto/DSIGN.hs
@@ -30,7 +30,7 @@ import Test.QuickCheck (
   counterexample,
   withMaxSuccess,
   )
-import Test.Hspec (Spec, describe)
+import Test.Hspec (Spec, describe, it, shouldBe)
 import Test.Hspec.QuickCheck (prop, modifyMaxSuccess)
 
 import qualified Data.ByteString as BS
@@ -84,7 +84,8 @@ import Cardano.Crypto.DSIGN (
   decodePossessionProofDSIGN
   )
 import Cardano.Binary (FromCBOR, ToCBOR)
-import Cardano.Crypto.EllipticCurve.BLS12_381 (Curve1, Curve2)
+import Cardano.Crypto.EllipticCurve.BLS12_381 (Curve1, Curve2, blsCompress, blsGenerator)
+import Cardano.Crypto.EllipticCurve.BLS12_381.Internal (blsZero)
 import Cardano.Crypto.PinnedSizedBytes (PinnedSizedBytes)
 import Cardano.Crypto.DirectSerialise
 import Test.Crypto.Util (
@@ -224,6 +225,31 @@ tests lock =
      describe "Aggregatable" $ do
       testDSIGNAggregatableWithContext (Proxy @(BLS12381DSIGN Curve1)) blsSignContextGen blsGenKeyWithContextGen (arbitrary @Message) "BLS12381MinVerKeyDSIGN"
       testDSIGNAggregatableWithContext (Proxy @(BLS12381DSIGN Curve2)) blsSignContextGen blsGenKeyWithContextGen (arbitrary @Message) "BLS12381MinSigDSIGN"
+      describe "PoP deserialisation rejects zero points" $ do
+        -- DualCurve Curve1 = Curve2, so MinVerKeyDSIGN PoP points live on Curve2
+        -- DualCurve Curve2 = Curve1, so MinSigDSIGN    PoP points live on Curve1
+        let zeroC1 = blsCompress (blsZero @Curve1)
+            zeroC2 = blsCompress (blsZero @Curve2)
+            genC1  = blsCompress (blsGenerator @Curve1)
+            genC2  = blsCompress (blsGenerator @Curve2)
+        it "BLS12381MinVerKeyDSIGN: mu1 zero, mu2 zero" $
+          rawDeserialisePossessionProofDSIGN @(BLS12381DSIGN Curve1) (zeroC2 <> zeroC2)
+            `shouldBe` Nothing
+        it "BLS12381MinVerKeyDSIGN: mu1 zero, mu2 non-zero" $
+          rawDeserialisePossessionProofDSIGN @(BLS12381DSIGN Curve1) (zeroC2 <> genC2)
+            `shouldBe` Nothing
+        it "BLS12381MinVerKeyDSIGN: mu1 non-zero, mu2 zero" $
+          rawDeserialisePossessionProofDSIGN @(BLS12381DSIGN Curve1) (genC2 <> zeroC2)
+            `shouldBe` Nothing
+        it "BLS12381MinSigDSIGN: mu1 zero, mu2 zero" $
+          rawDeserialisePossessionProofDSIGN @(BLS12381DSIGN Curve2) (zeroC1 <> zeroC1)
+            `shouldBe` Nothing
+        it "BLS12381MinSigDSIGN: mu1 zero, mu2 non-zero" $
+          rawDeserialisePossessionProofDSIGN @(BLS12381DSIGN Curve2) (zeroC1 <> genC1)
+            `shouldBe` Nothing
+        it "BLS12381MinSigDSIGN: mu1 non-zero, mu2 zero" $
+          rawDeserialisePossessionProofDSIGN @(BLS12381DSIGN Curve2) (genC1 <> zeroC1)
+            `shouldBe` Nothing
 
 testDSIGNAlgorithmWithContext :: forall (v :: Type) (a :: Type).
   (DSIGNAlgorithm v,

--- a/cardano-crypto-class/testlib/Test/Crypto/DSIGN.hs
+++ b/cardano-crypto-class/testlib/Test/Crypto/DSIGN.hs
@@ -78,11 +78,12 @@ import Cardano.Crypto.DSIGN (
   BLS12381DSIGN,
 
   DSIGNAggregatable (..),
-  BLS12381SignContext (..),
+  BLS12381SignContext,
   possessionProofSizeDSIGN,
   encodePossessionProofDSIGN,
   decodePossessionProofDSIGN
   )
+import Cardano.Crypto.DSIGN.BLS12381.Internal (BLS12381SignContext (..))
 import Cardano.Binary (FromCBOR, ToCBOR)
 import Cardano.Crypto.EllipticCurve.BLS12_381 (Curve1, Curve2, blsCompress, blsGenerator)
 import Cardano.Crypto.EllipticCurve.BLS12_381.Internal (blsZero)
@@ -150,7 +151,7 @@ blsSignContextGen :: Gen BLS12381SignContext
 blsSignContextGen = do
   dst <- Gen.frequency [(1, pure Nothing), (100, Just . BS.pack <$> arbitrary)]
   aug <- Gen.frequency [(1, pure Nothing), (100, Just . BS.pack <$> arbitrary)]
-  pure BLS12381SignContext {blsSignContextAug = aug, blsSignContextDst = dst}
+  pure $ BLS12381SignContext dst aug
 
 
 #ifdef SECP256K1_ENABLED

--- a/cardano-crypto-class/testlib/Test/Crypto/DSIGN.hs
+++ b/cardano-crypto-class/testlib/Test/Crypto/DSIGN.hs
@@ -250,6 +250,23 @@ tests lock =
         it "BLS12381MinSigDSIGN: mu1 non-zero, mu2 zero" $
           rawDeserialisePossessionProofDSIGN @(BLS12381DSIGN Curve2) (genC1 <> zeroC1)
             `shouldBe` Nothing
+      describe "VerKey and SignKey deserialisation rejects zero" $ do
+        let zeroC1 = blsCompress (blsZero @Curve1)
+            zeroC2 = blsCompress (blsZero @Curve2)
+            -- Scalar size is 32 bytes for both curve variants
+            zeroScalar = BS.replicate 32 0
+        it "BLS12381MinVerKeyDSIGN: zero verification key rejected" $
+          rawDeserialiseVerKeyDSIGN @(BLS12381DSIGN Curve1) zeroC1
+            `shouldBe` Nothing
+        it "BLS12381MinSigDSIGN: zero verification key rejected" $
+          rawDeserialiseVerKeyDSIGN @(BLS12381DSIGN Curve2) zeroC2
+            `shouldBe` Nothing
+        it "BLS12381MinVerKeyDSIGN: zero signing key rejected" $
+          rawDeserialiseSignKeyDSIGN @(BLS12381DSIGN Curve1) zeroScalar
+            `shouldBe` Nothing
+        it "BLS12381MinSigDSIGN: zero signing key rejected" $
+          rawDeserialiseSignKeyDSIGN @(BLS12381DSIGN Curve2) zeroScalar
+            `shouldBe` Nothing
 
 testDSIGNAlgorithmWithContext :: forall (v :: Type) (a :: Type).
   (DSIGNAlgorithm v,


### PR DESCRIPTION
# Description

This PR fixes seven things,

1. It removes the unused termination null pointer from `PointArrayPtr` and in its helper function `withPointArray`. It also removes these null pointers for `AffineArrayPtr` and removes the previously used function `withAffineBlockArrayPtr` as in the usage is no longer needed. This is because `blst_{p1s,p2s}_to_affines` already returns a continuous block of points, and `blst` is flexible in what form it receives its data (the previous method of conversion was not needed). Lastly, this commit also removes the unused termination null pointer from `ScalarArrayPtr` and its helper function `withScalarArray`.

2. It fixed the `memcmp` FFI import, which was incorrectly using `CSize` (unsigned int). Note that the return value of `memcmp` is a signed integer [here](https://www.tutorialspoint.com/c_standard_library/c_function_memcmp.htm). Since we used this function only in
```haskell
eqAffinePtr :: forall curve. BLS curve => AffinePtr curve -> AffinePtr curve -> IO Bool
eqAffinePtr (AffinePtr a) (AffinePtr b) =
  (== 0) <$> c_memcmp (castPtr a) (castPtr b) (sizeAffine_ (Proxy @curve))
```
Where the sign did not matter, it did not cause problems. **(Report finding 3)**

3. Use `CBool` instead of `Bool` in the FFI calls **(Report finding 6)**

4. Serialization of PoP bytes should reject the zero point in the group (point at infinity)  **(Report finding 2)**

5. Add the PoP Cipher suite as per the IETF draft (plus a comment on usage). **(Report finding 4)**

6. Add an extra `blsIsInf` check on inputs that are aggregated for signatures and verification keys. Note that before this change we roughly had the timing
```bash
nix run github:IntersectMBO/cardano-base/c9a6c770c018ccc7195156e70efe6355b1bab76b#cardano-crypto-class:bench:bench -- --match pattern 'DSIGN/BLS12381MinVerKey/Aggregatable/n=300/aggregateVerKeys (no PoPs)'
benchmarking DSIGN/BLS12381MinVerKey/Aggregatable/n=300/aggregateVerKeys (no PoPs)
time                 187.8 μs   (186.8 μs .. 188.7 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 186.7 μs   (186.1 μs .. 187.4 μs)
std dev              2.169 μs   (1.758 μs .. 2.980 μs)
```
Now this becomes
```bash
nix run github:IntersectMBO/cardano-base/1cb297dcf7b75b3a44b5df847161cb7e9394e971#cardano-crypto-class:bench:bench -- --match pattern 'DSIGN/BLS12381MinVerKey/Aggregatable/n=300/aggregateVerKeys (no PoPs)'
benchmarking DSIGN/BLS12381MinVerKey/Aggregatable/n=300/aggregateVerKeys (no PoPs)
time                 197.6 μs   (196.3 μs .. 199.6 μs)
                     0.999 R²   (0.998 R² .. 0.999 R²)
mean                 207.3 μs   (204.6 μs .. 209.7 μs)
std dev              8.305 μs   (7.332 μs .. 9.105 μs)
```
which is not significant, given that we gain safety. **(Report finding 5)**

7. add non-identity check to `rawDeserialiseVerKeyDSIGN` and `rawDeserialiseSignKeyDSIGN`. **(Report finding 8)**

Note that the report has 8 findings, where the above fixes 7. This is because **(report finding 7)** was on [this](https://github.com/IntersectMBO/cardano-base/pull/538) issue, which is already resolved (the audit confirmed it was correctly addressed)

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process))
- [x] Self-reviewed the diff
