### PR TITLE
Generalize type signature for withNumTests

### DIFF
--- a/cardano-base/CHANGELOG.md
+++ b/cardano-base/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog for `cardano-base`
 
-## 0.1.4.1
+## 0.1.5.0
 
-*
+* Generalize type signature for `withNumTests` by making it polymorphic.
 
 ## 0.1.4.0
 

--- a/cardano-base/cardano-base.cabal
+++ b/cardano-base/cardano-base.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-base
-version: 0.1.4.0
+version: 0.1.5.0
 synopsis: Various utilities for Cardano
 description: Various utilities for Cardano.
 category:

--- a/cardano-base/testlib/Test/Cardano/Base/QuickCheck.hs
+++ b/cardano-base/testlib/Test/Cardano/Base/QuickCheck.hs
@@ -16,11 +16,12 @@ import Test.QuickCheck (withNumTests)
 #else
 import Test.QuickCheck (
     Property,
+    Testable,
     withMaxSuccess,
   )
 #endif
 
 #if !MIN_VERSION_QuickCheck(2, 18, 0)
-withNumTests :: Int -> Property -> Property
+withNumTests :: Testable prop => Int -> prop -> Property
 withNumTests = withMaxSuccess
 #endif


### PR DESCRIPTION
# Description

Code in `cardano-base` depends on the generalized type sig.

When this is merged, I will release it to CHaP.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#changelogmd))
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process))
- [ ] Self-reviewed the diff
