### PR TITLE
Add `Ord` constraint on `CertVRF` in `VRFAlgorithm`

### DIFF
--- a/cardano-crypto-class/CHANGELOG.md
+++ b/cardano-crypto-class/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 2.5.0.0
 
+* Add `Ord` superclass constraint for the `CertVRF` associated type in `VRFAlgorithm`
+* Add `Ord` instances for `CertVRF {SimpleVRF,PraosVRF,PraosBatchCompatVRF}`
+* Add `Ord` instances for `Cardano.Crypto.VRF.Praos{,BatchCompat}.Proof`
 * Add `NFData` superclass constraints for the `VerKeyVRF`, `SignKeyVRF`,
   and `CertVRF` associated types in `VRFAlgorithm`.
 * Remove constructors of `BLS12381SignContext` from export; use `minSigPoPDST` or `minVerKeyPoPDST` for the standard PoP ciphersuites.

--- a/cardano-crypto-class/src/Cardano/Crypto/VRF/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/VRF/Class.hs
@@ -84,7 +84,7 @@ class
   , Show (SignKeyVRF v)
   , NFData (SignKeyVRF v)
   , Show (CertVRF v)
-  , Eq (CertVRF v)
+  , Ord (CertVRF v)
   , NFData (CertVRF v)
   , NoThunks (CertVRF v)
   , NoThunks (VerKeyVRF v)
@@ -321,8 +321,9 @@ data CertifiedVRF v a = CertifiedVRF
   }
   deriving (Generic)
 
-deriving instance VRFAlgorithm v => Show (CertifiedVRF v a)
 deriving instance VRFAlgorithm v => Eq (CertifiedVRF v a)
+deriving instance VRFAlgorithm v => Ord (CertifiedVRF v a)
+deriving instance VRFAlgorithm v => Show (CertifiedVRF v a)
 
 instance VRFAlgorithm v => NoThunks (CertifiedVRF v a)
 

--- a/cardano-crypto-class/src/Cardano/Crypto/VRF/Simple.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/VRF/Simple.hs
@@ -68,6 +68,10 @@ instance ToCBOR Point where
 instance FromCBOR Point where
   fromCBOR = Point . pointFromMaybe <$> fromCBOR
 
+-- This isn't mathematically meaningful, but we want to be able to store Points in a Set
+instance Ord Point where
+  compare (Point p) (Point r) = compare (pointToMaybe p) (pointToMaybe r)
+
 instance Semigroup Point where
   Point p <> Point r = Point $ C.pointAdd curve p r
 
@@ -118,7 +122,7 @@ instance VRFAlgorithm SimpleVRF where
     , certC :: !Natural -- md5 hash, so 16 bytes
     , certS :: !Integer -- at most q, so 15 bytes, round up to 16
     }
-    deriving stock (Show, Eq, Generic)
+    deriving stock (Show, Eq, Ord, Generic)
     deriving anyclass (NoThunks)
     deriving anyclass (NFData)
 

--- a/cardano-crypto-praos/src/Cardano/Crypto/VRF/Praos.hs
+++ b/cardano-crypto-praos/src/Cardano/Crypto/VRF/Praos.hs
@@ -71,6 +71,7 @@ import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Unsafe as BS
 import Data.Coerce (coerce)
+import Data.Ord (comparing)
 import Data.Primitive.ByteArray (
   ByteArray,
   copyPtrToMutableByteArray,
@@ -291,6 +292,9 @@ instance Show Proof where
 
 instance Eq Proof where
   a == b = proofBytes a == proofBytes b
+
+instance Ord Proof where
+  compare = comparing proofBytes
 
 instance ToCBOR Proof where
   toCBOR = toCBOR . proofBytes
@@ -526,7 +530,7 @@ instance VRFAlgorithm PraosVRF where
     deriving newtype (NFData)
 
   newtype CertVRF PraosVRF = CertPraosVRF Proof
-    deriving stock (Show, Eq, Generic)
+    deriving stock (Show, Eq, Ord, Generic)
     deriving newtype (ToCBOR, FromCBOR)
     deriving (NoThunks) via OnlyCheckWhnfNamed "CertKeyVRF PraosVRF" Proof
     deriving newtype (NFData)

--- a/cardano-crypto-praos/src/Cardano/Crypto/VRF/PraosBatchCompat.hs
+++ b/cardano-crypto-praos/src/Cardano/Crypto/VRF/PraosBatchCompat.hs
@@ -77,6 +77,7 @@ import Control.Monad (void, (<$!>))
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
 import Data.Coerce (coerce)
+import Data.Ord (comparing)
 import Data.Primitive.ByteArray (
   ByteArray,
   copyPtrToMutableByteArray,
@@ -314,6 +315,9 @@ instance Show Proof where
 instance Eq Proof where
   a == b = proofBytes a == proofBytes b
 
+instance Ord Proof where
+  compare = comparing proofBytes
+
 instance ToCBOR Proof where
   toCBOR = toCBOR . proofBytes
   encodedSizeExpr _ _ =
@@ -537,7 +541,7 @@ instance VRFAlgorithm PraosBatchCompatVRF where
     deriving newtype (NFData)
 
   newtype CertVRF PraosBatchCompatVRF = CertPraosBatchCompatVRF Proof
-    deriving stock (Show, Eq, Generic)
+    deriving stock (Show, Eq, Ord, Generic)
     deriving newtype (ToCBOR, FromCBOR)
     deriving (NoThunks) via OnlyCheckWhnfNamed "CertKeyVRF PraosBatchCompatVRF" Proof
     deriving newtype (NFData)


### PR DESCRIPTION
# Description

We want to be able to store ledger predicate failures in a `Set`, which requires an `Ord` constraint. Some of these failures transitively embed VRF certs so they too need to have `Ord` instances.

This change adds `Ord` instances for the three types of VRF provided in base. It also upgrades the `Eq` constraint to `Ord` in the `VRFAlgorithm` class to avoid having to repeat more specific constraints in many places in the ledger codebase.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process))
- [x] Self-reviewed the diff
