### PR TITLE
Add Cardano.Base.Typeable with type TypeName a

### DIFF
--- a/cardano-base/CHANGELOG.md
+++ b/cardano-base/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.1.4.0
 
+* Add `Cardano.Base.Typeable` module with type `TypeName a` and its `IsString` and `Show` instances.
 * Add a workaround for QuickCheck >= 2.18 replacing `withMaxSuccess`
   with `withNumTests` and deprecating the former.
 

--- a/cardano-base/cardano-base.cabal
+++ b/cardano-base/cardano-base.cabal
@@ -44,6 +44,7 @@ library
     Cardano.Base.FeatureFlags
     Cardano.Base.IP
     Cardano.Base.Proxy
+    Cardano.Base.Typeable
 
   build-depends:
     aeson,

--- a/cardano-base/src/Cardano/Base/Typeable.hs
+++ b/cardano-base/src/Cardano/Base/Typeable.hs
@@ -1,0 +1,23 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+
+-- | Wrapper for Data.Typeable, plus convenience functions
+module Cardano.Base.Typeable (
+  module X,
+  TypeName (..),
+) where
+
+import Data.String (IsString (fromString))
+import Data.Typeable as X
+
+data TypeName a where
+  TypeNameString :: String -> TypeName a
+  TypeName :: Typeable a => TypeName a
+
+instance IsString (TypeName a) where
+  fromString = TypeNameString
+
+instance Show (TypeName a) where
+  show = \case
+    TypeNameString name -> name
+    t@(TypeName {}) -> show (typeRep t)


### PR DESCRIPTION
# Description

Add `IsString` and `Show` instances for `TypeName a`, where `a` can be any type, so that it is convenient to use `show` on any type using the `TypeName` constructor, as well as just use a `String` when necessary.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process))
- [x] Self-reviewed the diff
