### PR TITLE
QuickCheck compatibility shim

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -62,7 +62,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["9.6.7", "9.8.4", "9.10.2", "9.12.2"]
+        ghc: ["9.6.7", "9.8.4", "9.10.2", "9.12.2", "9.14.1"]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     env:
@@ -75,7 +75,7 @@ jobs:
       id: setup-haskell
       with:
         ghc-version: ${{ matrix.ghc }}
-        cabal-version: 3.14.1.0
+        cabal-version: 3.16.1.0
 
     - name: Install system dependencies
       uses: input-output-hk/actions/base@latest

--- a/cabal.project
+++ b/cabal.project
@@ -11,8 +11,8 @@ repository cardano-haskell-packages
 
 -- The index-states
 index-state:
-  , hackage.haskell.org 2026-03-07T07:19:41Z
-  , cardano-haskell-packages 2026-01-26T18:50:24Z
+  , hackage.haskell.org 2026-05-07T19:55:27Z
+  , cardano-haskell-packages 2026-05-05T04:28:05Z
 
 packages:
   base-deriving-via

--- a/cabal.project
+++ b/cabal.project
@@ -41,30 +41,18 @@ package bitvec
   -- Workaround for windows cross-compilation
   flags: -simd
 
--- cabal-allow-newer
+-- cabal-allow-newer begin
 if impl(ghc >=9.14)
   allow-newer:
-    , aeson:base
-    , aeson:bytestring
-    , aeson:containers
-    , aeson:deepseq
-    , aeson:ghc-prim
-    , aeson:template-haskell
-    , aeson:time
-    , binary-orphans:base
     , boring:base
+    , canonical-json:containers
     , cborg:base
-    , indexed-traversable:base
-    , indexed-traversable-instances:base
-    , microstache:base
-    , parsec:base
-    , quickcheck-instances:base
-    , quickcheck-instances:bytestring
-    , recursion-schemes:template-haskell
-    , semialign:base
+    , cborg:containers
     , serialise:base
-    , serialise:bytestring
-    , these:base
-    , time-compat:base
+    , serialise:containers
+    , serialise:time
+    , tree-diff:QuickCheck
     , tree-diff:base
-    , uuid-types:template-haskell
+    , tree-diff:containers
+    , tree-diff:time
+-- cabal-allow-newer end

--- a/cardano-base/CHANGELOG.md
+++ b/cardano-base/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog for `cardano-base`
 
-## 0.1.3.1
+## 0.1.4.0
 
-*
+* Add a workaround for QuickCheck >= 2.18 replacing `withMaxSuccess`
+  with `withNumTests` and deprecating the former.
 
 ## 0.1.3.0
 

--- a/cardano-base/cardano-base.cabal
+++ b/cardano-base/cardano-base.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-base
-version: 0.1.3.0
+version: 0.1.4.0
 synopsis: Various utilities for Cardano
 description: Various utilities for Cardano.
 category:
@@ -62,6 +62,7 @@ library testlib
     Test.Cardano.Base.Arbitrary
     Test.Cardano.Base.Bytes
     Test.Cardano.Base.Properties
+    Test.Cardano.Base.QuickCheck
     Test.Cardano.Base.TreeDiff
 
   build-depends:

--- a/cardano-base/testlib/Test/Cardano/Base/QuickCheck.hs
+++ b/cardano-base/testlib/Test/Cardano/Base/QuickCheck.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE CPP #-}
+
+module Test.Cardano.Base.QuickCheck (
+  withNumTests,
+)
+where
+
+-- QuickCheck 2.18 replaces `withMaxSuccess` with `withNumTests` and
+-- immediately deprecates the former.
+-- We handle this for the whole Cardano stack here. Any other code
+-- that uses withMaxSuccess should import this module or switch to
+-- using withNumTests.
+--
+#if MIN_VERSION_QuickCheck(2, 18, 0)
+import Test.QuickCheck (withNumTests)
+#else
+import Test.QuickCheck (
+    Property,
+    withMaxSuccess,
+  )
+#endif
+
+#if !MIN_VERSION_QuickCheck(2, 18, 0)
+withNumTests :: Int -> Property -> Property
+withNumTests = withMaxSuccess
+#endif

--- a/cardano-crypto-class/cardano-crypto-class.cabal
+++ b/cardano-crypto-class/cardano-crypto-class.cabal
@@ -192,7 +192,7 @@ library testlib
     base,
     base16-bytestring,
     bytestring >=0.10.12.0,
-    cardano-base:testlib,
+    cardano-base:testlib >=0.1.4,
     cardano-binary,
     cardano-crypto-class,
     cborg,

--- a/cardano-crypto-class/src/Cardano/Crypto/Hash/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Hash/Class.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -152,6 +153,25 @@ deriving instance HashAlgorithm h => Storable (Hash h a)
 -- >>> let hash = $$("0123456789abcdef") :: Hash ShortHash ()
 -- >>> print hash
 -- "0123456789abcdef"
+#if __GLASGOW_HASKELL__ >= 914
+-- >>> let hash = $$("deadbeef") :: Hash ShortHash ()
+-- ...
+--     • <Hash blake2b_prefix_8>: Expected in decoded form to be: 8 bytes, but got: 4
+--     • In the typed Template Haskell splice: $$("deadbeef")
+-- ...
+--       In the expression: $$("deadbeef") :: Hash ShortHash ()
+--       In an equation for ‘hash’:
+--           hash = $$("deadbeef") :: Hash ShortHash ()
+-- ...
+-- >>> let hash = $$("123") :: Hash ShortHash ()
+-- ...
+--     • <Hash blake2b_prefix_8>: Malformed hex: invalid bytestring size
+--     • In the typed Template Haskell splice: $$("123")
+-- ...
+--       In the expression: $$("123") :: Hash ShortHash ()
+--       In an equation for ‘hash’: hash = $$("123") :: Hash ShortHash ()
+-- ...
+#else
 -- >>> let hash = $$("deadbeef") :: Hash ShortHash ()
 -- ...
 --     • <Hash blake2b_prefix_8>: Expected in decoded form to be: 8 bytes, but got: 4
@@ -167,6 +187,7 @@ deriving instance HashAlgorithm h => Storable (Hash h a)
 --       In the expression: $$("123") :: Hash ShortHash ()
 --       In an equation for ‘hash’: hash = $$("123") :: Hash ShortHash ()
 -- ...
+#endif
 instance HashAlgorithm h => IsString (Q (TExp (Hash h a))) where
   fromString hexStr = do
     let n = fromInteger $ natVal (Proxy @(HashSize h))

--- a/cardano-crypto-class/src/Cardano/Crypto/PinnedSizedBytes.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/PinnedSizedBytes.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -164,6 +165,25 @@ instance KnownNat n => FromCBOR (PinnedSizedBytes n) where
 -- "deadbeef"
 -- >>> print ($$("deadbeef") :: PinnedSizedBytes 4)
 -- "deadbeef"
+#if __GLASGOW_HASKELL__ >= 914
+-- >>> let bsb = $$("0xdeadbeef") :: PinnedSizedBytes 5
+-- ...
+--     • <PinnedSizedBytes>: Expected in decoded form to be: 5 bytes, but got: 4
+--     • In the typed Template Haskell splice: $$("0xdeadbeef")
+-- ...
+--       In the expression: $$("0xdeadbeef") :: PinnedSizedBytes 5
+--       In an equation for ‘bsb’:
+--           bsb = $$("0xdeadbeef") :: PinnedSizedBytes 5
+-- ...
+-- >>> let bsb = $$("nogood") :: PinnedSizedBytes 5
+-- ...
+--     • <PinnedSizedBytes>: Malformed hex: invalid character at offset: 0
+--     • In the typed Template Haskell splice: $$("nogood")
+-- ...
+--       In the expression: $$("nogood") :: PinnedSizedBytes 5
+--       In an equation for ‘bsb’: bsb = $$("nogood") :: PinnedSizedBytes 5
+-- ...
+#else
 -- >>> let bsb = $$("0xdeadbeef") :: PinnedSizedBytes 5
 -- ...
 --     • <PinnedSizedBytes>: Expected in decoded form to be: 5 bytes, but got: 4
@@ -179,6 +199,7 @@ instance KnownNat n => FromCBOR (PinnedSizedBytes n) where
 --       In the expression: $$("nogood") :: PinnedSizedBytes 5
 --       In an equation for ‘bsb’: bsb = $$("nogood") :: PinnedSizedBytes 5
 -- ...
+#endif
 instance KnownNat n => IsString (Q (TExp (PinnedSizedBytes n))) where
   fromString hexStr = do
     let n = fromInteger $ natVal (Proxy :: Proxy n)

--- a/cardano-crypto-class/testlib/Test/Crypto/DSIGN.hs
+++ b/cardano-crypto-class/testlib/Test/Crypto/DSIGN.hs
@@ -28,7 +28,6 @@ import Test.QuickCheck (
   forAllShow,
   ioProperty,
   counterexample,
-  withMaxSuccess,
   )
 import Test.Hspec (Spec, describe, it, shouldBe)
 import Test.Hspec.QuickCheck (prop, modifyMaxSuccess)
@@ -89,6 +88,7 @@ import Cardano.Crypto.EllipticCurve.BLS12_381 (Curve1, Curve2, blsCompress, blsG
 import Cardano.Crypto.EllipticCurve.BLS12_381.Internal (blsZero)
 import Cardano.Crypto.PinnedSizedBytes (PinnedSizedBytes)
 import Cardano.Crypto.DirectSerialise
+import Test.Cardano.Base.QuickCheck (withNumTests)
 import Test.Crypto.Util (
   BadInputFor,
   genBadInputFor,
@@ -827,14 +827,14 @@ testDSIGNAggregatableWithContext _ genContext genKeyCtx genMsg name = testEnough
         forAllPoP $ prop_cbor_direct_vs_class encodePossessionProofDSIGN
   describe "aggregate" $ do
     prop "aggregate verify positive" $
-      withMaxSuccess 1000 .
+      withNumTests 1000 .
       forAllShow (genAggregateCase genContext genMsg) ppShow $
           \(ctx, msg, vksPops, sigs) -> (=== Right ()) $ do
             sig <- aggregateSigsDSIGN @v sigs
             aggVk <- aggregateVerKeysDSIGN ctx vksPops
             verifyDSIGN @v ctx aggVk msg sig
     prop "aggregate verify negative (wrong message)" $
-      withMaxSuccess 1000 .
+      withNumTests 1000 .
       forAllShow (genAggregateCase genContext genMsg) ppShow $ \(ctx, msg, vksPops, sigs) ->
           forAllShow arbitrary ppShow $ \msg' ->
             msg /= msg' ==> (=/= Right ()) $ do

--- a/flake.lock
+++ b/flake.lock
@@ -192,11 +192,11 @@
     "hackage-for-stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1772843567,
-        "narHash": "sha256-lJ815yY7u2TpN7UXUjVV4yH2qCGGiQw3PdEEuHfprL4=",
+        "lastModified": 1778374235,
+        "narHash": "sha256-Oafnecz9FjEdsejwYszbxgqjsURnlQVWGiKyADKYIVI=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "adfbef799e1e3a837e693c35e964a172b2cadb75",
+        "rev": "d7afcbf497a457f51dfbb73798656c9bcc78c989",
         "type": "github"
       },
       "original": {
@@ -225,11 +225,11 @@
     "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1778201313,
-        "narHash": "sha256-NN9iazHbyuZ5rr0oNq6Q+KQHuLdPUScLbfKYQRwTA5M=",
+        "lastModified": 1778451219,
+        "narHash": "sha256-k4AmhT5+MPfyXI6G50+LW5xCxju7PpYmlSlc6qvUTiA=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "446aceb8c40270dfd38cf06f58074e69e4884cb7",
+        "rev": "aa349f3c7f02b41da2321474ea96948e1392c350",
         "type": "github"
       },
       "original": {
@@ -281,11 +281,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1772844803,
-        "narHash": "sha256-ZRn6u0FvfWr/OTvshjObJ0QDsT9cNRUwp+IXt/5d/SM=",
+        "lastModified": 1778376069,
+        "narHash": "sha256-mpCxzNwQ5EX6JI5htVlzIRoSw5pUKBtnGgxusk5Xk/A=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "2e559cba4c8b0c5284fd9110186356c0b0718892",
+        "rev": "3b751eced7673d91ae7de4fd84013eb99d57b85b",
         "type": "github"
       },
       "original": {
@@ -571,11 +571,11 @@
     "iserv-proxy": {
       "flake": false,
       "locked": {
-        "lastModified": 1770174258,
-        "narHash": "sha256-x6QYupvHZM7rRpVO4AIC5gUWFprFQ59A95FPC7/Owjg=",
+        "lastModified": 1775620557,
+        "narHash": "sha256-10x8/G0x3eR/++XRHPx4MBuqlnc6+N+ajIxXyLkG+nU=",
         "owner": "stable-haskell",
         "repo": "iserv-proxy",
-        "rev": "91ef7ffdeedfb141a4d69dcf9e550abe3e1160c6",
+        "rev": "3f7b2815307c20a0dfd816bdf4a39ab86af3e0d4",
         "type": "github"
       },
       "original": {
@@ -683,11 +683,11 @@
     },
     "nixpkgs-2511": {
       "locked": {
-        "lastModified": 1764572236,
-        "narHash": "sha256-hLp6T/vKdrBQolpbN3EhJOKTXZYxJZPzpnoZz+fEGlE=",
+        "lastModified": 1775749320,
+        "narHash": "sha256-msT6frWJSQ2WR+0cpk+KPcZdLTLagUIsJwQwIX9JNSo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b0924ea1889b366de6bb0018a9db70b2c43a15f8",
+        "rev": "74b87959b2d16f59f54d8559cf3cf26b9d907949",
         "type": "github"
       },
       "original": {
@@ -699,11 +699,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1764587062,
-        "narHash": "sha256-hdFa0TAVQAQLDF31cEW3enWmBP+b592OvHs6WVe3D8k=",
+        "lastModified": 1775888245,
+        "narHash": "sha256-nwASzrRDD1JBEu/o8ekKYEXm/oJW6EMCzCRdrwcLe90=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c1cb7d097cb250f6e1904aacd5f2ba5ffd8a49ce",
+        "rev": "13043924aaa7375ce482ebe2494338e058282925",
         "type": "github"
       },
       "original": {
@@ -818,11 +818,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1772842633,
-        "narHash": "sha256-s16ieCAf8b8zzStdl+eEcrybdbn4t603HbxQ/cCg8s4=",
+        "lastModified": 1778113854,
+        "narHash": "sha256-DwLWzpWyPwubVRZCZLhsc2R4aUeNEGng1vL08kZZunk=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "3ec6f7b01124f50f3f1e5550c1887a68626ad9a5",
+        "rev": "166b880930f411975aec6c0238d95e498e0bc45e",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1769459742,
-        "narHash": "sha256-nS+nujs7nocUpWgQ9qvsB5V1BcP4mbVpkoksskwkwQY=",
+        "lastModified": 1778002516,
+        "narHash": "sha256-7cwOaCb9kmmgdyKEU1dxv3+HcsOXInfR/drb76lrVzE=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "2ece2c26fab870bf822dc67e956aaf0dcad8d324",
+        "rev": "3df4d04984097ce5caa431bd67645673bbe2b88a",
         "type": "github"
       },
       "original": {
@@ -225,11 +225,11 @@
     "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1772913514,
-        "narHash": "sha256-Xhvk3M/adIIZHyxqs0Tn+/pOYkKxuIPLnt8jiUmruv0=",
+        "lastModified": 1778201313,
+        "narHash": "sha256-NN9iazHbyuZ5rr0oNq6Q+KQHuLdPUScLbfKYQRwTA5M=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "3343b617472488cfbf9b51f2f1e88696e050c2ff",
+        "rev": "446aceb8c40270dfd38cf06f58074e69e4884cb7",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -91,7 +91,7 @@
             # tools we want in our shell, from hackage
             tools =
               {
-                cabal = "3.14.1.0";
+                cabal = "3.16.1.0";
               }
               // lib.optionalAttrs (config.compiler-nix-name == defaultCompiler) {
                 # tools that work only with default compiler
@@ -109,7 +109,7 @@
               (let
                 doctest = haskell-nix.hackage-package {
                   name = "doctest";
-                  version = "0.24.0";
+                  version = "0.25.0";
                   configureArgs = "-f cabal-doctest";
                   inherit (config) compiler-nix-name;
                 };
@@ -125,10 +125,9 @@
           };
           flake = {
             # on linux, build/test other supported compilers
-            # TODO uncomment this to enable GHC 9.12 testing
-            # variants = lib.genAttrs ["ghc912"] (compiler-nix-name: {
-            #   inherit compiler-nix-name;
-            # });
+            variants = lib.genAttrs ["ghc9141"] (compiler-nix-name: {
+              inherit compiler-nix-name;
+            });
             # we also want cross compilation to windows.
             crossPlatforms = p: lib.optional (system == "x86_64-linux") p.ucrt64;
           };

--- a/scripts/doctest.sh
+++ b/scripts/doctest.sh
@@ -2,6 +2,17 @@
 
 set -euo pipefail
 
+# GHC 9.14's interactive linker does not pull in symbols from pkgconfig
+# C libraries when loading the doctest shared object, so doctests for
+# packages that FFI into libsodium fail with `undefined symbol: sodium_*`.
+# Preloading libsodium makes those symbols available to GHCi.
+# `--repl-options=--optimistic-linking` would also work, but doctest 0.25
+# passes that flag to the non-interactive GHC extraction stage which
+# rejects it as unknown.
+if [[ "$(uname -s)" == Linux ]] && libsodium_libdir=$(pkg-config --variable=libdir libsodium 2>/dev/null); then
+  export LD_PRELOAD="${libsodium_libdir}/libsodium.so${LD_PRELOAD:+:$LD_PRELOAD}"
+fi
+
 # Packages to run doctests for; defaults to all packages if none are specified
 PACKAGES=("$@")
 


### PR DESCRIPTION
# Description

* Fix doctest for ghc-9.14 and add it to CI
* Update cabal to 3.16 on CI and in nix
* Update index-state for CHaP and Hackage
* Introduce compatibility with `QuickCheck-2.18`

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process))
- [x] Self-reviewed the diff
