### PR TITLE
Convert `BLS12381` haddock examples into `doctest`

### DIFF
--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/BLS12381/Internal.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/BLS12381/Internal.hs
@@ -214,33 +214,51 @@ type family CurveVariant (c :: Type) :: Symbol where
 --
 -- A typical same-message aggregation workflow is:
 --
--- @
 -- -- Minimal-pubkey-size PoP ciphersuite
--- let ctx = minVerKeyPoPDST
---
 -- -- Each participant has a signing key and derived verification key
--- let vk1 = deriveVerKeyDSIGN sk1
---     vk2 = deriveVerKeyDSIGN sk2
---
 -- -- Each participant proves possession of its secret key
--- let pop1 = createPossessionProofDSIGN ctx sk1
---     pop2 = createPossessionProofDSIGN ctx sk2
+-- >>> :set -XTypeApplications
+-- >>> import Cardano.Crypto.Seed (mkSeedFromBytes)
 --
--- verifyPossessionProofDSIGN ctx vk1 pop1
--- verifyPossessionProofDSIGN ctx vk2 pop2
+-- >>> :{
+-- let ctx = minVerKeyPoPDST
+--     msg = BS.pack [0, 1, 2, 3]
+--     sk1 =
+--       genKeyDSIGNWithContext
+--         @BLS12381MinVerKeyDSIGN
+--         Nothing
+--         (mkSeedFromBytes (BS.replicate 32 1))
+--     sk2 =
+--       genKeyDSIGNWithContext
+--         @BLS12381MinVerKeyDSIGN
+--         Nothing
+--         (mkSeedFromBytes (BS.replicate 32 2))
+--     vk1 = deriveVerKeyDSIGN sk1
+--     vk2 = deriveVerKeyDSIGN sk2
+--     pop1 = createPossessionProofDSIGN ctx sk1
+--     pop2 = createPossessionProofDSIGN ctx sk2
+-- :}
+--
+-- >>> verifyPossessionProofDSIGN ctx vk1 pop1
+-- Right ()
+--
+-- >>> verifyPossessionProofDSIGN ctx vk2 pop2
+-- Right ()
 --
 -- -- Once the proofs have been checked, it is safe to aggregate keys
--- Right avk <- uncheckedAggregateVerKeysDSIGN [vk1, vk2]
+-- >>> Right avk = uncheckedAggregateVerKeysDSIGN [vk1, vk2]
 --
 -- -- Both participants sign the same message
--- let sig1 = signDSIGN ctx msg sk1
---     sig2 = signDSIGN ctx msg sk2
+-- >>> let sig1 = signDSIGN ctx msg sk1
+-- >>> let sig2 = signDSIGN ctx msg sk2
 --
--- Right asig <- aggregateSigsDSIGN [sig1, sig2]
+-- The signatures can be aggregated:
 --
--- -- The aggregate signature can then be checked against the aggregate key
--- verifyDSIGN ctx avk msg asig
--- @
+-- >>> Right asig = aggregateSigsDSIGN [sig1, sig2]
+--
+-- -- The aggregate signature can then be checked against the aggregate key:
+-- >>> verifyDSIGN ctx avk msg asig
+-- Right ()
 data BLS12381SignContext = BLS12381SignContext
   { blsSignContextDst :: !(Maybe ByteString)
   , blsSignContextAug :: !(Maybe ByteString)


### PR DESCRIPTION
Fix #647

# Description

Converts the BLS12381 PoP aggregation Haddock example into an executable doctest.

Tested with:
```sh
bash -x scripts/doctest.sh
echo $?
```
output shows:
```text
***** cabal doctest cardano-crypto-class:lib:cardano-crypto-class *****
+ cabal repl --with-repl=doctest '--repl-options=-w -Wdefault' --build-depends=QuickCheck --build-depends=template-haskell cardano-crypto-class:lib:cardano-crypto-class
...
Examples: 34  Tried: 34  Errors: 0  Failures: 0
```
and last command exit code is `0`

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process))
- [x] Self-reviewed the diff
