### PR TITLE
Require NFData for VRF associated types

### DIFF
--- a/cardano-crypto-class/CHANGELOG.md
+++ b/cardano-crypto-class/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 2.5.0.0
 
+* Add `NFData` superclass constraints for the `VerKeyVRF`, `SignKeyVRF`,
+  and `CertVRF` associated types in `VRFAlgorithm`.
 * Remove constructors of `BLS12381SignContext` from export; use `minSigPoPDST` or `minVerKeyPoPDST` for the standard PoP ciphersuites.
 
 ## 2.4.0.0

--- a/cardano-crypto-class/src/Cardano/Crypto/VRF/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/VRF/Class.hs
@@ -80,9 +80,12 @@ class
   ( Typeable v
   , Show (VerKeyVRF v)
   , Eq (VerKeyVRF v)
+  , NFData (VerKeyVRF v)
   , Show (SignKeyVRF v)
+  , NFData (SignKeyVRF v)
   , Show (CertVRF v)
   , Eq (CertVRF v)
+  , NFData (CertVRF v)
   , NoThunks (CertVRF v)
   , NoThunks (VerKeyVRF v)
   , NoThunks (SignKeyVRF v)

--- a/cardano-crypto-class/src/Cardano/Crypto/VRF/Mock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/VRF/Mock.hs
@@ -12,6 +12,7 @@ module Cardano.Crypto.VRF.Mock (
 )
 where
 
+import Control.DeepSeq (NFData)
 import Data.Proxy (Proxy (..))
 import Data.Word (Word64)
 import GHC.Generics (Generic)
@@ -33,13 +34,13 @@ instance VRFAlgorithm MockVRF where
   --
 
   newtype VerKeyVRF MockVRF = VerKeyMockVRF Word64
-    deriving (Show, Eq, Ord, Generic, NoThunks)
+    deriving (Show, Eq, Ord, Generic, NoThunks, NFData)
 
   newtype SignKeyVRF MockVRF = SignKeyMockVRF Word64
-    deriving (Show, Eq, Ord, Generic, NoThunks)
+    deriving (Show, Eq, Ord, Generic, NoThunks, NFData)
 
   newtype CertVRF MockVRF = CertMockVRF Word64
-    deriving (Show, Eq, Ord, Generic, NoThunks)
+    deriving (Show, Eq, Ord, Generic, NoThunks, NFData)
 
   --
   -- Metadata and basic key operations

--- a/cardano-crypto-class/src/Cardano/Crypto/VRF/NeverUsed.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/VRF/NeverUsed.hs
@@ -11,6 +11,7 @@ module Cardano.Crypto.VRF.NeverUsed (
 )
 where
 
+import Control.DeepSeq (NFData (..))
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks)
 
@@ -21,6 +22,15 @@ import Cardano.Crypto.VRF.Class
 -- The type of keys and certificates is isomorphic to unit, but when actually
 -- trying to sign or verify something a runtime exception will be thrown.
 data NeverVRF
+
+instance NFData (VerKeyVRF NeverVRF) where
+  rnf x = x `seq` ()
+
+instance NFData (SignKeyVRF NeverVRF) where
+  rnf x = x `seq` ()
+
+instance NFData (CertVRF NeverVRF) where
+  rnf x = x `seq` ()
 
 instance VRFAlgorithm NeverVRF where
   data VerKeyVRF NeverVRF = NeverUsedVerKeyVRF

--- a/cardano-crypto-praos/bench/Bench/Crypto/VRF.hs
+++ b/cardano-crypto-praos/bench/Bench/Crypto/VRF.hs
@@ -11,8 +11,6 @@ module Bench.Crypto.VRF (
 import Data.ByteString (ByteString)
 import Data.Proxy
 
-import Control.DeepSeq
-
 import Cardano.Crypto.VRF.Class
 import Cardano.Crypto.VRF.Praos hiding (Seed)
 import Cardano.Crypto.VRF.Simple
@@ -34,9 +32,6 @@ benchVRF ::
   ( VRFAlgorithm v
   , ContextVRF v ~ ()
   , Signable v ByteString
-  , NFData (CertVRF v)
-  , NFData (SignKeyVRF v)
-  , NFData (VerKeyVRF v)
   ) =>
   proxy v ->
   [Char] ->

--- a/cardano-crypto-praos/cardano-crypto-praos.cabal
+++ b/cardano-crypto-praos/cardano-crypto-praos.cabal
@@ -153,6 +153,5 @@ benchmark bench
     cardano-crypto-class:{cardano-crypto-class, benchlib},
     cardano-crypto-praos,
     criterion,
-    deepseq,
 
   ghc-options: -threaded


### PR DESCRIPTION
Fix #533

# Description

This adds `NFData` superclass constraints for the VRF associated types in `VRFAlgorithm`:
- `VerKeyVRF`
- `SignKeyVRF`
- `CertVRF`

Tested with:
```sh
cabal build all --enable-tests --enable-benchmarks
```

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#changelogmd))
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process))
- [x] Self-reviewed the diff
