### PR TITLE
Lift TotalPeriodsKES to the type level in KESAlgorithm

### DIFF
--- a/cardano-crypto-class/CHANGELOG.md
+++ b/cardano-crypto-class/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.3.2.0
 
+* Lift `TotalPeriodsKES` in `KESAlgorithm` to a type-level associated `Nat` and make `totalPeriodsKES` its default term-level reflection.
 * Add `psbToPackedBytes` to `Cardano.Crypto.PinnedSizedBytes`
 * Add `IncrementalHashAlgorithm` typeclass with `Blake2b_224` and `Blake2b_256` instances
 * Add `withHashContext` and `withHashContextST` for resource management when incremental hashing

--- a/cardano-crypto-class/cardano-crypto-class.cabal
+++ b/cardano-crypto-class/cardano-crypto-class.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-crypto-class
-version: 2.3.2.0
+version: 2.4.0.0
 synopsis:
   Type classes abstracting over cryptography primitives for Cardano
 

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Class.hs
@@ -118,6 +118,7 @@ class
   , KnownNat (VerKeySizeKES v)
   , KnownNat (SignKeySizeKES v)
   , KnownNat (SigSizeKES v)
+  , KnownNat (TotalPeriodsKES v)
   ) =>
   KESAlgorithm v
   where
@@ -132,6 +133,7 @@ class
   type VerKeySizeKES v :: Nat
   type SignKeySizeKES v :: Nat
   type SigSizeKES v :: Nat
+  type TotalPeriodsKES v :: Nat
 
   type SizeVerKeyKES v :: Nat
   type SizeVerKeyKES v = VerKeySizeKES v
@@ -184,6 +186,8 @@ class
   -- periods (period 0 and 1) then there is only one evolution.
   totalPeriodsKES ::
     proxy v -> Word
+  totalPeriodsKES _ =
+    fromIntegral @Integer @Word $ natVal (Proxy @(TotalPeriodsKES v))
 
   --
   -- Serialisation/(de)serialisation in fixed-size raw format

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/CompactSingle.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/CompactSingle.hs
@@ -103,7 +103,7 @@ instance
 
   algorithmNameKES _ = algorithmNameDSIGN (Proxy :: Proxy d) ++ "_kes_2^0"
 
-  totalPeriodsKES _ = 1
+  type TotalPeriodsKES (CompactSingleKES d) = 1
 
   --
   -- Core algorithm operations

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/CompactSum.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/CompactSum.hs
@@ -162,6 +162,7 @@ instance
   , KnownNat (VerKeySizeKES (CompactSumKES h d))
   , KnownNat (SignKeySizeKES (CompactSumKES h d))
   , KnownNat (SigSizeKES (CompactSumKES h d))
+  , KnownNat (2 * TotalPeriodsKES d)
   ) =>
   KESAlgorithm (CompactSumKES h d)
   where
@@ -220,7 +221,7 @@ instance
 
   verifyKES = verifyOptimizedKES
 
-  totalPeriodsKES _ = 2 * totalPeriodsKES (Proxy :: Proxy d)
+  type TotalPeriodsKES (CompactSumKES h d) = 2 * TotalPeriodsKES d
 
   --
   -- raw serialise/deserialise
@@ -410,9 +411,7 @@ instance
   , SodiumHashAlgorithm h
   , HashSize h ~ SeedSizeKES d
   , NoThunks (VerKeyKES (CompactSumKES h d))
-  , KnownNat (VerKeySizeKES (CompactSumKES h d))
-  , KnownNat (SignKeySizeKES (CompactSumKES h d))
-  , KnownNat (SigSizeKES (CompactSumKES h d))
+  , KESAlgorithm (CompactSumKES h d)
   ) =>
   ToCBOR (VerKeyKES (CompactSumKES h d))
   where
@@ -424,9 +423,7 @@ instance
   , SodiumHashAlgorithm h
   , HashSize h ~ SeedSizeKES d
   , NoThunks (VerKeyKES (CompactSumKES h d))
-  , KnownNat (VerKeySizeKES (CompactSumKES h d))
-  , KnownNat (SignKeySizeKES (CompactSumKES h d))
-  , KnownNat (SigSizeKES (CompactSumKES h d))
+  , KESAlgorithm (CompactSumKES h d)
   ) =>
   FromCBOR (VerKeyKES (CompactSumKES h d))
   where
@@ -466,9 +463,7 @@ instance
   , SodiumHashAlgorithm h
   , HashSize h ~ SeedSizeKES d
   , NoThunks (VerKeyKES (CompactSumKES h d))
-  , KnownNat (VerKeySizeKES (CompactSumKES h d))
-  , KnownNat (SignKeySizeKES (CompactSumKES h d))
-  , KnownNat (SigSizeKES (CompactSumKES h d))
+  , KESAlgorithm (CompactSumKES h d)
   ) =>
   ToCBOR (SigKES (CompactSumKES h d))
   where
@@ -480,9 +475,7 @@ instance
   , SodiumHashAlgorithm h
   , HashSize h ~ SeedSizeKES d
   , NoThunks (VerKeyKES (CompactSumKES h d))
-  , KnownNat (VerKeySizeKES (CompactSumKES h d))
-  , KnownNat (SignKeySizeKES (CompactSumKES h d))
-  , KnownNat (SigSizeKES (CompactSumKES h d))
+  , KESAlgorithm (CompactSumKES h d)
   ) =>
   FromCBOR (SigKES (CompactSumKES h d))
   where
@@ -601,9 +594,7 @@ instance
   , OptimizedKESAlgorithm d
   , UnsoundPureKESAlgorithm d
   , SodiumHashAlgorithm h
-  , KnownNat (VerKeySizeKES (CompactSumKES h d))
-  , KnownNat (SignKeySizeKES (CompactSumKES h d))
-  , KnownNat (SigSizeKES (CompactSumKES h d))
+  , KESAlgorithm (CompactSumKES h d)
   ) =>
   ToCBOR (UnsoundPureSignKeyKES (CompactSumKES h d))
   where
@@ -615,9 +606,7 @@ instance
   , OptimizedKESAlgorithm d
   , UnsoundPureKESAlgorithm d
   , SodiumHashAlgorithm h
-  , KnownNat (VerKeySizeKES (CompactSumKES h d))
-  , KnownNat (SignKeySizeKES (CompactSumKES h d))
-  , KnownNat (SigSizeKES (CompactSumKES h d))
+  , KESAlgorithm (CompactSumKES h d)
   ) =>
   FromCBOR (UnsoundPureSignKeyKES (CompactSumKES h d))
   where

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Mock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Mock.hs
@@ -25,7 +25,7 @@ import Data.Proxy (Proxy (..))
 import Data.Word (Word64)
 import Foreign.Ptr (castPtr)
 import GHC.Generics (Generic)
-import GHC.TypeNats (KnownNat, Nat, Natural, natVal)
+import GHC.TypeNats (KnownNat, Nat)
 import NoThunks.Class (NoThunks)
 
 import Control.DeepSeq (NFData)
@@ -110,7 +110,7 @@ instance KnownNat t => KESAlgorithm (MockKES t) where
     | otherwise =
         Left "KES verification failed"
 
-  totalPeriodsKES _ = fromIntegral @Natural @Period (natVal (Proxy @t))
+  type TotalPeriodsKES (MockKES t) = t
 
   --
   -- raw serialise/deserialise

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/NeverUsed.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/NeverUsed.hs
@@ -40,7 +40,7 @@ instance KESAlgorithm NeverKES where
 
   verifyKES = error "KES not available"
 
-  totalPeriodsKES _ = 0
+  type TotalPeriodsKES NeverKES = 0
 
   type VerKeySizeKES NeverKES = 0
   type SignKeySizeKES NeverKES = 0

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Simple.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Simple.hs
@@ -114,7 +114,7 @@ instance
 
   algorithmNameKES proxy = "simple_" ++ show (totalPeriodsKES proxy)
 
-  totalPeriodsKES _ = fromIntegral @Natural @Word (natVal (Proxy @t))
+  type TotalPeriodsKES (SimpleKES d t) = t
 
   --
   -- Core algorithm operations

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Single.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Single.hs
@@ -87,7 +87,7 @@ instance DSIGNMAlgorithm d => KESAlgorithm (SingleKES d) where
 
   algorithmNameKES _ = algorithmNameDSIGN (Proxy :: Proxy d) ++ "_kes_2^0"
 
-  totalPeriodsKES _ = 1
+  type TotalPeriodsKES (SingleKES d) = 1
 
   verifyKES ctxt (VerKeySingleKES vk) t a (SigSingleKES sig) =
     assert (t == 0) $

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Sum.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Sum.hs
@@ -125,6 +125,7 @@ instance
   , HashSize h ~ SeedSizeKES d -- can be relaxed
   , KnownNat ((SignKeySizeKES d + SeedSizeKES d) + (2 * VerKeySizeKES d))
   , KnownNat (SigSizeKES d + (VerKeySizeKES d * 2))
+  , KnownNat (2 * TotalPeriodsKES d)
   ) =>
   KESAlgorithm (SumKES h d)
   where
@@ -187,7 +188,7 @@ instance
     where
       _T = totalPeriodsKES (Proxy :: Proxy d)
 
-  totalPeriodsKES _ = 2 * totalPeriodsKES (Proxy :: Proxy d)
+  type TotalPeriodsKES (SumKES h d) = 2 * TotalPeriodsKES d
 
   --
   -- raw serialise/deserialise
@@ -514,9 +515,7 @@ instance
   ( HashSize h ~ SeedSizeKES d
   , UnsoundPureKESAlgorithm d
   , SodiumHashAlgorithm h
-  , KnownNat (VerKeySizeKES (SumKES h d))
-  , KnownNat (SignKeySizeKES (SumKES h d))
-  , KnownNat (SigSizeKES (SumKES h d))
+  , KESAlgorithm (SumKES h d)
   ) =>
   ToCBOR (UnsoundPureSignKeyKES (SumKES h d))
   where
@@ -527,9 +526,7 @@ instance
   ( HashSize h ~ SeedSizeKES d
   , UnsoundPureKESAlgorithm d
   , SodiumHashAlgorithm h
-  , KnownNat (VerKeySizeKES (SumKES h d))
-  , KnownNat (SignKeySizeKES (SumKES h d))
-  , KnownNat (SigSizeKES (SumKES h d))
+  , KESAlgorithm (SumKES h d)
   ) =>
   FromCBOR (UnsoundPureSignKeyKES (SumKES h d))
   where

--- a/cardano-crypto-class/testlib/Test/Crypto/KES.hs
+++ b/cardano-crypto-class/testlib/Test/Crypto/KES.hs
@@ -268,6 +268,8 @@ testKESAlgorithm lock n =
     prop "one update signkey" $ prop_oneUpdateSignKeyKES @v lock
     prop "all updates signkey" $ prop_allUpdatesSignKeyKES @v lock
     prop "total periods" $ prop_totalPeriodsKES @v lock
+    prop "total periods matches type-level nat" $
+      prop_totalPeriodsKES_matches_typelevel @v lock
     describe "NoThunks" $ do
       prop "VerKey" $
         ioPropertyWithSK @v lock $ \sk ->
@@ -547,6 +549,17 @@ prop_allUpdatesSignKeyKES ::
 prop_allUpdatesSignKeyKES lock seedPSB =
   ioProperty . withLock lock $ do
     void $ withAllUpdatesKES_ @v seedPSB $ const (return ())
+
+-- | The term-level 'totalPeriodsKES' agrees with the type-level
+-- 'TotalPeriodsKES' associated type.
+prop_totalPeriodsKES_matches_typelevel ::
+  forall v.
+  KESAlgorithm v =>
+  Lock ->
+  Property
+prop_totalPeriodsKES_matches_typelevel _lock =
+  totalPeriodsKES (Proxy @v)
+    === fromIntegral (natVal (Proxy @(TotalPeriodsKES v)))
 
 -- | If we start with a signing key, we can evolve it a number of times so that
 -- the total number of signing keys (including the initial one) equals the


### PR DESCRIPTION
# Description

Fixes #364

This PR lifts the total number of supported KES periods to the type level by
adding:

```haskell
type TotalPeriodsKES v :: Nat
```
to `KESAlgorithm`.

This is a small API change for downstream `KESAlgorithm` instances.

## Changes
* add `TotalPeriodsKES` as an associated type of `KESAlgorithm`
* require `KnownNat (TotalPeriodsKES v)` in the `KESAlgorithm` superclass context
* make `totalPeriodsKES` a default term-level reflection of `TotalPeriodsKES`
* update KES instances to define `TotalPeriodsKES` at the type level
* adjust affected instance contexts using generic KES CBOR helpers
* add a test checking that `totalPeriodsKES` agrees with `TotalPeriodsKES`

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process))
- [x] Self-reviewed the diff
