### PR TITLE
Bump cardano-crypto-praos to 2.2.3

### DIFF
--- a/cardano-crypto-class/CHANGELOG.md
+++ b/cardano-crypto-class/CHANGELOG.md
@@ -8,8 +8,8 @@
 
 * Drop mu2 from `PossessionProofDSIGN`
 * Add `Ord` superclass constraint for the `CertVRF` associated type in `VRFAlgorithm`
-* Add `Ord` instances for `CertVRF {SimpleVRF,PraosVRF,PraosBatchCompatVRF}`
-* Add `Ord` instances for `Cardano.Crypto.VRF.Praos{,BatchCompat}.Proof`
+* Add `Ord` instance for `CertVRF SimpleVRF`
+* Add `Ord` instance for `CertifiedVRF`
 * Add `NFData` superclass constraints for the `VerKeyVRF`, `SignKeyVRF`,
   and `CertVRF` associated types in `VRFAlgorithm`.
 * Remove constructors of `BLS12381SignContext` from export; use `minSigPoPDST` or `minVerKeyPoPDST` for the standard PoP ciphersuites.

--- a/cardano-crypto-praos/CHANGELOG.md
+++ b/cardano-crypto-praos/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog for `cardano-crypto-praos`
 
-## 2.2.2.1
+## 2.2.3.0
 
-*
+* Add `Ord` instances for `CertVRF PraosVRF` and `CertVRF PraosBatchCompatVRF`
+* Add `Ord` instances for `Cardano.Crypto.VRF.Praos.Proof` and `Cardano.Crypto.VRF.PraosBatchCompat.Proof`
 
 ## 2.2.2.0
 

--- a/cardano-crypto-praos/cardano-crypto-praos.cabal
+++ b/cardano-crypto-praos/cardano-crypto-praos.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-crypto-praos
-version: 2.2.2.0
+version: 2.2.3.0
 synopsis: Crypto primitives from libsodium
 description: VRF (and KES, tba) primitives from libsodium.
 license: Apache-2.0


### PR DESCRIPTION
# Description

followup on https://github.com/IntersectMBO/cardano-base/pull/658 - the changes for `cardano-crypto-praos` were bundled in the `cardano-crypto-class` changelog and as a result they were not released; the two packages however go hand in hand so we'll need a new release of `crypto-praos`.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#changelogmd))
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process))
- [x] Self-reviewed the diff
