### PR TITLE
Add `FixedSizeCodec`, lift VRF sizes to the type level

### DIFF
--- a/cardano-binary/CHANGELOG.md
+++ b/cardano-binary/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.9.1.0
 
 * Add `NFData` instance for `DecoderError`.
+* Add `Cardano.Binary.FixedSizeCodec` module
 
 ## 1.9.0.0
 

--- a/cardano-binary/cardano-binary.cabal
+++ b/cardano-binary/cardano-binary.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-binary
-version: 1.9.0.0
+version: 1.9.1.0
 synopsis: Binary serialization for Cardano
 description: This package includes the binary serialization format for Cardano
 license: Apache-2.0
@@ -39,7 +39,10 @@ common project-config
 library
   import: base, project-config
   hs-source-dirs: src
-  exposed-modules: Cardano.Binary
+  exposed-modules:
+    Cardano.Binary
+    Cardano.Binary.FixedSizeCodec
+
   other-modules:
     Cardano.Binary.Deserialize
     Cardano.Binary.FromCBOR

--- a/cardano-binary/src/Cardano/Binary/FixedSizeCodec.hs
+++ b/cardano-binary/src/Cardano/Binary/FixedSizeCodec.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
+
+module Cardano.Binary.FixedSizeCodec (
+  FixedSizeCodec (..),
+  decodeFixedSized,
+  encodeFixedSized,
+  fixedSize,
+  guardFixedSized,
+) where
+
+import Cardano.Binary (Decoder, Encoding, decodeBytes, encodeBytes)
+import Control.Monad (when)
+import qualified Data.ByteString as BS
+import Data.Proxy (Proxy (..))
+import Data.Typeable (Typeable, typeRep)
+import GHC.TypeLits (KnownNat, Nat, natVal)
+
+class KnownNat (FixedSize a) => FixedSizeCodec a where
+  type FixedSize a :: Nat
+  rawEncodeFixedSized :: a -> BS.ByteString
+  rawDecodeFixedSized :: MonadFail m => BS.ByteString -> m a
+
+fixedSize :: forall a proxy. FixedSizeCodec a => proxy a -> Word
+fixedSize _ = fromInteger @Word . natVal $ Proxy @(FixedSize a)
+
+guardFixedSized ::
+  forall a m.
+  (FixedSizeCodec a, MonadFail m, Typeable a) =>
+  BS.ByteString -> m a -> m a
+guardFixedSized bs action = do
+  when (actualSize /= expectedSize) $
+    fail
+      ( tyName
+          ++ ": wrong length, expected "
+          ++ show expectedSize
+          ++ " bytes but got "
+          ++ show actualSize
+      )
+  action
+  where
+    tyName = show (typeRep $ Proxy @a)
+    expectedSize = fixedSize $ Proxy @a
+    actualSize = fromIntegral @Int @Word $ BS.length bs
+{-# INLINE guardFixedSized #-}
+
+decodeFixedSized :: FixedSizeCodec a => Decoder s a
+decodeFixedSized = decodeBytes >>= rawDecodeFixedSized
+
+encodeFixedSized :: FixedSizeCodec a => a -> Encoding
+encodeFixedSized = encodeBytes . rawEncodeFixedSized

--- a/cardano-crypto-class/CHANGELOG.md
+++ b/cardano-crypto-class/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog for `cardano-crypto-class`
 
+## 2.6.0.0
+
+* Add `VerKeySizeVRF`, `SignKeySizeVRF` and `CertSizeVRF` type-level sizes to `VRFAlgorithm`
+* Change `sizeVerKeyVRF`, `sizeSignKeyVRF` and `sizeCertVRF` from `VRFAlgorithm` methods to standalone functions
+
 ## 2.5.1.0
 
 * Add `psbToByteArray`

--- a/cardano-crypto-class/CHANGELOG.md
+++ b/cardano-crypto-class/CHANGELOG.md
@@ -1,9 +1,15 @@
 # Changelog for `cardano-crypto-class`
 
-## 2.6.0.0
+## 2.5.2.0
 
 * Add `VerKeySizeVRF`, `SignKeySizeVRF` and `CertSizeVRF` type-level sizes to `VRFAlgorithm`
 * Change `sizeVerKeyVRF`, `sizeSignKeyVRF` and `sizeCertVRF` from `VRFAlgorithm` methods to standalone functions
+* Add `FixedSizeCodec` as a superclass of `DSIGNAlgorithm`, `KESAlgorithm`, `VRFAlgorithm`, `UnsoundPureKESAlgorithm` and `DSIGNAggregatable`
+* Remove `failSizeCheck`
+* Deprecate the `encode*` and `decode*` functions for DSIGN, KES and VRF keys, signatures and certificates in favor of `encodeFixedSized` and `decodeFixedSized`
+* Add `FixedSizeCodec` instances for `PinnedSizedBytes` and `PackedBytes`
+* Add `psbFromByteStringForM`
+* Add `hashFromByteStringM`
 
 ## 2.5.1.0
 

--- a/cardano-crypto-class/CHANGELOG.md
+++ b/cardano-crypto-class/CHANGELOG.md
@@ -7,6 +7,9 @@
 * Add `FixedSizeCodec` as a superclass of `DSIGNAlgorithm`, `KESAlgorithm`, `VRFAlgorithm`, `UnsoundPureKESAlgorithm` and `DSIGNAggregatable`
 * Remove `failSizeCheck`
 * Deprecate the `encode*` and `decode*` functions for DSIGN, KES and VRF keys, signatures and certificates in favor of `encodeFixedSized` and `decodeFixedSized`
+* Deprecate the `rawSerialise*` and `rawDeserialise*` methods for DSIGN, KES and VRF keys, signatures, certificates and proofs of possession in favor of `rawEncodeFixedSized` and `rawDecodeFixedSized`
+* Deprecate `verKeySizeDSIGN`, `signKeySizeDSIGN`, `sigSizeDSIGN`, `verKeySizeKES`, `sigSizeKES`, `sizeVerKeyVRF`, `sizeSignKeyVRF` and `sizeCertVRF` in favor of `fixedSize`
+* Re-export `fixedSize` from `Cardano.Crypto.KES.Class`
 * Add `FixedSizeCodec` instances for `PinnedSizedBytes` and `PackedBytes`
 * Add `psbFromByteStringForM`
 * Add `hashFromByteStringM`

--- a/cardano-crypto-class/cardano-crypto-class.cabal
+++ b/cardano-crypto-class/cardano-crypto-class.cabal
@@ -128,7 +128,6 @@ library
     cardano-base >=0.1.6,
     cardano-binary >=1.7.3,
     cardano-strict-containers,
-    cborg,
     crypton ^>=1.0,
     deepseq,
     heapwords,

--- a/cardano-crypto-class/cardano-crypto-class.cabal
+++ b/cardano-crypto-class/cardano-crypto-class.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-crypto-class
-version: 2.6.0.0
+version: 2.5.2.0
 synopsis:
   Type classes abstracting over cryptography primitives for Cardano
 
@@ -126,7 +126,7 @@ library
     base16-bytestring >=1,
     bytestring,
     cardano-base >=0.1.6,
-    cardano-binary >=1.7.3,
+    cardano-binary >=1.9.1,
     cardano-strict-containers,
     crypton ^>=1.0,
     deepseq,

--- a/cardano-crypto-class/cardano-crypto-class.cabal
+++ b/cardano-crypto-class/cardano-crypto-class.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-crypto-class
-version: 2.5.1.0
+version: 2.6.0.0
 synopsis:
   Type classes abstracting over cryptography primitives for Cardano
 

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/BLS12381/Internal.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/BLS12381/Internal.hs
@@ -33,6 +33,11 @@ module Cardano.Crypto.DSIGN.BLS12381.Internal (
 #include "blst_util.h"
 
 import Cardano.Binary (FromCBOR (fromCBOR), ToCBOR (encodedSizeExpr, toCBOR))
+import Cardano.Binary.FixedSizeCodec (
+  FixedSizeCodec (..),
+  decodeFixedSized,
+  encodeFixedSized,
+ )
 import Cardano.Crypto.DSIGN.Class (
   DSIGNAggregatable (..),
   DSIGNAlgorithm (
@@ -40,37 +45,21 @@ import Cardano.Crypto.DSIGN.Class (
     KeyGenContextDSIGN,
     SeedSizeDSIGN,
     SigDSIGN,
-    SigSizeDSIGN,
     SignKeyDSIGN,
-    SignKeySizeDSIGN,
     Signable,
     VerKeyDSIGN,
-    VerKeySizeDSIGN,
     algorithmNameDSIGN,
     deriveVerKeyDSIGN,
     genKeyDSIGN,
     genKeyDSIGNWithContext,
-    rawDeserialiseSigDSIGN,
-    rawDeserialiseSignKeyDSIGN,
-    rawDeserialiseVerKeyDSIGN,
-    rawSerialiseSigDSIGN,
-    rawSerialiseSignKeyDSIGN,
-    rawSerialiseVerKeyDSIGN,
     signDSIGN,
     verifyDSIGN
   ),
-  decodePossessionProofDSIGN,
-  decodeSigDSIGN,
-  decodeSignKeyDSIGN,
-  decodeVerKeyDSIGN,
-  encodePossessionProofDSIGN,
-  encodeSigDSIGN,
-  encodeSignKeyDSIGN,
-  encodeVerKeyDSIGN,
   encodedPossessionProofDSIGNSizeExpr,
   encodedSigDSIGNSizeExpr,
   encodedSignKeyDSIGNSizeExpr,
   encodedVerKeyDSIGNSizeExpr,
+  rawSerialiseVerKeyDSIGN,
   seedSizeDSIGN,
  )
 import Cardano.Crypto.EllipticCurve.BLS12_381.Internal (
@@ -105,6 +94,7 @@ import Cardano.Crypto.PinnedSizedBytes (
 import Cardano.Crypto.Seed (getBytesFromSeedT)
 import Cardano.Crypto.Util (SignableRepresentation (getSignableRepresentation))
 import Control.DeepSeq (NFData)
+import Control.Monad (when)
 import Data.Bifunctor (first)
 import Data.ByteString (ByteString)
 import qualified Data.ByteString as BS
@@ -119,6 +109,10 @@ import GHC.TypeLits (KnownSymbol, Symbol, symbolVal)
 import GHC.TypeNats (KnownNat, type (+))
 import NoThunks.Class (NoThunks)
 import System.IO.Unsafe (unsafeDupablePerformIO)
+
+failDecodeBLS :: MonadFail m => String -> String -> m a
+failDecodeBLS ty msg =
+  fail $ ty <> " BLS12381DSIGN: deserialisation failed (" <> msg <> ")"
 
 data BLS12381DSIGN curve
 
@@ -275,12 +269,9 @@ instance
   DSIGNAlgorithm (BLS12381DSIGN curve)
   where
   type SeedSizeDSIGN (BLS12381DSIGN curve) = CARDANO_BLST_SCALAR_SIZE
-  type SignKeySizeDSIGN (BLS12381DSIGN curve) = CARDANO_BLST_SCALAR_SIZE
 
   -- These *Sizes* are used in the serialization/deserialization
   -- so these use the compressed sizes of the BLS12-381 `Point curve`
-  type VerKeySizeDSIGN (BLS12381DSIGN curve) = CompressedPointSize curve
-  type SigSizeDSIGN (BLS12381DSIGN curve) = CompressedPointSize (DualCurve curve)
   type Signable (BLS12381DSIGN curve) = SignableRepresentation
 
   -- Context can hold domain separation tag and/or augmentation data for signatures
@@ -378,51 +369,6 @@ instance
                     infoPtr
                     (fromIntegral @Int @CSize infoLen)
 
-  -- Note that this also compresses the signature according to the ZCash standard
-  {-# INLINE rawSerialiseSigDSIGN #-}
-  rawSerialiseSigDSIGN (SigBLS12381 sigPSB) = blsCompress @(DualCurve curve) sigPSB
-
-  {-# INLINE rawSerialiseVerKeyDSIGN #-}
-  -- Note that this also compresses the verification key according to the ZCash standard
-  rawSerialiseVerKeyDSIGN (VerKeyBLS12381 vkPSB) = blsCompress @curve vkPSB
-
-  {-# INLINE rawSerialiseSignKeyDSIGN #-}
-  rawSerialiseSignKeyDSIGN (SignKeyBLS12381 skPSB) = scalarToBS skPSB
-
-  {-# INLINE rawDeserialiseVerKeyDSIGN #-}
-  rawDeserialiseVerKeyDSIGN bs =
-    -- Note that this also performs a group membership check.
-    -- That is, the deserialised point is in the subgroup of Curve1/Curve2.
-    case blsUncompress @curve bs of
-      Left _ -> Nothing
-      Right vkPsb ->
-        -- Reject the identity (point at infinity) as a verification key
-        if blsIsInf @curve vkPsb
-          then Nothing
-          else Just (VerKeyBLS12381 vkPsb)
-
-  {-# INLINE rawDeserialiseSignKeyDSIGN #-}
-  rawDeserialiseSignKeyDSIGN bs =
-    -- A signing key is strictly a BE integer mod the curve order.
-    -- The `DSIGN` interface via PSB would ensure at the type level that
-    -- they are of size 32 bytes (256 bits). But we must even ensure
-    -- they are valid Scalars, i.e., less than the curve order (255 bits).
-    case scalarFromBS bs of
-      Left _ -> Nothing
-      Right skScalar ->
-        -- Reject the zero scalar as a signing key
-        if BS.all (== 0) (scalarToBS skScalar)
-          then Nothing
-          else Just (SignKeyBLS12381 skScalar)
-
-  {-# INLINE rawDeserialiseSigDSIGN #-}
-  rawDeserialiseSigDSIGN bs =
-    -- Note that this also performs a group membership check.
-    -- That is, the deserialised point is in the subgroup of Curve1/Curve2.
-    case blsUncompress @(DualCurve curve) bs of
-      Left _ -> Nothing
-      Right sigPsb -> Just (SigBLS12381 sigPsb)
-
 deriving stock instance
   BLS curve =>
   Eq (VerKeyDSIGN (BLS12381DSIGN curve))
@@ -447,35 +393,89 @@ instance Show (SignKeyDSIGN (BLS12381DSIGN curve)) where
 
 instance
   BLS12381CurveConstraints curve =>
+  FixedSizeCodec (VerKeyDSIGN (BLS12381DSIGN curve))
+  where
+  type FixedSize (VerKeyDSIGN (BLS12381DSIGN curve)) = CompressedPointSize curve
+
+  -- Note that this also compresses the verification key according to the ZCash standard
+  {-# INLINE rawEncodeFixedSized #-}
+  rawEncodeFixedSized (VerKeyBLS12381 vkPSB) = blsCompress @curve vkPSB
+  {-# INLINE rawDecodeFixedSized #-}
+  rawDecodeFixedSized bs =
+    -- Note that this also performs a group membership check.
+    -- That is, the deserialised point is in the subgroup of Curve1/Curve2.
+    case blsUncompress @curve bs of
+      Left err -> failDecodeBLS "VerKeyDSIGN" $ show err
+      Right vkPsb ->
+        -- Reject the identity (point at infinity) as a verification key
+        if blsIsInf @curve vkPsb
+          then failDecodeBLS "VerKeyDSIGN" "infinity point"
+          else pure (VerKeyBLS12381 vkPsb)
+
+instance FixedSizeCodec (SignKeyDSIGN (BLS12381DSIGN curve)) where
+  type FixedSize (SignKeyDSIGN (BLS12381DSIGN curve)) = CARDANO_BLST_SCALAR_SIZE
+  {-# INLINE rawEncodeFixedSized #-}
+  rawEncodeFixedSized (SignKeyBLS12381 skPSB) = scalarToBS skPSB
+  {-# INLINE rawDecodeFixedSized #-}
+  rawDecodeFixedSized bs = do
+    -- A signing key is strictly a BE integer mod the curve order.
+    -- We must ensure they are valid Scalars, i.e., less than the curve order (255 bits).
+    case scalarFromBS bs of
+      Left err -> failDecodeBLS "SignKeyDSIGN" $ show err
+      Right skScalar ->
+        -- Reject the zero scalar as a signing key
+        if BS.all (== 0) (scalarToBS skScalar)
+          then failDecodeBLS "SignKeyDSIGN" "zero scalar"
+          else pure (SignKeyBLS12381 skScalar)
+
+instance
+  BLS12381CurveConstraints curve =>
+  FixedSizeCodec (SigDSIGN (BLS12381DSIGN curve))
+  where
+  type FixedSize (SigDSIGN (BLS12381DSIGN curve)) = CompressedPointSize (DualCurve curve)
+
+  -- Note that this also compresses the signature according to the ZCash standard
+  {-# INLINE rawEncodeFixedSized #-}
+  rawEncodeFixedSized (SigBLS12381 sigPSB) = blsCompress @(DualCurve curve) sigPSB
+  {-# INLINE rawDecodeFixedSized #-}
+  rawDecodeFixedSized bs =
+    -- Note that this also performs a group membership check.
+    -- That is, the deserialised point is in the subgroup of Curve1/Curve2.
+    case blsUncompress @(DualCurve curve) bs of
+      Left err -> failDecodeBLS "SigDSIGN" $ show err
+      Right sigPsb -> pure (SigBLS12381 sigPsb)
+
+instance
+  BLS12381CurveConstraints curve =>
   ToCBOR (VerKeyDSIGN (BLS12381DSIGN curve))
   where
-  toCBOR = encodeVerKeyDSIGN
+  toCBOR = encodeFixedSized
   encodedSizeExpr _ = encodedVerKeyDSIGNSizeExpr
 
 instance
   BLS12381CurveConstraints curve =>
   FromCBOR (VerKeyDSIGN (BLS12381DSIGN curve))
   where
-  fromCBOR = decodeVerKeyDSIGN
+  fromCBOR = decodeFixedSized
 
 instance
   BLS12381CurveConstraints curve =>
   ToCBOR (SignKeyDSIGN (BLS12381DSIGN curve))
   where
-  toCBOR = encodeSignKeyDSIGN
+  toCBOR = encodeFixedSized
   encodedSizeExpr _ = encodedSignKeyDSIGNSizeExpr
 
 instance
   BLS12381CurveConstraints curve =>
   FromCBOR (SignKeyDSIGN (BLS12381DSIGN curve))
   where
-  fromCBOR = decodeSignKeyDSIGN
+  fromCBOR = decodeFixedSized
 
 instance
   BLS12381CurveConstraints curve =>
   ToCBOR (SigDSIGN (BLS12381DSIGN curve))
   where
-  toCBOR = encodeSigDSIGN
+  toCBOR = encodeFixedSized
   encodedSizeExpr _ = encodedSigDSIGNSizeExpr
 
 -- | Helper functions to extract the internal Point representation
@@ -490,7 +490,7 @@ instance
   BLS12381CurveConstraints curve =>
   FromCBOR (SigDSIGN (BLS12381DSIGN curve))
   where
-  fromCBOR = decodeSigDSIGN
+  fromCBOR = decodeFixedSized
 
 instance
   BLS12381CurveConstraints curve =>
@@ -550,23 +550,32 @@ instance
     first
       (const "verifyPossessionProofDSIGN: BLS12381DSIGN failed to verify.")
       (verifyDSIGN ctx vk (rawSerialiseVerKeyDSIGN vk) (SigBLS12381 mu1Psb))
-  {-# INLINE rawSerialisePossessionProofDSIGN #-}
-  rawSerialisePossessionProofDSIGN (PossessionProofBLS12381 mu1Psb) =
-    blsCompress @(DualCurve curve) mu1Psb
-  {-# INLINE rawDeserialisePossessionProofDSIGN #-}
-  rawDeserialisePossessionProofDSIGN bs = do
-    -- Note that these also perform group membership and size checks.
-    -- It will also ensure that all of the supplied `ByteString` is consumed
-    -- through the size checks.
-    Right mu1Point <- pure $ blsUncompress @(DualCurve curve) bs
-    -- Reject the zero point (point at infinity) for both mu1 and mu2
-    if blsIsInf @(DualCurve curve) mu1Point
-      then Nothing
-      else Just $ PossessionProofBLS12381 mu1Point
 
 deriving stock instance
   BLS (DualCurve curve) =>
   Eq (PossessionProofDSIGN (BLS12381DSIGN curve))
+
+instance
+  BLS12381CurveConstraints curve =>
+  FixedSizeCodec (PossessionProofDSIGN (BLS12381DSIGN curve))
+  where
+  type
+    FixedSize (PossessionProofDSIGN (BLS12381DSIGN curve)) =
+      PossessionProofSizeDSIGN (BLS12381DSIGN curve)
+  rawEncodeFixedSized (PossessionProofBLS12381 mu1Psb) =
+    blsCompress @(DualCurve curve) mu1Psb
+  rawDecodeFixedSized bs = do
+    -- Note that these also perform group membership and size checks.
+    -- It will also ensure that all of the supplied `ByteString` is consumed
+    -- through the size checks.
+    case blsUncompress @(DualCurve curve) bs of
+      Left err -> failDecodeBLS "PossessionProofDSIGN" (show err)
+      Right mu1Point -> do
+        -- Reject the zero point (point at infinity) for both mu1 and mu2
+        when (blsIsInf @(DualCurve curve) mu1Point) $ do
+          failDecodeBLS "PossessionProofDSIGN" "infinity point"
+        pure $ PossessionProofBLS12381 mu1Point
+  {-# INLINE rawDecodeFixedSized #-}
 
 instance
   ( BLS12381CurveConstraints curve
@@ -574,7 +583,7 @@ instance
   ) =>
   ToCBOR (PossessionProofDSIGN (BLS12381DSIGN curve))
   where
-  toCBOR = encodePossessionProofDSIGN
+  toCBOR = encodeFixedSized
   encodedSizeExpr _ = encodedPossessionProofDSIGNSizeExpr
 
 instance
@@ -583,4 +592,4 @@ instance
   ) =>
   FromCBOR (PossessionProofDSIGN (BLS12381DSIGN curve))
   where
-  fromCBOR = decodePossessionProofDSIGN
+  fromCBOR = decodeFixedSized

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/BLS12381/Internal.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/BLS12381/Internal.hs
@@ -59,7 +59,6 @@ import Cardano.Crypto.DSIGN.Class (
   encodedSigDSIGNSizeExpr,
   encodedSignKeyDSIGNSizeExpr,
   encodedVerKeyDSIGNSizeExpr,
-  rawSerialiseVerKeyDSIGN,
   seedSizeDSIGN,
  )
 import Cardano.Crypto.EllipticCurve.BLS12_381.Internal (
@@ -543,13 +542,13 @@ instance
   {-# INLINE createPossessionProofDSIGN #-}
   createPossessionProofDSIGN ctx sk =
     let vk = deriveVerKeyDSIGN sk :: VerKeyDSIGN (BLS12381DSIGN curve)
-        SigBLS12381 sig = signDSIGN ctx (rawSerialiseVerKeyDSIGN vk) sk
+        SigBLS12381 sig = signDSIGN ctx (rawEncodeFixedSized vk) sk
      in PossessionProofBLS12381 sig
   {-# INLINE verifyPossessionProofDSIGN #-}
   verifyPossessionProofDSIGN ctx vk (PossessionProofBLS12381 mu1Psb) =
     first
       (const "verifyPossessionProofDSIGN: BLS12381DSIGN failed to verify.")
-      (verifyDSIGN ctx vk (rawSerialiseVerKeyDSIGN vk) (SigBLS12381 mu1Psb))
+      (verifyDSIGN ctx vk (rawEncodeFixedSized vk) (SigBLS12381 mu1Psb))
 
 deriving stock instance
   BLS (DualCurve curve) =>

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Class.hs
@@ -157,7 +157,7 @@ class
   deriveVerKeyDSIGN :: SignKeyDSIGN v -> VerKeyDSIGN v
 
   hashVerKeyDSIGN :: HashAlgorithm h => VerKeyDSIGN v -> Hash h (VerKeyDSIGN v)
-  hashVerKeyDSIGN = hashWith rawSerialiseVerKeyDSIGN
+  hashVerKeyDSIGN = hashWith rawEncodeFixedSized
 
   --
   -- Core algorithm operations
@@ -221,6 +221,13 @@ class
   rawDeserialiseSigDSIGN :: ByteString -> Maybe (SigDSIGN v)
   rawDeserialiseSigDSIGN = rawDecodeFixedSized
 
+{-# DEPRECATED rawSerialiseVerKeyDSIGN "Use `rawEncodeFixedSized` instead" #-}
+{-# DEPRECATED rawSerialiseSignKeyDSIGN "Use `rawEncodeFixedSized` instead" #-}
+{-# DEPRECATED rawSerialiseSigDSIGN "Use `rawEncodeFixedSized` instead" #-}
+{-# DEPRECATED rawDeserialiseVerKeyDSIGN "Use `rawDecodeFixedSized` instead" #-}
+{-# DEPRECATED rawDeserialiseSignKeyDSIGN "Use `rawDecodeFixedSized` instead" #-}
+{-# DEPRECATED rawDeserialiseSigDSIGN "Use `rawDecodeFixedSized` instead" #-}
+
 --
 -- Do not provide Ord instances for keys, see #38
 --
@@ -241,17 +248,17 @@ instance
   where
   compare = error "unsupported"
 
-{-# DEPRECATED sizeVerKeyDSIGN "In favor of `verKeySizeDSIGN`" #-}
+{-# DEPRECATED sizeVerKeyDSIGN "In favor of `fixedSize`" #-}
 sizeVerKeyDSIGN :: forall v proxy. DSIGNAlgorithm v => proxy v -> Word
-sizeVerKeyDSIGN = verKeySizeDSIGN
+sizeVerKeyDSIGN _ = fixedSize $ Proxy @(VerKeyDSIGN v)
 
-{-# DEPRECATED sizeSignKeyDSIGN "In favor of `signKeySizeDSIGN`" #-}
+{-# DEPRECATED sizeSignKeyDSIGN "In favor of `fixedSize`" #-}
 sizeSignKeyDSIGN :: forall v proxy. DSIGNAlgorithm v => proxy v -> Word
-sizeSignKeyDSIGN = signKeySizeDSIGN
+sizeSignKeyDSIGN _ = fixedSize $ Proxy @(SignKeyDSIGN v)
 
-{-# DEPRECATED sizeSigDSIGN "In favor of `sigSizeDSIGN`" #-}
+{-# DEPRECATED sizeSigDSIGN "In favor of `fixedSize`" #-}
 sizeSigDSIGN :: forall v proxy. DSIGNAlgorithm v => proxy v -> Word
-sizeSigDSIGN = sigSizeDSIGN
+sizeSigDSIGN _ = fixedSize $ Proxy @(SigDSIGN v)
 
 -- | The upper bound on the 'Seed' size needed by 'genKeyDSIGN'
 seedSizeDSIGN :: forall v proxy. DSIGNAlgorithm v => proxy v -> Word
@@ -259,12 +266,15 @@ seedSizeDSIGN _ = fromInteger (natVal (Proxy @(SeedSizeDSIGN v)))
 
 verKeySizeDSIGN :: forall v proxy. DSIGNAlgorithm v => proxy v -> Word
 verKeySizeDSIGN _ = fixedSize $ Proxy @(VerKeyDSIGN v)
+{-# DEPRECATED verKeySizeDSIGN "Use `fixedSize` instead" #-}
 
 signKeySizeDSIGN :: forall v proxy. DSIGNAlgorithm v => proxy v -> Word
 signKeySizeDSIGN _ = fixedSize $ Proxy @(SignKeyDSIGN v)
+{-# DEPRECATED signKeySizeDSIGN "Use `fixedSize` instead" #-}
 
 sigSizeDSIGN :: forall v proxy. DSIGNAlgorithm v => proxy v -> Word
 sigSizeDSIGN _ = fixedSize $ Proxy @(SigDSIGN v)
+{-# DEPRECATED sigSizeDSIGN "Use `fixedSize` instead" #-}
 
 --
 -- Convenient CBOR encoding/decoding
@@ -348,33 +358,27 @@ decodeSignedDSIGN = decodeFixedSized
 -- Encoded 'Size' expressions for 'ToCBOR' instances
 --
 
--- | 'Size' expression for 'VerKeyDSIGN' which is using 'verKeySizeDSIGN'
--- encoded as 'Size'.
 encodedVerKeyDSIGNSizeExpr :: forall v. DSIGNAlgorithm v => Proxy (VerKeyDSIGN v) -> Size
 encodedVerKeyDSIGNSizeExpr _proxy =
   -- 'encodeBytes' envelope
-  fromIntegral @Integer @Size (withWordSize (verKeySizeDSIGN (Proxy :: Proxy v)))
+  fromIntegral @Integer @Size (withWordSize (fixedSize (Proxy @(VerKeyDSIGN v))))
     -- payload
-    + fromIntegral @Word @Size (verKeySizeDSIGN (Proxy :: Proxy v))
+    + fromIntegral @Word @Size (fixedSize (Proxy @(VerKeyDSIGN v)))
 
--- | 'Size' expression for 'SignKeyDSIGN' which is using 'signKeySizeDSIGN'
--- encoded as 'Size'.
 encodedSignKeyDSIGNSizeExpr :: forall v. DSIGNAlgorithm v => Proxy (SignKeyDSIGN v) -> Size
 encodedSignKeyDSIGNSizeExpr _proxy =
   -- 'encodeBytes' envelope
   fromIntegral @Integer @Size
-    (withWordSize (signKeySizeDSIGN (Proxy :: Proxy v)))
+    (withWordSize (fixedSize (Proxy @(SignKeyDSIGN v))))
     -- payload
-    + fromIntegral @Word @Size (signKeySizeDSIGN (Proxy :: Proxy v))
+    + fromIntegral @Word @Size (fixedSize (Proxy @(SignKeyDSIGN v)))
 
--- | 'Size' expression for 'SigDSIGN' which is using 'sigSizeDSIGN' encoded as
--- 'Size'.
 encodedSigDSIGNSizeExpr :: forall v. DSIGNAlgorithm v => Proxy (SigDSIGN v) -> Size
 encodedSigDSIGNSizeExpr _proxy =
   -- 'encodeBytes' envelope
-  fromIntegral @Integer @Size (withWordSize (sigSizeDSIGN (Proxy :: Proxy v)))
+  fromIntegral @Integer @Size (withWordSize (fixedSize (Proxy @(SigDSIGN v))))
     -- payload
-    + fromIntegral @Word @Size (sigSizeDSIGN (Proxy :: Proxy v))
+    + fromIntegral @Word @Size (fixedSize (Proxy @(SigDSIGN v)))
 
 class (DSIGNAlgorithm v, NoThunks (SignKeyDSIGNM v)) => DSIGNMAlgorithm v where
   data SignKeyDSIGNM v :: Type
@@ -502,7 +506,7 @@ decodeSignKeyDSIGNM = do
               )
         | otherwise -> error "decodeSignKeyDSIGNM: cannot decode key"
         where
-          expected = fromIntegral @Word @Int (signKeySizeDSIGN (Proxy :: Proxy v))
+          expected = fromIntegral @Word @Int (fixedSize (Proxy @(SignKeyDSIGN v)))
           actual = BS.length bs
 
 -- | Extension of the `DSIGNAlgorithm` to allow for aggregatable digital
@@ -568,6 +572,9 @@ class
   rawDeserialisePossessionProofDSIGN :: ByteString -> Maybe (PossessionProofDSIGN v)
   rawDeserialisePossessionProofDSIGN = rawDecodeFixedSized
 
+{-# DEPRECATED rawSerialisePossessionProofDSIGN "Use `rawEncodeFixedSized` instead" #-}
+{-# DEPRECATED rawDeserialisePossessionProofDSIGN "Use `rawDecodeFixedSized` instead" #-}
+
 -- | Aggregate multiple verification keys into a single verification key given
 -- their corresponding Proofs of Possession.
 --
@@ -584,6 +591,7 @@ aggregateVerKeysDSIGN ctx verKeysAndPoPs = do
 
 possessionProofSizeDSIGN :: forall v proxy. DSIGNAggregatable v => proxy v -> Word
 possessionProofSizeDSIGN _ = fixedSize $ Proxy @(PossessionProofDSIGN v)
+{-# DEPRECATED possessionProofSizeDSIGN "Use `fixedSize` instead" #-}
 
 -- | Encode a PoP into CBOR.
 encodePossessionProofDSIGN :: DSIGNAggregatable v => PossessionProofDSIGN v -> Encoding
@@ -597,12 +605,10 @@ decodePossessionProofDSIGN = decodeFixedSized
 {-# INLINE decodePossessionProofDSIGN #-}
 {-# DEPRECATED decodePossessionProofDSIGN "Use `decodeFixedSized` instead" #-}
 
--- | 'Size' expression for 'PossessionProofDSIGN' which is using 'possessionProofSizeDSIGN'
--- encoded as 'Size'.
 encodedPossessionProofDSIGNSizeExpr ::
   forall v. DSIGNAggregatable v => Proxy (PossessionProofDSIGN v) -> Size
 encodedPossessionProofDSIGNSizeExpr _proxy =
   -- 'encodeBytes' envelope
-  fromIntegral @Integer @Size (withWordSize (possessionProofSizeDSIGN (Proxy :: Proxy v)))
+  fromIntegral @Integer @Size (withWordSize (fixedSize (Proxy @(PossessionProofDSIGN v))))
     -- payload
-    + fromIntegral @Word @Size (possessionProofSizeDSIGN (Proxy :: Proxy v))
+    + fromIntegral @Word @Size (fixedSize (Proxy @(PossessionProofDSIGN v)))

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Class.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuantifiedConstraints #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeApplications #-}
@@ -53,9 +54,6 @@ module Cardano.Crypto.DSIGN.Class (
   encodedSignKeyDSIGNSizeExpr,
   encodedSigDSIGNSizeExpr,
 
-  -- * Helper
-  failSizeCheck,
-
   -- * Unsound CBOR encoding and decoding of MLocked DSIGN keys
   UnsoundDSIGNMAlgorithm (..),
   encodeSignKeyDSIGNM,
@@ -89,6 +87,12 @@ import NoThunks.Class (NoThunks)
 
 import Cardano.Binary (Decoder, Encoding, Size, decodeBytes, encodeBytes, withWordSize)
 
+import Cardano.Binary.FixedSizeCodec (
+  FixedSizeCodec (..),
+  decodeFixedSized,
+  encodeFixedSized,
+  fixedSize,
+ )
 import Cardano.Crypto.Hash.Class (Hash, HashAlgorithm, hashWith)
 import Cardano.Crypto.Libsodium (MLockedAllocator, mlockedMalloc)
 import Cardano.Crypto.Libsodium.MLockedSeed
@@ -115,13 +119,19 @@ class
   , KnownNat (SignKeySizeDSIGN v)
   , KnownNat (VerKeySizeDSIGN v)
   , KnownNat (SigSizeDSIGN v)
+  , FixedSizeCodec (VerKeyDSIGN v)
+  , FixedSizeCodec (SignKeyDSIGN v)
+  , FixedSizeCodec (SigDSIGN v)
   ) =>
   DSIGNAlgorithm v
   where
   type SeedSizeDSIGN v :: Nat
   type SignKeySizeDSIGN v :: Nat
+  type SignKeySizeDSIGN v = FixedSize (SignKeyDSIGN v)
   type VerKeySizeDSIGN v :: Nat
+  type VerKeySizeDSIGN v = FixedSize (VerKeyDSIGN v)
   type SigSizeDSIGN v :: Nat
+  type SigSizeDSIGN v = FixedSize (SigDSIGN v)
 
   type SizeSignKeyDSIGN v :: Nat
   type SizeSignKeyDSIGN v = SignKeySizeDSIGN v
@@ -198,12 +208,18 @@ class
   --
 
   rawSerialiseVerKeyDSIGN :: VerKeyDSIGN v -> ByteString
+  rawSerialiseVerKeyDSIGN = rawEncodeFixedSized
   rawSerialiseSignKeyDSIGN :: SignKeyDSIGN v -> ByteString
+  rawSerialiseSignKeyDSIGN = rawEncodeFixedSized
   rawSerialiseSigDSIGN :: SigDSIGN v -> ByteString
+  rawSerialiseSigDSIGN = rawEncodeFixedSized
 
   rawDeserialiseVerKeyDSIGN :: ByteString -> Maybe (VerKeyDSIGN v)
+  rawDeserialiseVerKeyDSIGN = rawDecodeFixedSized
   rawDeserialiseSignKeyDSIGN :: ByteString -> Maybe (SignKeyDSIGN v)
+  rawDeserialiseSignKeyDSIGN = rawDecodeFixedSized
   rawDeserialiseSigDSIGN :: ByteString -> Maybe (SigDSIGN v)
+  rawDeserialiseSigDSIGN = rawDecodeFixedSized
 
 --
 -- Do not provide Ord instances for keys, see #38
@@ -242,11 +258,13 @@ seedSizeDSIGN :: forall v proxy. DSIGNAlgorithm v => proxy v -> Word
 seedSizeDSIGN _ = fromInteger (natVal (Proxy @(SeedSizeDSIGN v)))
 
 verKeySizeDSIGN :: forall v proxy. DSIGNAlgorithm v => proxy v -> Word
-verKeySizeDSIGN _ = fromInteger (natVal (Proxy @(VerKeySizeDSIGN v)))
+verKeySizeDSIGN _ = fixedSize $ Proxy @(VerKeyDSIGN v)
+
 signKeySizeDSIGN :: forall v proxy. DSIGNAlgorithm v => proxy v -> Word
-signKeySizeDSIGN _ = fromInteger (natVal (Proxy @(SignKeySizeDSIGN v)))
+signKeySizeDSIGN _ = fixedSize $ Proxy @(SignKeyDSIGN v)
+
 sigSizeDSIGN :: forall v proxy. DSIGNAlgorithm v => proxy v -> Word
-sigSizeDSIGN _ = fromInteger (natVal (Proxy @(SigSizeDSIGN v)))
+sigSizeDSIGN _ = fixedSize $ Proxy @(SigDSIGN v)
 
 --
 -- Convenient CBOR encoding/decoding
@@ -255,53 +273,31 @@ sigSizeDSIGN _ = fromInteger (natVal (Proxy @(SigSizeDSIGN v)))
 --
 
 encodeVerKeyDSIGN :: DSIGNAlgorithm v => VerKeyDSIGN v -> Encoding
-encodeVerKeyDSIGN = encodeBytes . rawSerialiseVerKeyDSIGN
+encodeVerKeyDSIGN = encodeFixedSized
+{-# DEPRECATED encodeVerKeyDSIGN "Use `encodeFixedSized` instead" #-}
 
 encodeSignKeyDSIGN :: DSIGNAlgorithm v => SignKeyDSIGN v -> Encoding
-encodeSignKeyDSIGN = encodeBytes . rawSerialiseSignKeyDSIGN
+encodeSignKeyDSIGN = encodeFixedSized
+{-# DEPRECATED encodeSignKeyDSIGN "Use `encodeFixedSized` instead" #-}
 
 encodeSigDSIGN :: DSIGNAlgorithm v => SigDSIGN v -> Encoding
-encodeSigDSIGN = encodeBytes . rawSerialiseSigDSIGN
+encodeSigDSIGN = encodeFixedSized
+{-# DEPRECATED encodeSigDSIGN "Use `encodeFixedSized` instead" #-}
 
 decodeVerKeyDSIGN :: forall v s. DSIGNAlgorithm v => Decoder s (VerKeyDSIGN v)
-decodeVerKeyDSIGN = do
-  bs <- decodeBytes
-  case rawDeserialiseVerKeyDSIGN bs of
-    Just vk -> return vk
-    Nothing -> failSizeCheck "decodeVerKeyDSIGN" "key" bs (verKeySizeDSIGN (Proxy :: Proxy v))
+decodeVerKeyDSIGN = decodeFixedSized
 {-# INLINE decodeVerKeyDSIGN #-}
+{-# DEPRECATED decodeVerKeyDSIGN "Use `decodeFixedSized` instead" #-}
 
 decodeSignKeyDSIGN :: forall v s. DSIGNAlgorithm v => Decoder s (SignKeyDSIGN v)
-decodeSignKeyDSIGN = do
-  bs <- decodeBytes
-  case rawDeserialiseSignKeyDSIGN bs of
-    Just sk -> return sk
-    Nothing -> failSizeCheck "decodeSignKeyDSIGN" "key" bs (signKeySizeDSIGN (Proxy :: Proxy v))
+decodeSignKeyDSIGN = decodeFixedSized
+{-# INLINE decodeSignKeyDSIGN #-}
+{-# DEPRECATED decodeSignKeyDSIGN "Use `decodeFixedSized` instead" #-}
 
 decodeSigDSIGN :: forall v s. DSIGNAlgorithm v => Decoder s (SigDSIGN v)
-decodeSigDSIGN = do
-  bs <- decodeBytes
-  case rawDeserialiseSigDSIGN bs of
-    Just sig -> return sig
-    Nothing -> failSizeCheck "decodeSigDSIGN" "signature" bs (sigSizeDSIGN (Proxy :: Proxy v))
+decodeSigDSIGN = decodeFixedSized
 {-# INLINE decodeSigDSIGN #-}
-
--- | Helper function that always fails, but it provides a different message whenever
--- expected size does not match.
-failSizeCheck :: MonadFail m => String -> String -> ByteString -> Word -> m a
-failSizeCheck fname name bs expectedSize
-  | actualSize /= expectedSize =
-      fail
-        ( fname
-            ++ ": wrong length, expected "
-            ++ show expectedSize
-            ++ " bytes but got "
-            ++ show actualSize
-        )
-  | otherwise = fail $ fname ++ ": cannot decode " ++ name
-  where
-    actualSize = fromIntegral @Int @Word (BS.length bs)
-{-# NOINLINE failSizeCheck #-}
+{-# DEPRECATED decodeSigDSIGN "Use `decodeFixedSized` instead" #-}
 
 newtype SignedDSIGN v a = SignedDSIGN (SigDSIGN v)
   deriving (Generic)
@@ -313,7 +309,14 @@ deriving instance NFData (SigDSIGN v) => NFData (SignedDSIGN v a)
 
 instance DSIGNAlgorithm v => NoThunks (SignedDSIGN v a)
 
--- use generic instance
+instance
+  FixedSizeCodec (SigDSIGN v) =>
+  FixedSizeCodec (SignedDSIGN v a)
+  where
+  type FixedSize (SignedDSIGN v a) = FixedSize (SigDSIGN v)
+
+  rawEncodeFixedSized (SignedDSIGN x) = rawEncodeFixedSized x
+  rawDecodeFixedSized bs = SignedDSIGN <$> rawDecodeFixedSized bs
 
 signedDSIGN ::
   (DSIGNAlgorithm v, Signable v a) =>
@@ -333,11 +336,13 @@ verifySignedDSIGN ::
 verifySignedDSIGN ctxt key a (SignedDSIGN s) = verifyDSIGN ctxt key a s
 
 encodeSignedDSIGN :: DSIGNAlgorithm v => SignedDSIGN v a -> Encoding
-encodeSignedDSIGN (SignedDSIGN s) = encodeSigDSIGN s
+encodeSignedDSIGN = encodeFixedSized
+{-# DEPRECATED encodeSignedDSIGN "Use `encodeFixedSized` instead" #-}
 
 decodeSignedDSIGN :: DSIGNAlgorithm v => Decoder s (SignedDSIGN v a)
-decodeSignedDSIGN = SignedDSIGN <$> decodeSigDSIGN
+decodeSignedDSIGN = decodeFixedSized
 {-# INLINE decodeSignedDSIGN #-}
+{-# DEPRECATED decodeSignedDSIGN "Use `decodeFixedSized` instead" #-}
 
 --
 -- Encoded 'Size' expressions for 'ToCBOR' instances
@@ -516,6 +521,7 @@ class
   , Eq (PossessionProofDSIGN v)
   , NoThunks (PossessionProofDSIGN v)
   , KnownNat (PossessionProofSizeDSIGN v)
+  , FixedSizeCodec (PossessionProofDSIGN v)
   ) =>
   DSIGNAggregatable v
   where
@@ -556,9 +562,11 @@ class
 
   -- | Serialise a PoP into fixed-size raw bytes.
   rawSerialisePossessionProofDSIGN :: PossessionProofDSIGN v -> ByteString
+  rawSerialisePossessionProofDSIGN = rawEncodeFixedSized
 
   -- | Deserialise a PoP from fixed-size raw bytes.
   rawDeserialisePossessionProofDSIGN :: ByteString -> Maybe (PossessionProofDSIGN v)
+  rawDeserialisePossessionProofDSIGN = rawDecodeFixedSized
 
 -- | Aggregate multiple verification keys into a single verification key given
 -- their corresponding Proofs of Possession.
@@ -575,25 +583,19 @@ aggregateVerKeysDSIGN ctx verKeysAndPoPs = do
   uncheckedAggregateVerKeysDSIGN (map fst verKeysAndPoPs)
 
 possessionProofSizeDSIGN :: forall v proxy. DSIGNAggregatable v => proxy v -> Word
-possessionProofSizeDSIGN _ = fromInteger (natVal (Proxy @(PossessionProofSizeDSIGN v)))
+possessionProofSizeDSIGN _ = fixedSize $ Proxy @(PossessionProofDSIGN v)
 
 -- | Encode a PoP into CBOR.
 encodePossessionProofDSIGN :: DSIGNAggregatable v => PossessionProofDSIGN v -> Encoding
-encodePossessionProofDSIGN = encodeBytes . rawSerialisePossessionProofDSIGN
+encodePossessionProofDSIGN = encodeFixedSized
+{-# DEPRECATED encodePossessionProofDSIGN "Use `encodeFixedSized` instead" #-}
 
 -- | Decode a PoP from CBOR.
 decodePossessionProofDSIGN ::
   forall v s. DSIGNAggregatable v => Decoder s (PossessionProofDSIGN v)
-decodePossessionProofDSIGN = do
-  bs <- decodeBytes
-  case rawDeserialisePossessionProofDSIGN bs of
-    Just pop -> return pop
-    Nothing ->
-      failSizeCheck
-        "decodePossessionProof"
-        "proof of possession"
-        bs
-        (possessionProofSizeDSIGN (Proxy :: Proxy v))
+decodePossessionProofDSIGN = decodeFixedSized
+{-# INLINE decodePossessionProofDSIGN #-}
+{-# DEPRECATED decodePossessionProofDSIGN "Use `decodeFixedSized` instead" #-}
 
 -- | 'Size' expression for 'PossessionProofDSIGN' which is using 'possessionProofSizeDSIGN'
 -- encoded as 'Size'.

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/EcdsaSecp256k1.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/EcdsaSecp256k1.hs
@@ -36,34 +36,24 @@ module Cardano.Crypto.DSIGN.EcdsaSecp256k1 (
 ) where
 
 import Cardano.Binary (FromCBOR (fromCBOR), ToCBOR (encodedSizeExpr, toCBOR))
+import Cardano.Binary.FixedSizeCodec (
+  FixedSizeCodec (..),
+  decodeFixedSized,
+  encodeFixedSized,
+ )
 import Cardano.Crypto.DSIGN.Class (
   DSIGNAlgorithm (
     SeedSizeDSIGN,
     SigDSIGN,
-    SigSizeDSIGN,
     SignKeyDSIGN,
-    SignKeySizeDSIGN,
     Signable,
     VerKeyDSIGN,
-    VerKeySizeDSIGN,
     algorithmNameDSIGN,
     deriveVerKeyDSIGN,
     genKeyDSIGN,
-    rawDeserialiseSigDSIGN,
-    rawDeserialiseSignKeyDSIGN,
-    rawDeserialiseVerKeyDSIGN,
-    rawSerialiseSigDSIGN,
-    rawSerialiseSignKeyDSIGN,
-    rawSerialiseVerKeyDSIGN,
     signDSIGN,
     verifyDSIGN
   ),
-  decodeSigDSIGN,
-  decodeSignKeyDSIGN,
-  decodeVerKeyDSIGN,
-  encodeSigDSIGN,
-  encodeSignKeyDSIGN,
-  encodeVerKeyDSIGN,
   encodedSigDSIGNSizeExpr,
   encodedSignKeyDSIGNSizeExpr,
   encodedVerKeyDSIGNSizeExpr,
@@ -74,7 +64,8 @@ import Cardano.Crypto.PinnedSizedBytes (
   psbCreateLen,
   psbCreateSized,
   psbCreateSizedResult,
-  psbFromByteStringCheck,
+  psbFromByteStringForM,
+  psbFromByteStringM,
   psbToByteString,
   psbUseAsCPtrLen,
   psbUseAsSizedPtr,
@@ -104,7 +95,7 @@ import Control.Monad (unless, void, when)
 import Crypto.Random (getRandomBytes)
 import Data.ByteString (ByteString)
 import Data.Kind (Type)
-import Data.Proxy (Proxy)
+import Data.Proxy (Proxy (..))
 import Foreign.C.Types (CSize)
 import Foreign.ForeignPtr (withForeignPtr)
 import Foreign.Marshal.Alloc (alloca)
@@ -129,14 +120,21 @@ newtype MessageHash = MH (PinnedSizedBytes SECP256K1_ECDSA_MESSAGE_BYTES)
   deriving stock (Show)
   deriving newtype (ToCBOR, FromCBOR)
 
+instance FixedSizeCodec MessageHash where
+  type FixedSize MessageHash = SECP256K1_ECDSA_MESSAGE_BYTES
+  rawEncodeFixedSized (MH psb) = rawEncodeFixedSized psb
+  rawDecodeFixedSized bs = MH <$> rawDecodeFixedSized bs
+
 -- | Take a blob of bytes (which is presumed to be a 32-byte hash), verify its
 -- length, and package it into a 'MessageHash' if that length is exactly 32.
 toMessageHash :: ByteString -> Maybe MessageHash
-toMessageHash bs = MH <$> psbFromByteStringCheck bs
+toMessageHash = rawDecodeFixedSized
+{-# DEPRECATED toMessageHash "Use `rawDecodeFixedSized` instead" #-}
 
 -- | Turn a 'MessageHash' into its bytes without a length marker.
 fromMessageHash :: MessageHash -> ByteString
-fromMessageHash (MH psb) = psbToByteString psb
+fromMessageHash = rawEncodeFixedSized
+{-# DEPRECATED fromMessageHash "Use rawEncodeFixedSized instead" #-}
 
 -- | A helper to use with the 'HashAlgorithm' API, as this can ensure sizing.
 hashAndPack ::
@@ -145,7 +143,7 @@ hashAndPack ::
   Proxy h ->
   ByteString ->
   MessageHash
-hashAndPack p bs = case psbFromByteStringCheck . digest p $ bs of
+hashAndPack p bs = case rawDecodeFixedSized . digest p $ bs of
   Nothing ->
     error $
       "hashAndPack: unexpected mismatch of guaranteed hash length\n"
@@ -156,9 +154,6 @@ data EcdsaSecp256k1DSIGN
 
 instance DSIGNAlgorithm EcdsaSecp256k1DSIGN where
   type SeedSizeDSIGN EcdsaSecp256k1DSIGN = SECP256K1_ECDSA_PRIVKEY_BYTES
-  type SigSizeDSIGN EcdsaSecp256k1DSIGN = SECP256K1_ECDSA_SIGNATURE_BYTES
-  type SignKeySizeDSIGN EcdsaSecp256k1DSIGN = SECP256K1_ECDSA_PRIVKEY_BYTES
-  type VerKeySizeDSIGN EcdsaSecp256k1DSIGN = SECP256K1_ECDSA_PUBKEY_BYTES
   type Signable EcdsaSecp256k1DSIGN = ((~) MessageHash)
   newtype VerKeyDSIGN EcdsaSecp256k1DSIGN
     = VerKeyEcdsaSecp256k1 (PinnedSizedBytes SECP256K1_ECDSA_PUBKEY_BYTES_INTERNAL)
@@ -210,26 +205,17 @@ instance DSIGNAlgorithm EcdsaSecp256k1DSIGN where
               _ -> Right ()
   genKeyDSIGN seed = runMonadRandomWithSeed seed $ do
     bs <- getRandomBytes 32
-    case psbFromByteStringCheck bs of
+    case rawDecodeFixedSized bs of
       Nothing -> error "genKeyDSIGN: Failed to generate SignKeyDSIGN EcdsaSecp256k1DSIGN unexpectedly"
       Just psb -> pure $ SignKeyEcdsaSecp256k1 psb
-  {-# NOINLINE rawSerialiseSigDSIGN #-}
-  rawSerialiseSigDSIGN (SigEcdsaSecp256k1 psb) =
-    psbToByteString @SECP256K1_ECDSA_SIGNATURE_BYTES . unsafeDupablePerformIO $ do
-      psbUseAsSizedPtr psb $ \psp ->
-        psbCreateSized $ \dstp ->
-          withForeignPtr secpCtxPtr $ \ctx ->
-            void $ secpEcdsaSignatureSerializeCompact ctx dstp psp
-  {-# NOINLINE rawSerialiseVerKeyDSIGN #-}
-  rawSerialiseVerKeyDSIGN (VerKeyEcdsaSecp256k1 psb) =
+
+instance FixedSizeCodec (VerKeyDSIGN EcdsaSecp256k1DSIGN) where
+  type FixedSize (VerKeyDSIGN EcdsaSecp256k1DSIGN) = SECP256K1_ECDSA_PUBKEY_BYTES
+  {-# NOINLINE rawEncodeFixedSized #-}
+  rawEncodeFixedSized (VerKeyEcdsaSecp256k1 psb) =
     psbToByteString . unsafeDupablePerformIO . psbUseAsSizedPtr psb $ \psp ->
       psbCreateLen @SECP256K1_ECDSA_PUBKEY_BYTES $ \ptr len -> do
         let dstp = castPtr ptr
-        -- This is necessary because of how the C API handles checking writes:
-        -- maximum permissible length is given as a pointer, which is
-        -- overwritten to indicate the number of bytes we actually wrote; if
-        -- we get a mismatch, then the serialization failed. While an odd
-        -- choice, we have to go with it.
         alloca $ \(lenPtr :: Ptr CSize) -> do
           poke lenPtr len
           withForeignPtr secpCtxPtr $ \ctx -> do
@@ -237,34 +223,19 @@ instance DSIGNAlgorithm EcdsaSecp256k1DSIGN where
             writtenLen <- peek lenPtr
             unless
               (writtenLen == len)
-              (error "rawSerializeVerKeyDSIGN: Did not write correct length for VerKeyDSIGN EcdsaSecp256k1DSIGN")
-            -- This should never happen, since `secpEcPubkeySerialize` in the current
-            -- version of `secp256k1` library always returns 1:
+              (error "rawEncodeFixedSized @(VerKeyDSIGN EcdsaSecp256k1DSIGN): Did not write correct length")
             unless
               (ret == 1)
-              (error "rawSerializeVerKeyDSIGN: Failed for unknown reason")
-  rawSerialiseSignKeyDSIGN (SignKeyEcdsaSecp256k1 psb) = psbToByteString psb
-  {-# NOINLINE rawDeserialiseSigDSIGN #-}
-  rawDeserialiseSigDSIGN bs =
-    SigEcdsaSecp256k1 <$> (psbFromByteStringCheck bs >>= go)
+              (error "rawEncodeFixedSized @(VerKeyDSIGN EcdsaSecp256k1DSIGN): Failed for unknown reason")
+  {-# NOINLINE rawDecodeFixedSized #-}
+  rawDecodeFixedSized bs = do
+    psb <- psbFromByteStringM bs
+    VerKeyEcdsaSecp256k1 <$> go psb
     where
       go ::
-        PinnedSizedBytes SECP256K1_ECDSA_SIGNATURE_BYTES ->
-        Maybe (PinnedSizedBytes SECP256K1_ECDSA_SIGNATURE_BYTES_INTERNAL)
-      go psb = unsafeDupablePerformIO . psbUseAsSizedPtr psb $ \psp -> do
-        (sigPsb, res) <- psbCreateSizedResult $ \sigp ->
-          withForeignPtr secpCtxPtr $ \ctx ->
-            secpEcdsaSignatureParseCompact ctx sigp psp
-        pure $ case res of
-          1 -> pure sigPsb
-          _ -> Nothing
-  {-# NOINLINE rawDeserialiseVerKeyDSIGN #-}
-  rawDeserialiseVerKeyDSIGN bs =
-    VerKeyEcdsaSecp256k1 <$> (psbFromByteStringCheck bs >>= go)
-    where
-      go ::
+        MonadFail m =>
         PinnedSizedBytes SECP256K1_ECDSA_PUBKEY_BYTES ->
-        Maybe (PinnedSizedBytes SECP256K1_ECDSA_PUBKEY_BYTES_INTERNAL)
+        m (PinnedSizedBytes SECP256K1_ECDSA_PUBKEY_BYTES_INTERNAL)
       go psb = unsafeDupablePerformIO . psbUseAsCPtrLen psb $ \p srcLen -> do
         let srcp = castPtr p
         (vkPsb, res) <- psbCreateSizedResult $ \vkp ->
@@ -272,27 +243,56 @@ instance DSIGNAlgorithm EcdsaSecp256k1DSIGN where
             secpEcPubkeyParse ctx vkp srcp srcLen
         pure $ case res of
           1 -> pure vkPsb
-          _ -> Nothing
-  rawDeserialiseSignKeyDSIGN bs =
-    SignKeyEcdsaSecp256k1 <$> psbFromByteStringCheck bs
+          _ -> fail "VerKeyDSIGN SchnorrSecp256k1DSIGN: deserialisation failed"
+
+instance FixedSizeCodec (SignKeyDSIGN EcdsaSecp256k1DSIGN) where
+  type FixedSize (SignKeyDSIGN EcdsaSecp256k1DSIGN) = SECP256K1_ECDSA_PRIVKEY_BYTES
+  rawEncodeFixedSized (SignKeyEcdsaSecp256k1 psb) = psbToByteString psb
+  rawDecodeFixedSized bs = SignKeyEcdsaSecp256k1 <$> rawDecodeFixedSized bs
+
+instance FixedSizeCodec (SigDSIGN EcdsaSecp256k1DSIGN) where
+  type FixedSize (SigDSIGN EcdsaSecp256k1DSIGN) = SECP256K1_ECDSA_SIGNATURE_BYTES
+  {-# NOINLINE rawEncodeFixedSized #-}
+  rawEncodeFixedSized (SigEcdsaSecp256k1 psb) =
+    psbToByteString @SECP256K1_ECDSA_SIGNATURE_BYTES . unsafeDupablePerformIO $ do
+      psbUseAsSizedPtr psb $ \psp ->
+        psbCreateSized $ \dstp ->
+          withForeignPtr secpCtxPtr $ \ctx ->
+            void $ secpEcdsaSignatureSerializeCompact ctx dstp psp
+  {-# NOINLINE rawDecodeFixedSized #-}
+  rawDecodeFixedSized bs = do
+    psb <- psbFromByteStringForM (Proxy @(SigDSIGN EcdsaSecp256k1DSIGN)) bs
+    SigEcdsaSecp256k1 <$> go psb
+    where
+      go ::
+        MonadFail m =>
+        PinnedSizedBytes SECP256K1_ECDSA_SIGNATURE_BYTES ->
+        m (PinnedSizedBytes SECP256K1_ECDSA_SIGNATURE_BYTES_INTERNAL)
+      go psb = unsafeDupablePerformIO . psbUseAsSizedPtr psb $ \psp -> do
+        (sigPsb, res) <- psbCreateSizedResult $ \sigp ->
+          withForeignPtr secpCtxPtr $ \ctx ->
+            secpEcdsaSignatureParseCompact ctx sigp psp
+        pure $ case res of
+          1 -> pure sigPsb
+          _ -> fail "SigDSIGN: deserialisation failed"
 
 instance ToCBOR (VerKeyDSIGN EcdsaSecp256k1DSIGN) where
-  toCBOR = encodeVerKeyDSIGN
+  toCBOR = encodeFixedSized
   encodedSizeExpr _ = encodedVerKeyDSIGNSizeExpr
 
 instance FromCBOR (VerKeyDSIGN EcdsaSecp256k1DSIGN) where
-  fromCBOR = decodeVerKeyDSIGN
+  fromCBOR = decodeFixedSized
 
 instance ToCBOR (SignKeyDSIGN EcdsaSecp256k1DSIGN) where
-  toCBOR = encodeSignKeyDSIGN
+  toCBOR = encodeFixedSized
   encodedSizeExpr _ = encodedSignKeyDSIGNSizeExpr
 
 instance FromCBOR (SignKeyDSIGN EcdsaSecp256k1DSIGN) where
-  fromCBOR = decodeSignKeyDSIGN
+  fromCBOR = decodeFixedSized
 
 instance ToCBOR (SigDSIGN EcdsaSecp256k1DSIGN) where
-  toCBOR = encodeSigDSIGN
+  toCBOR = encodeFixedSized
   encodedSizeExpr _ = encodedSigDSIGNSizeExpr
 
 instance FromCBOR (SigDSIGN EcdsaSecp256k1DSIGN) where
-  fromCBOR = decodeSigDSIGN
+  fromCBOR = decodeFixedSized

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed25519.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed25519.hs
@@ -33,8 +33,14 @@ module Cardano.Crypto.DSIGN.Ed25519 (
 )
 where
 
+import Cardano.Binary.FixedSizeCodec (
+  FixedSizeCodec (..),
+  decodeFixedSized,
+  encodeFixedSized,
+  guardFixedSized,
+ )
 import Control.DeepSeq (NFData (..), rwhnf)
-import Control.Monad (guard, unless, (<$!>))
+import Control.Monad (unless, (<$!>))
 import Control.Monad.Class.MonadST (MonadST (..))
 import Control.Monad.Class.MonadThrow (MonadThrow (..), throwIO)
 import Control.Monad.ST (ST)
@@ -69,7 +75,6 @@ import Cardano.Crypto.PinnedSizedBytes (
   psbCreate,
   psbCreateSized,
   psbCreateSizedResult,
-  psbFromByteStringCheck,
   psbToByteString,
   psbUseAsCPtrLen,
   psbUseAsSizedPtr,
@@ -133,24 +138,6 @@ instance DSIGNAlgorithm Ed25519DSIGN where
   -- a sign key is literally just taking a chunk from the seed. We use
   -- SEEDBYTES to define both the seed size and the sign key size.
   type SeedSizeDSIGN Ed25519DSIGN = CRYPTO_SIGN_ED25519_SEEDBYTES
-
-  -- \| Ed25519 key size is 32 octets
-  -- (per <https://tools.ietf.org/html/rfc8032#section-5.1.6>)
-  type VerKeySizeDSIGN Ed25519DSIGN = CRYPTO_SIGN_ED25519_PUBLICKEYBYTES
-
-  -- \| Ed25519 secret key size is 32 octets; however, libsodium packs both
-  -- the secret key and the public key into a 64-octet compound and exposes
-  -- that as the secret key; the actual 32-octet secret key is called
-  -- \"seed\" in libsodium. For backwards compatibility reasons and
-  -- efficiency, we use the 64-octet compounds internally (this is what
-  -- libsodium expects), but we only serialize the 32-octet secret key part
-  -- (the libsodium \"seed\"). And because of this, we need to define the
-  -- sign key size to be SEEDBYTES (which is 32), not PRIVATEKEYBYTES (which
-  -- would be 64).
-  type SignKeySizeDSIGN Ed25519DSIGN = CRYPTO_SIGN_ED25519_SEEDBYTES
-
-  -- \| Ed25519 signature size is 64 octets
-  type SigSizeDSIGN Ed25519DSIGN = CRYPTO_SIGN_ED25519_BYTES
 
   --
   -- Key and signature types
@@ -233,28 +220,6 @@ instance DSIGNAlgorithm Ed25519DSIGN where
                 allocaSized $ \pkPtr -> do
                   cOrThrowError "genKeyDSIGN @Ed25519DSIGN" "c_crypto_sign_ed25519_seed_keypair" $
                     c_crypto_sign_ed25519_seed_keypair pkPtr skPtr (SizedPtr . castPtr $ seedPtr)
-
-  --
-  -- raw serialise/deserialise
-  --
-
-  rawSerialiseVerKeyDSIGN (VerKeyEd25519DSIGN vk) = psbToByteString vk
-  rawSerialiseSignKeyDSIGN (SignKeyEd25519DSIGN sk) =
-    psbToByteString @(SeedSizeDSIGN Ed25519DSIGN) $ unsafeDupablePerformIO $ do
-      psbCreateSized $ \seedPtr ->
-        psbUseAsSizedPtr sk $ \skPtr ->
-          cOrThrowError "deriveVerKeyDSIGN @Ed25519DSIGN" "c_crypto_sign_ed25519_sk_to_seed" $
-            c_crypto_sign_ed25519_sk_to_seed seedPtr skPtr
-
-  rawSerialiseSigDSIGN (SigEd25519DSIGN sig) = psbToByteString sig
-
-  rawDeserialiseVerKeyDSIGN = fmap VerKeyEd25519DSIGN . psbFromByteStringCheck
-  {-# INLINE rawDeserialiseVerKeyDSIGN #-}
-  rawDeserialiseSignKeyDSIGN bs = do
-    guard (fromIntegral @Int @Word (BS.length bs) == seedSizeDSIGN (Proxy @Ed25519DSIGN))
-    pure . genKeyDSIGN . mkSeedFromBytes $ bs
-  rawDeserialiseSigDSIGN = fmap SigEd25519DSIGN . psbFromByteStringCheck
-  {-# INLINE rawDeserialiseSigDSIGN #-}
 
 instance DSIGNMAlgorithm Ed25519DSIGN where
   -- Note that the size of the internal key data structure is the SECRET KEY
@@ -352,26 +317,61 @@ instance UnsoundDSIGNMAlgorithm Ed25519DSIGN where
         mlockedSeedFinalize seed
         return sk
 
+instance FixedSizeCodec (VerKeyDSIGN Ed25519DSIGN) where
+  -- \| Ed25519 key size is 32 octets
+  -- (per <https://tools.ietf.org/html/rfc8032#section-5.1.6>)
+  type FixedSize (VerKeyDSIGN Ed25519DSIGN) = CRYPTO_SIGN_ED25519_PUBLICKEYBYTES
+  rawEncodeFixedSized (VerKeyEd25519DSIGN vk) = psbToByteString vk
+  rawDecodeFixedSized bs = VerKeyEd25519DSIGN <$> rawDecodeFixedSized bs
+  {-# INLINE rawDecodeFixedSized #-}
+
+instance FixedSizeCodec (SignKeyDSIGN Ed25519DSIGN) where
+  -- \| Ed25519 secret key size is 32 octets; however, libsodium packs both
+  -- the secret key and the public key into a 64-octet compound and exposes
+  -- that as the secret key; the actual 32-octet secret key is called
+  -- \"seed\" in libsodium. For backwards compatibility reasons and
+  -- efficiency, we use the 64-octet compounds internally (this is what
+  -- libsodium expects), but we only serialize the 32-octet secret key part
+  -- (the libsodium \"seed\"). And because of this, we need to define the
+  -- sign key size to be SEEDBYTES (which is 32), not PRIVATEKEYBYTES (which
+  -- would be 64).
+  type FixedSize (SignKeyDSIGN Ed25519DSIGN) = CRYPTO_SIGN_ED25519_SEEDBYTES
+  rawEncodeFixedSized (SignKeyEd25519DSIGN sk) =
+    psbToByteString @(SeedSizeDSIGN Ed25519DSIGN) $ unsafeDupablePerformIO $ do
+      psbCreateSized $ \seedPtr ->
+        psbUseAsSizedPtr sk $ \skPtr ->
+          cOrThrowError "rawEncodeFixedSized @(SignKeyDSIGN Ed25519DSIGN)" "c_crypto_sign_ed25519_sk_to_seed" $
+            c_crypto_sign_ed25519_sk_to_seed seedPtr skPtr
+  rawDecodeFixedSized bs = guardFixedSized bs $ pure . genKeyDSIGN $ mkSeedFromBytes bs
+  {-# INLINE rawDecodeFixedSized #-}
+
+instance FixedSizeCodec (SigDSIGN Ed25519DSIGN) where
+  -- \| Ed25519 signature size is 64 octets
+  type FixedSize (SigDSIGN Ed25519DSIGN) = CRYPTO_SIGN_ED25519_BYTES
+  rawEncodeFixedSized (SigEd25519DSIGN sig) = psbToByteString sig
+  rawDecodeFixedSized bs = SigEd25519DSIGN <$> rawDecodeFixedSized bs
+  {-# INLINE rawDecodeFixedSized #-}
+
 instance ToCBOR (VerKeyDSIGN Ed25519DSIGN) where
-  toCBOR = encodeVerKeyDSIGN
+  toCBOR = encodeFixedSized
   encodedSizeExpr _ = encodedVerKeyDSIGNSizeExpr
 
 instance FromCBOR (VerKeyDSIGN Ed25519DSIGN) where
-  fromCBOR = decodeVerKeyDSIGN
+  fromCBOR = decodeFixedSized
 
 instance ToCBOR (SignKeyDSIGN Ed25519DSIGN) where
-  toCBOR = encodeSignKeyDSIGN
+  toCBOR = encodeFixedSized
   encodedSizeExpr _ = encodedSignKeyDSIGNSizeExpr
 
 instance FromCBOR (SignKeyDSIGN Ed25519DSIGN) where
-  fromCBOR = decodeSignKeyDSIGN
+  fromCBOR = decodeFixedSized
 
 instance ToCBOR (SigDSIGN Ed25519DSIGN) where
-  toCBOR = encodeSigDSIGN
+  toCBOR = encodeFixedSized
   encodedSizeExpr _ = encodedSigDSIGNSizeExpr
 
 instance FromCBOR (SigDSIGN Ed25519DSIGN) where
-  fromCBOR = decodeSigDSIGN
+  fromCBOR = decodeFixedSized
 
 instance
   TypeError ('Text "CBOR encoding would violate mlocking guarantees") =>

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed25519.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed25519.hs
@@ -37,6 +37,7 @@ import Cardano.Binary.FixedSizeCodec (
   FixedSizeCodec (..),
   decodeFixedSized,
   encodeFixedSized,
+  fixedSize,
   guardFixedSized,
  )
 import Control.DeepSeq (NFData (..), rwhnf)
@@ -422,12 +423,12 @@ instance DirectSerialise (VerKeyDSIGN Ed25519DSIGN) where
     psbUseAsCPtrLen psb $ \ptr _ ->
       push
         (castPtr ptr)
-        (fromIntegral @Word @CSize $ verKeySizeDSIGN (Proxy @Ed25519DSIGN))
+        (fromIntegral @Word @CSize $ fixedSize (Proxy @(VerKeyDSIGN Ed25519DSIGN)))
 
 instance DirectDeserialise (VerKeyDSIGN Ed25519DSIGN) where
   directDeserialise pull = do
     psb <- psbCreate $ \ptr ->
       pull
         (castPtr ptr)
-        (fromIntegral @Word @CSize $ verKeySizeDSIGN (Proxy @Ed25519DSIGN))
+        (fromIntegral @Word @CSize $ fixedSize (Proxy @(VerKeyDSIGN Ed25519DSIGN)))
     return $! VerKeyEd25519DSIGN psb

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed448.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Ed448.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
 -- | Ed448 digital signatures.
@@ -15,6 +16,11 @@ module Cardano.Crypto.DSIGN.Ed448 (
 )
 where
 
+import Cardano.Binary.FixedSizeCodec (
+  FixedSizeCodec (..),
+  decodeFixedSized,
+  encodeFixedSized,
+ )
 import Control.DeepSeq (NFData)
 import Data.ByteArray as BA (ByteArrayAccess, convert)
 import GHC.Generics (Generic)
@@ -33,11 +39,6 @@ data Ed448DSIGN
 
 instance DSIGNAlgorithm Ed448DSIGN where
   type SeedSizeDSIGN Ed448DSIGN = 57
-
-  -- \| Goldilocks points are 448 bits long
-  type VerKeySizeDSIGN Ed448DSIGN = 57
-  type SignKeySizeDSIGN Ed448DSIGN = 57
-  type SigSizeDSIGN Ed448DSIGN = 114
 
   --
   -- Key and signature types
@@ -89,48 +90,45 @@ instance DSIGNAlgorithm Ed448DSIGN where
     let sk = runMonadRandomWithSeed seed Ed448.generateSecretKey
      in SignKeyEd448DSIGN sk
 
-  --
-  -- raw serialise/deserialise
-  --
-
-  rawSerialiseVerKeyDSIGN = BA.convert
-  rawSerialiseSignKeyDSIGN = BA.convert
-  rawSerialiseSigDSIGN = BA.convert
-
-  rawDeserialiseVerKeyDSIGN =
-    fmap VerKeyEd448DSIGN
-      . cryptoFailableToMaybe
-      . Ed448.publicKey
-  rawDeserialiseSignKeyDSIGN =
-    fmap SignKeyEd448DSIGN
-      . cryptoFailableToMaybe
-      . Ed448.secretKey
-  rawDeserialiseSigDSIGN =
-    fmap SigEd448DSIGN
-      . cryptoFailableToMaybe
-      . Ed448.signature
-
 instance ToCBOR (VerKeyDSIGN Ed448DSIGN) where
-  toCBOR = encodeVerKeyDSIGN
+  toCBOR = encodeFixedSized
   encodedSizeExpr _ = encodedVerKeyDSIGNSizeExpr
 
 instance FromCBOR (VerKeyDSIGN Ed448DSIGN) where
-  fromCBOR = decodeVerKeyDSIGN
+  fromCBOR = decodeFixedSized
 
 instance ToCBOR (SignKeyDSIGN Ed448DSIGN) where
-  toCBOR = encodeSignKeyDSIGN
+  toCBOR = encodeFixedSized
   encodedSizeExpr _ = encodedSignKeyDSIGNSizeExpr
 
 instance FromCBOR (SignKeyDSIGN Ed448DSIGN) where
-  fromCBOR = decodeSignKeyDSIGN
+  fromCBOR = decodeFixedSized
 
 instance ToCBOR (SigDSIGN Ed448DSIGN) where
-  toCBOR = encodeSigDSIGN
+  toCBOR = encodeFixedSized
   encodedSizeExpr _ = encodedSigDSIGNSizeExpr
 
 instance FromCBOR (SigDSIGN Ed448DSIGN) where
-  fromCBOR = decodeSigDSIGN
+  fromCBOR = decodeFixedSized
 
-cryptoFailableToMaybe :: CryptoFailable a -> Maybe a
-cryptoFailableToMaybe (CryptoPassed a) = Just a
-cryptoFailableToMaybe (CryptoFailed _) = Nothing
+instance FixedSizeCodec (VerKeyDSIGN Ed448DSIGN) where
+  type FixedSize (VerKeyDSIGN Ed448DSIGN) = 57
+  rawEncodeFixedSized (VerKeyEd448DSIGN vk) = BA.convert vk
+  rawDecodeFixedSized bs = VerKeyEd448DSIGN <$> liftCryptoFailable (Ed448.publicKey bs)
+  {-# INLINE rawDecodeFixedSized #-}
+
+instance FixedSizeCodec (SignKeyDSIGN Ed448DSIGN) where
+  type FixedSize (SignKeyDSIGN Ed448DSIGN) = 57
+  rawEncodeFixedSized (SignKeyEd448DSIGN sk) = BA.convert sk
+  rawDecodeFixedSized bs = SignKeyEd448DSIGN <$> liftCryptoFailable (Ed448.secretKey bs)
+  {-# INLINE rawDecodeFixedSized #-}
+
+instance FixedSizeCodec (SigDSIGN Ed448DSIGN) where
+  type FixedSize (SigDSIGN Ed448DSIGN) = 114
+  rawEncodeFixedSized (SigEd448DSIGN sig) = BA.convert sig
+  rawDecodeFixedSized bs = SigEd448DSIGN <$> liftCryptoFailable (Ed448.signature bs)
+  {-# INLINE rawDecodeFixedSized #-}
+
+liftCryptoFailable :: MonadFail m => CryptoFailable a -> m a
+liftCryptoFailable (CryptoPassed a) = pure a
+liftCryptoFailable (CryptoFailed a) = fail $ show a

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Mock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/Mock.hs
@@ -20,6 +20,12 @@ module Cardano.Crypto.DSIGN.Mock (
 )
 where
 
+import Cardano.Binary.FixedSizeCodec (
+  FixedSizeCodec (..),
+  decodeFixedSized,
+  encodeFixedSized,
+  guardFixedSized,
+ )
 import Control.DeepSeq (NFData)
 import Data.Proxy (Proxy (..))
 import Data.Word (Word64)
@@ -28,21 +34,18 @@ import GHC.Stack
 import GHC.TypeLits (type (+))
 import NoThunks.Class (NoThunks)
 
-import Cardano.Base.Bytes (splitsAt)
 import Cardano.Binary (FromCBOR (..), ToCBOR (..))
 
 import Cardano.Crypto.DSIGN.Class
 import Cardano.Crypto.Hash
 import Cardano.Crypto.Seed
 import Cardano.Crypto.Util
+import qualified Data.ByteString as BS
 
 data MockDSIGN
 
 instance DSIGNAlgorithm MockDSIGN where
   type SeedSizeDSIGN MockDSIGN = 8
-  type VerKeySizeDSIGN MockDSIGN = 8 -- for 64 bit int
-  type SignKeySizeDSIGN MockDSIGN = 8
-  type SigSizeDSIGN MockDSIGN = HashSize ShortHash + 8
 
   --
   -- Key and signature types
@@ -95,58 +98,48 @@ instance DSIGNAlgorithm MockDSIGN where
   genKeyDSIGN seed =
     SignKeyMockDSIGN (runMonadRandomWithSeed seed getRandomWord64)
 
-  --
-  -- raw serialise/deserialise
-  --
+instance FixedSizeCodec (VerKeyDSIGN MockDSIGN) where
+  type FixedSize (VerKeyDSIGN MockDSIGN) = 8 -- for 64 bit int
+  rawEncodeFixedSized (VerKeyMockDSIGN k) = writeBinaryWord64 k
+  rawDecodeFixedSized bs = guardFixedSized bs $ pure $! VerKeyMockDSIGN (readBinaryWord64 bs)
+  {-# INLINE rawDecodeFixedSized #-}
 
-  rawSerialiseVerKeyDSIGN (VerKeyMockDSIGN k) = writeBinaryWord64 k
-  rawSerialiseSignKeyDSIGN (SignKeyMockDSIGN k) = writeBinaryWord64 k
-  rawSerialiseSigDSIGN (SigMockDSIGN h k) =
-    hashToBytes h
-      <> writeBinaryWord64 k
+instance FixedSizeCodec (SignKeyDSIGN MockDSIGN) where
+  type FixedSize (SignKeyDSIGN MockDSIGN) = 8
+  rawEncodeFixedSized (SignKeyMockDSIGN k) = writeBinaryWord64 k
+  rawDecodeFixedSized bs = guardFixedSized bs $ pure $! SignKeyMockDSIGN (readBinaryWord64 bs)
+  {-# INLINE rawDecodeFixedSized #-}
 
-  rawDeserialiseVerKeyDSIGN bs
-    | [kb] <- splitsAt [8] bs
-    , let k = readBinaryWord64 kb =
-        Just $! VerKeyMockDSIGN k
-    | otherwise =
-        Nothing
-
-  rawDeserialiseSignKeyDSIGN bs
-    | [kb] <- splitsAt [8] bs
-    , let k = readBinaryWord64 kb =
-        Just $! SignKeyMockDSIGN k
-    | otherwise =
-        Nothing
-
-  rawDeserialiseSigDSIGN bs
-    | [hb, kb] <- splitsAt [fromIntegral @Word @Int $ hashSize (Proxy :: Proxy ShortHash), 8] bs
-    , Just h <- hashFromBytes hb
-    , let k = readBinaryWord64 kb =
-        Just $! SigMockDSIGN h k
-    | otherwise =
-        Nothing
+instance FixedSizeCodec (SigDSIGN MockDSIGN) where
+  type FixedSize (SigDSIGN MockDSIGN) = HashSize ShortHash + 8
+  rawEncodeFixedSized (SigMockDSIGN h k) = hashToBytes h <> writeBinaryWord64 k
+  rawDecodeFixedSized bs = guardFixedSized bs $ do
+    let
+      (hb, kb) = BS.splitAt (fromIntegral @Word @Int $ hashSize (Proxy :: Proxy ShortHash)) bs
+    h <- hashFromByteStringM hb
+    pure $! SigMockDSIGN h (readBinaryWord64 kb)
+  {-# INLINE rawDecodeFixedSized #-}
 
 instance ToCBOR (VerKeyDSIGN MockDSIGN) where
-  toCBOR = encodeVerKeyDSIGN
+  toCBOR = encodeFixedSized
   encodedSizeExpr _ = encodedVerKeyDSIGNSizeExpr
 
 instance FromCBOR (VerKeyDSIGN MockDSIGN) where
-  fromCBOR = decodeVerKeyDSIGN
+  fromCBOR = decodeFixedSized
 
 instance ToCBOR (SignKeyDSIGN MockDSIGN) where
-  toCBOR = encodeSignKeyDSIGN
+  toCBOR = encodeFixedSized
   encodedSizeExpr _ = encodedSignKeyDSIGNSizeExpr
 
 instance FromCBOR (SignKeyDSIGN MockDSIGN) where
-  fromCBOR = decodeSignKeyDSIGN
+  fromCBOR = decodeFixedSized
 
 instance ToCBOR (SigDSIGN MockDSIGN) where
-  toCBOR = encodeSigDSIGN
+  toCBOR = encodeFixedSized
   encodedSizeExpr _ = encodedSigDSIGNSizeExpr
 
 instance FromCBOR (SigDSIGN MockDSIGN) where
-  fromCBOR = decodeSigDSIGN
+  fromCBOR = decodeFixedSized
 
 -- | Debugging: provide information about the verification failure
 --

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/NeverUsed.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/NeverUsed.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
 module Cardano.Crypto.DSIGN.NeverUsed (
@@ -16,6 +17,7 @@ import GHC.Generics (Generic)
 
 import NoThunks.Class (NoThunks)
 
+import Cardano.Binary.FixedSizeCodec (FixedSizeCodec (..), guardFixedSized)
 import Cardano.Crypto.DSIGN.Class
 
 -- | DSIGN never used
@@ -26,9 +28,6 @@ data NeverDSIGN
 
 instance DSIGNAlgorithm NeverDSIGN where
   type SeedSizeDSIGN NeverDSIGN = 0
-  type VerKeySizeDSIGN NeverDSIGN = 0
-  type SignKeySizeDSIGN NeverDSIGN = 0
-  type SigSizeDSIGN NeverDSIGN = 0
 
   data VerKeyDSIGN NeverDSIGN = NeverUsedVerKeyDSIGN
     deriving (Show, Eq, Generic, NoThunks)
@@ -48,10 +47,17 @@ instance DSIGNAlgorithm NeverDSIGN where
 
   genKeyDSIGN _ = NeverUsedSignKeyDSIGN
 
-  rawSerialiseVerKeyDSIGN _ = mempty
-  rawSerialiseSignKeyDSIGN _ = mempty
-  rawSerialiseSigDSIGN _ = mempty
+instance FixedSizeCodec (VerKeyDSIGN NeverDSIGN) where
+  type FixedSize (VerKeyDSIGN NeverDSIGN) = 0
+  rawEncodeFixedSized _ = mempty
+  rawDecodeFixedSized bs = guardFixedSized bs $ pure NeverUsedVerKeyDSIGN
 
-  rawDeserialiseVerKeyDSIGN _ = Just NeverUsedVerKeyDSIGN
-  rawDeserialiseSignKeyDSIGN _ = Just NeverUsedSignKeyDSIGN
-  rawDeserialiseSigDSIGN _ = Just NeverUsedSigDSIGN
+instance FixedSizeCodec (SignKeyDSIGN NeverDSIGN) where
+  type FixedSize (SignKeyDSIGN NeverDSIGN) = 0
+  rawEncodeFixedSized _ = mempty
+  rawDecodeFixedSized bs = guardFixedSized bs $ pure NeverUsedSignKeyDSIGN
+
+instance FixedSizeCodec (SigDSIGN NeverDSIGN) where
+  type FixedSize (SigDSIGN NeverDSIGN) = 0
+  rawEncodeFixedSized _ = mempty
+  rawDecodeFixedSized bs = guardFixedSized bs $ pure NeverUsedSigDSIGN

--- a/cardano-crypto-class/src/Cardano/Crypto/DSIGN/SchnorrSecp256k1.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/DSIGN/SchnorrSecp256k1.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -27,6 +28,12 @@ module Cardano.Crypto.DSIGN.SchnorrSecp256k1 (
 ) where
 
 import Cardano.Binary (FromCBOR (fromCBOR), ToCBOR (encodedSizeExpr, toCBOR))
+import Cardano.Binary.FixedSizeCodec (
+  FixedSizeCodec (..),
+  decodeFixedSized,
+  encodeFixedSized,
+  guardFixedSized,
+ )
 import Cardano.Crypto.DSIGN.Class (
   DSIGNAlgorithm (
     SeedSizeDSIGN,
@@ -36,25 +43,12 @@ import Cardano.Crypto.DSIGN.Class (
     SignKeySizeDSIGN,
     Signable,
     VerKeyDSIGN,
-    VerKeySizeDSIGN,
     algorithmNameDSIGN,
     deriveVerKeyDSIGN,
     genKeyDSIGN,
-    rawDeserialiseSigDSIGN,
-    rawDeserialiseSignKeyDSIGN,
-    rawDeserialiseVerKeyDSIGN,
-    rawSerialiseSigDSIGN,
-    rawSerialiseSignKeyDSIGN,
-    rawSerialiseVerKeyDSIGN,
     signDSIGN,
     verifyDSIGN
   ),
-  decodeSigDSIGN,
-  decodeSignKeyDSIGN,
-  decodeVerKeyDSIGN,
-  encodeSigDSIGN,
-  encodeSignKeyDSIGN,
-  encodeVerKeyDSIGN,
   encodedSigDSIGNSizeExpr,
   encodedSignKeyDSIGNSizeExpr,
   encodedVerKeyDSIGNSizeExpr,
@@ -65,7 +59,6 @@ import Cardano.Crypto.PinnedSizedBytes (
   psbCreate,
   psbCreateSized,
   psbCreateSizedResult,
-  psbFromByteStringCheck,
   psbToByteString,
   psbUseAsSizedPtr,
  )
@@ -90,14 +83,13 @@ import Cardano.Foreign (allocaSized)
 import Control.DeepSeq (NFData)
 import Control.Monad (when)
 import Data.ByteString (useAsCStringLen)
-import Data.ByteString.Unsafe (unsafeUseAsCStringLen)
+import Data.ByteString.Unsafe (unsafeUseAsCString)
 import Data.Primitive.Ptr (copyPtr)
 import Data.Proxy (Proxy (Proxy))
 import Foreign.C.Types (CSize)
 import Foreign.ForeignPtr (withForeignPtr)
 import Foreign.Ptr (castPtr, nullPtr)
 import GHC.Generics (Generic)
-import GHC.TypeNats (Natural, natVal)
 import NoThunks.Class (NoThunks)
 import System.IO.Unsafe (unsafeDupablePerformIO)
 
@@ -105,9 +97,6 @@ data SchnorrSecp256k1DSIGN
 
 instance DSIGNAlgorithm SchnorrSecp256k1DSIGN where
   type SeedSizeDSIGN SchnorrSecp256k1DSIGN = SECP256K1_SCHNORR_PRIVKEY_BYTES
-  type SigSizeDSIGN SchnorrSecp256k1DSIGN = SECP256K1_SCHNORR_SIGNATURE_BYTES
-  type SignKeySizeDSIGN SchnorrSecp256k1DSIGN = SECP256K1_SCHNORR_PRIVKEY_BYTES
-  type VerKeySizeDSIGN SchnorrSecp256k1DSIGN = SECP256K1_SCHNORR_PUBKEY_BYTES
   type Signable SchnorrSecp256k1DSIGN = SignableRepresentation
   newtype VerKeyDSIGN SchnorrSecp256k1DSIGN
     = VerKeySchnorrSecp256k1 (PinnedSizedBytes SECP256K1_SCHNORR_PUBKEY_BYTES_INTERNAL)
@@ -185,53 +174,60 @@ instance DSIGNAlgorithm SchnorrSecp256k1DSIGN where
             psbCreate $ \skp ->
               useAsCStringLen bs $ \(bsp, sz) ->
                 copyPtr skp (castPtr bsp) sz
-  rawSerialiseSigDSIGN (SigSchnorrSecp256k1 sigPSB) = psbToByteString sigPSB
-  {-# NOINLINE rawSerialiseVerKeyDSIGN #-}
-  rawSerialiseVerKeyDSIGN (VerKeySchnorrSecp256k1 vkPSB) =
+
+instance FixedSizeCodec (VerKeyDSIGN SchnorrSecp256k1DSIGN) where
+  type FixedSize (VerKeyDSIGN SchnorrSecp256k1DSIGN) = SECP256K1_SCHNORR_PUBKEY_BYTES
+  {-# NOINLINE rawEncodeFixedSized #-}
+  rawEncodeFixedSized (VerKeySchnorrSecp256k1 vkPSB) =
     unsafeDupablePerformIO . psbUseAsSizedPtr vkPSB $ \pkbPtr -> do
       res <- psbCreateSized $ \bsPtr ->
         withForeignPtr secpCtxPtr $ \ctx -> do
           res' <- secpXOnlyPubkeySerialize ctx bsPtr pkbPtr
           when
             (res' /= 1)
-            (error "rawSerialiseVerKeyDSIGN: Failed to serialise VerKeyDSIGN SchnorrSecp256k1DSIGN")
+            (error "rawEncodeFixedSized @(VerKeyDSIGN SchnorrSecp256k1DSIGN): Failed to serialise")
       pure . psbToByteString $ res
-  rawSerialiseSignKeyDSIGN (SignKeySchnorrSecp256k1 skPSB) = psbToByteString skPSB
-  {-# NOINLINE rawDeserialiseVerKeyDSIGN #-}
-  rawDeserialiseVerKeyDSIGN bs =
-    unsafeDupablePerformIO . unsafeUseAsCStringLen bs $ \(ptr, len) ->
-      if len /= (fromIntegral @Natural @Int . natVal $ Proxy @(VerKeySizeDSIGN SchnorrSecp256k1DSIGN))
-        then pure Nothing
-        else do
-          let dataPtr = castPtr ptr
-          (vkPsb, res) <- psbCreateSizedResult $ \outPtr ->
-            withForeignPtr secpCtxPtr $ \ctx ->
-              secpXOnlyPubkeyParse ctx outPtr dataPtr
-          pure $ case res of
-            1 -> pure . VerKeySchnorrSecp256k1 $ vkPsb
-            _ -> Nothing
-  rawDeserialiseSignKeyDSIGN bs =
-    SignKeySchnorrSecp256k1 <$> psbFromByteStringCheck bs
-  rawDeserialiseSigDSIGN bs =
-    SigSchnorrSecp256k1 <$> psbFromByteStringCheck bs
+  {-# NOINLINE rawDecodeFixedSized #-}
+  rawDecodeFixedSized bs =
+    guardFixedSized bs
+      . unsafeDupablePerformIO
+      . unsafeUseAsCString bs
+      $ \ptr -> do
+        let dataPtr = castPtr ptr
+        (vkPsb, res) <- psbCreateSizedResult $ \outPtr ->
+          withForeignPtr secpCtxPtr $ \ctx ->
+            secpXOnlyPubkeyParse ctx outPtr dataPtr
+        pure $ case res of
+          1 -> pure . VerKeySchnorrSecp256k1 $ vkPsb
+          _ -> fail "VerKeyDSIGN SchnorrSecp256k1DSIGN: deserialisation failed"
+
+instance FixedSizeCodec (SignKeyDSIGN SchnorrSecp256k1DSIGN) where
+  type FixedSize (SignKeyDSIGN SchnorrSecp256k1DSIGN) = SECP256K1_SCHNORR_PRIVKEY_BYTES
+  rawEncodeFixedSized (SignKeySchnorrSecp256k1 skPSB) = psbToByteString skPSB
+  rawDecodeFixedSized bs = SignKeySchnorrSecp256k1 <$> rawDecodeFixedSized bs
+
+instance FixedSizeCodec (SigDSIGN SchnorrSecp256k1DSIGN) where
+  type FixedSize (SigDSIGN SchnorrSecp256k1DSIGN) = SECP256K1_SCHNORR_SIGNATURE_BYTES
+  rawEncodeFixedSized (SigSchnorrSecp256k1 sigPSB) = psbToByteString sigPSB
+  rawDecodeFixedSized bs = SigSchnorrSecp256k1 <$> rawDecodeFixedSized bs
 
 instance ToCBOR (VerKeyDSIGN SchnorrSecp256k1DSIGN) where
-  toCBOR = encodeVerKeyDSIGN
+  toCBOR = encodeFixedSized
   encodedSizeExpr _ = encodedVerKeyDSIGNSizeExpr
 
 instance FromCBOR (VerKeyDSIGN SchnorrSecp256k1DSIGN) where
-  fromCBOR = decodeVerKeyDSIGN
+  fromCBOR = decodeFixedSized
 
 instance ToCBOR (SignKeyDSIGN SchnorrSecp256k1DSIGN) where
-  toCBOR = encodeSignKeyDSIGN
+  toCBOR = encodeFixedSized
   encodedSizeExpr _ = encodedSignKeyDSIGNSizeExpr
 
 instance FromCBOR (SignKeyDSIGN SchnorrSecp256k1DSIGN) where
-  fromCBOR = decodeSignKeyDSIGN
+  fromCBOR = decodeFixedSized
 
 instance ToCBOR (SigDSIGN SchnorrSecp256k1DSIGN) where
-  toCBOR = encodeSigDSIGN
+  toCBOR = encodeFixedSized
   encodedSizeExpr _ = encodedSigDSIGNSizeExpr
 
 instance FromCBOR (SigDSIGN SchnorrSecp256k1DSIGN) where
-  fromCBOR = decodeSigDSIGN
+  fromCBOR = decodeFixedSized

--- a/cardano-crypto-class/src/Cardano/Crypto/Hash/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/Hash/Class.hs
@@ -39,6 +39,7 @@ module Cardano.Crypto.Hash.Class (
   hashToByteArray,
   hashToBytes,
   hashFromBytes,
+  hashFromByteStringM,
   hashToBytesShort,
   hashFromBytesShort,
   hashFromOffsetBytesShort,
@@ -209,17 +210,23 @@ hashToBytes :: Hash h a -> ByteString
 hashToBytes (UnsafeHashRep h) = unpackPinnedBytes h
 
 -- | Make a hash from it bytes representation.
+hashFromByteStringM ::
+  forall h a m.
+  ( HashAlgorithm h
+  , MonadFail m
+  ) =>
+  -- | It must have an exact length, as given by 'hashSize'.
+  ByteString ->
+  m (Hash h a)
+hashFromByteStringM = fmap UnsafeHashRep . packByteString
+
 hashFromBytes ::
   forall h a.
   HashAlgorithm h =>
   -- | It must have an exact length, as given by 'hashSize'.
   ByteString ->
   Maybe (Hash h a)
-hashFromBytes bytes
-  | BS.length bytes == fromIntegral @Word @Int (hashSize (Proxy :: Proxy h)) =
-      Just $ UnsafeHashRep (packPinnedBytes bytes)
-  | otherwise =
-      Nothing
+hashFromBytes = hashFromByteStringM
 
 -- | Make a hash from it bytes representation, as a 'ShortByteString'.
 hashFromBytesShort ::

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Class.hs
@@ -50,6 +50,7 @@ module Cardano.Crypto.KES.Class (
   encodedSigKESSizeExpr,
 
   -- * Raw sizes
+  fixedSize,
   verKeySizeKES,
   sigSizeKES,
   signKeySizeKES,
@@ -98,6 +99,7 @@ import Cardano.Binary.FixedSizeCodec (
   FixedSizeCodec (..),
   decodeFixedSized,
   encodeFixedSized,
+  fixedSize,
  )
 import Cardano.Crypto.Hash.Class (Hash, HashAlgorithm, hashWith)
 import Cardano.Crypto.Libsodium (MLockedAllocator, mlockedMalloc)
@@ -157,7 +159,7 @@ class
   algorithmNameKES :: proxy v -> String
 
   hashVerKeyKES :: HashAlgorithm h => VerKeyKES v -> Hash h (VerKeyKES v)
-  hashVerKeyKES = hashWith rawSerialiseVerKeyKES
+  hashVerKeyKES = hashWith rawEncodeFixedSized
 
   -- | Context required to run the KES algorithm
   --
@@ -258,26 +260,33 @@ class
     SignKeyKES v ->
     m ()
 
+{-# DEPRECATED rawSerialiseVerKeyKES "Use `rawEncodeFixedSized` instead" #-}
+{-# DEPRECATED rawSerialiseSigKES "Use `rawEncodeFixedSized` instead" #-}
+{-# DEPRECATED rawDeserialiseVerKeyKES "Use `rawDecodeFixedSized` instead" #-}
+{-# DEPRECATED rawDeserialiseSigKES "Use `rawDecodeFixedSized` instead" #-}
+
 verKeySizeKES :: forall v proxy. KESAlgorithm v => proxy v -> Word
-verKeySizeKES _ = fromInteger (natVal (Proxy @(VerKeySizeKES v)))
+verKeySizeKES _ = fixedSize $ Proxy @(VerKeyKES v)
+{-# DEPRECATED verKeySizeKES "Use `fixedSize` instead" #-}
 
 sigSizeKES :: forall v proxy. KESAlgorithm v => proxy v -> Word
-sigSizeKES _ = fromInteger (natVal (Proxy @(SigSizeKES v)))
+sigSizeKES _ = fixedSize $ Proxy @(SigKES v)
+{-# DEPRECATED sigSizeKES "Use `fixedSize` instead" #-}
 
 signKeySizeKES :: forall v proxy. KESAlgorithm v => proxy v -> Word
 signKeySizeKES _ = fromInteger (natVal (Proxy @(SignKeySizeKES v)))
 
-{-# DEPRECATED sizeVerKeyKES "In favor of `verKeySizeKES`" #-}
+{-# DEPRECATED sizeVerKeyKES "Use `fixedSize` instead" #-}
 sizeVerKeyKES :: forall v proxy. KESAlgorithm v => proxy v -> Word
-sizeVerKeyKES = verKeySizeKES
+sizeVerKeyKES _ = fixedSize $ Proxy @(VerKeyKES v)
 
 {-# DEPRECATED sizeSignKeyKES "In favor of `signKeySizeKES`" #-}
 sizeSignKeyKES :: forall v proxy. KESAlgorithm v => proxy v -> Word
 sizeSignKeyKES = signKeySizeKES
 
-{-# DEPRECATED sizeSigKES "In favor of `sigSizeKES`" #-}
+{-# DEPRECATED sizeSigKES "Use `fixedSize` instead" #-}
 sizeSigKES :: forall v proxy. KESAlgorithm v => proxy v -> Word
-sizeSigKES = sigSizeKES
+sizeSigKES _ = fixedSize $ Proxy @(SigKES v)
 
 -- | The upper bound on the 'Seed' size needed by 'genKeyKES'
 seedSizeKES :: forall v proxy. KESAlgorithm v => proxy v -> Word
@@ -377,6 +386,9 @@ class
   rawDeserialiseUnsoundPureSignKeyKES :: ByteString -> Maybe (UnsoundPureSignKeyKES v)
   rawDeserialiseUnsoundPureSignKeyKES = rawDecodeFixedSized
 
+{-# DEPRECATED rawSerialiseUnsoundPureSignKeyKES "Use `rawEncodeFixedSized` instead" #-}
+{-# DEPRECATED rawDeserialiseUnsoundPureSignKeyKES "Use `rawDecodeFixedSized` instead" #-}
+
 -- | Unsound operations on KES sign keys. These operations violate secure
 -- forgetting constraints by leaking secrets to unprotected memory. Consider
 -- using the 'DirectSerialise' / 'DirectDeserialise' APIs instead.
@@ -405,7 +417,7 @@ unsoundPureSignKeyKESToSoundSignKeyKESViaSer ::
   m (SignKeyKES k)
 unsoundPureSignKeyKESToSoundSignKeyKESViaSer sk =
   maybe (error "unsoundPureSignKeyKESToSoundSignKeyKES: deserialisation failure") return
-    =<< (rawDeserialiseSignKeyKES . rawSerialiseUnsoundPureSignKeyKES $ sk)
+    =<< (rawDeserialiseSignKeyKES . rawEncodeFixedSized $ sk)
 
 -- | Subclass for KES algorithms that embed a copy of the VerKey into the
 -- signature itself, rather than relying on the externally supplied VerKey
@@ -478,15 +490,15 @@ instance
 --
 
 encodeVerKeyKES :: KESAlgorithm v => VerKeyKES v -> Encoding
-encodeVerKeyKES = encodeBytes . rawSerialiseVerKeyKES
+encodeVerKeyKES = encodeBytes . rawEncodeFixedSized
 {-# DEPRECATED encodeVerKeyKES "Use `encodeFixedSized` instead" #-}
 
 encodeUnsoundPureSignKeyKES :: UnsoundPureKESAlgorithm v => UnsoundPureSignKeyKES v -> Encoding
-encodeUnsoundPureSignKeyKES = encodeBytes . rawSerialiseUnsoundPureSignKeyKES
+encodeUnsoundPureSignKeyKES = encodeBytes . rawEncodeFixedSized
 {-# DEPRECATED encodeUnsoundPureSignKeyKES "Use `encodeFixedSized` instead" #-}
 
 encodeSigKES :: KESAlgorithm v => SigKES v -> Encoding
-encodeSigKES = encodeBytes . rawSerialiseSigKES
+encodeSigKES = encodeBytes . rawEncodeFixedSized
 {-# DEPRECATED encodeSigKES "Use `encodeFixedSized` instead" #-}
 
 encodeSignKeyKES ::
@@ -617,14 +629,12 @@ updateKESWithPeriod c (SignKeyWithPeriodKES sk t) = runMaybeT $ do
 -- 'Size' expressions for 'ToCBOR' instances.
 --
 
--- | 'Size' expression for 'VerKeyKES' which is using 'verKeySizeKES' encoded
--- as 'Size'.
 encodedVerKeyKESSizeExpr :: forall v. KESAlgorithm v => Proxy (VerKeyKES v) -> Size
 encodedVerKeyKESSizeExpr _proxy =
   -- 'encodeBytes' envelope
-  fromIntegral @Integer @Size (withWordSize (verKeySizeKES (Proxy :: Proxy v)))
+  fromIntegral @Integer @Size (withWordSize (fixedSize (Proxy @(VerKeyKES v))))
     -- payload
-    + fromIntegral @Word @Size (verKeySizeKES (Proxy :: Proxy v))
+    + fromIntegral @Word @Size (fixedSize (Proxy @(VerKeyKES v)))
 
 -- | 'Size' expression for 'SignKeyKES' which is using 'signKeySizeKES' encoded
 -- as 'Size'.
@@ -635,14 +645,12 @@ encodedSignKeyKESSizeExpr _proxy =
     -- payload
     + fromIntegral @Word @Size (signKeySizeKES (Proxy :: Proxy v))
 
--- | 'Size' expression for 'SigKES' which is using 'sigSizeKES' encoded as
--- 'Size'.
 encodedSigKESSizeExpr :: forall v. KESAlgorithm v => Proxy (SigKES v) -> Size
 encodedSigKESSizeExpr _proxy =
   -- 'encodeBytes' envelope
-  fromIntegral @Integer @Size (withWordSize (sigSizeKES (Proxy :: Proxy v)))
+  fromIntegral @Integer @Size (withWordSize (fixedSize (Proxy @(SigKES v))))
     -- payload
-    + fromIntegral @Word @Size (sigSizeKES (Proxy :: Proxy v))
+    + fromIntegral @Word @Size (fixedSize (Proxy @(SigKES v)))
 
 hashPairOfVKeys ::
   (KESAlgorithm d, HashAlgorithm h) =>
@@ -650,7 +658,7 @@ hashPairOfVKeys ::
   Hash h (VerKeyKES d, VerKeyKES d)
 hashPairOfVKeys =
   hashWith $ \(a, b) ->
-    rawSerialiseVerKeyKES a <> rawSerialiseVerKeyKES b
+    rawEncodeFixedSized a <> rawEncodeFixedSized b
 
 mungeName :: String -> String
 mungeName basename

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Class.hs
@@ -94,7 +94,11 @@ import NoThunks.Class (NoThunks)
 
 import Cardano.Binary (Decoder, Encoding, Size, decodeBytes, encodeBytes, withWordSize)
 
-import Cardano.Crypto.DSIGN.Class (failSizeCheck)
+import Cardano.Binary.FixedSizeCodec (
+  FixedSizeCodec (..),
+  decodeFixedSized,
+  encodeFixedSized,
+ )
 import Cardano.Crypto.Hash.Class (Hash, HashAlgorithm, hashWith)
 import Cardano.Crypto.Libsodium (MLockedAllocator, mlockedMalloc)
 import Cardano.Crypto.Libsodium.MLockedSeed
@@ -119,6 +123,8 @@ class
   , KnownNat (SignKeySizeKES v)
   , KnownNat (SigSizeKES v)
   , KnownNat (TotalPeriodsKES v)
+  , FixedSizeCodec (VerKeyKES v)
+  , FixedSizeCodec (SigKES v)
   ) =>
   KESAlgorithm v
   where
@@ -131,8 +137,11 @@ class
 
   type SeedSizeKES v :: Nat
   type VerKeySizeKES v :: Nat
+  type VerKeySizeKES v = FixedSize (VerKeyKES v)
   type SignKeySizeKES v :: Nat
+  type SignKeySizeKES v = FixedSize (SignKeyKES v)
   type SigSizeKES v :: Nat
+  type SigSizeKES v = FixedSize (SigKES v)
   type TotalPeriodsKES v :: Nat
 
   type SizeVerKeyKES v :: Nat
@@ -194,10 +203,14 @@ class
   --
 
   rawSerialiseVerKeyKES :: VerKeyKES v -> ByteString
+  rawSerialiseVerKeyKES = rawEncodeFixedSized
   rawSerialiseSigKES :: SigKES v -> ByteString
+  rawSerialiseSigKES = rawEncodeFixedSized
 
   rawDeserialiseVerKeyKES :: ByteString -> Maybe (VerKeyKES v)
+  rawDeserialiseVerKeyKES = rawDecodeFixedSized
   rawDeserialiseSigKES :: ByteString -> Maybe (SigKES v)
+  rawDeserialiseSigKES = rawDecodeFixedSized
 
   deriveVerKeyKES :: (MonadST m, MonadThrow m) => SignKeyKES v -> m (VerKeyKES v)
 
@@ -323,6 +336,7 @@ updateKES = updateKESWith mlockedMalloc
 class
   ( KESAlgorithm v
   , NoThunks (UnsoundPureSignKeyKES v)
+  , FixedSizeCodec (UnsoundPureSignKeyKES v)
   ) =>
   UnsoundPureKESAlgorithm v
   where
@@ -359,7 +373,9 @@ class
     m (SignKeyKES v)
 
   rawSerialiseUnsoundPureSignKeyKES :: UnsoundPureSignKeyKES v -> ByteString
+  rawSerialiseUnsoundPureSignKeyKES = rawEncodeFixedSized
   rawDeserialiseUnsoundPureSignKeyKES :: ByteString -> Maybe (UnsoundPureSignKeyKES v)
+  rawDeserialiseUnsoundPureSignKeyKES = rawDecodeFixedSized
 
 -- | Unsound operations on KES sign keys. These operations violate secure
 -- forgetting constraints by leaking secrets to unprotected memory. Consider
@@ -463,12 +479,15 @@ instance
 
 encodeVerKeyKES :: KESAlgorithm v => VerKeyKES v -> Encoding
 encodeVerKeyKES = encodeBytes . rawSerialiseVerKeyKES
+{-# DEPRECATED encodeVerKeyKES "Use `encodeFixedSized` instead" #-}
 
 encodeUnsoundPureSignKeyKES :: UnsoundPureKESAlgorithm v => UnsoundPureSignKeyKES v -> Encoding
 encodeUnsoundPureSignKeyKES = encodeBytes . rawSerialiseUnsoundPureSignKeyKES
+{-# DEPRECATED encodeUnsoundPureSignKeyKES "Use `encodeFixedSized` instead" #-}
 
 encodeSigKES :: KESAlgorithm v => SigKES v -> Encoding
 encodeSigKES = encodeBytes . rawSerialiseSigKES
+{-# DEPRECATED encodeSigKES "Use `encodeFixedSized` instead" #-}
 
 encodeSignKeyKES ::
   forall v m.
@@ -478,29 +497,20 @@ encodeSignKeyKES ::
 encodeSignKeyKES = fmap encodeBytes . rawSerialiseSignKeyKES
 
 decodeVerKeyKES :: forall v s. KESAlgorithm v => Decoder s (VerKeyKES v)
-decodeVerKeyKES = do
-  bs <- decodeBytes
-  case rawDeserialiseVerKeyKES bs of
-    Just vk -> return vk
-    Nothing -> failSizeCheck "decodeVerKeyKES" "key" bs (verKeySizeKES (Proxy :: Proxy v))
+decodeVerKeyKES = decodeFixedSized
 {-# INLINE decodeVerKeyKES #-}
+{-# DEPRECATED decodeVerKeyKES "Use `decodeFixedSized` instead" #-}
 
 decodeUnsoundPureSignKeyKES ::
   forall v s. UnsoundPureKESAlgorithm v => Decoder s (UnsoundPureSignKeyKES v)
-decodeUnsoundPureSignKeyKES = do
-  bs <- decodeBytes
-  case rawDeserialiseUnsoundPureSignKeyKES bs of
-    Just vk -> return vk
-    Nothing -> failSizeCheck "decodeUnsoundPureSignKeyKES" "key" bs (signKeySizeKES (Proxy :: Proxy v))
+decodeUnsoundPureSignKeyKES = decodeFixedSized
 {-# INLINE decodeUnsoundPureSignKeyKES #-}
+{-# DEPRECATED decodeUnsoundPureSignKeyKES "Use `decodeFixedSized` instead" #-}
 
 decodeSigKES :: forall v s. KESAlgorithm v => Decoder s (SigKES v)
-decodeSigKES = do
-  bs <- decodeBytes
-  case rawDeserialiseSigKES bs of
-    Just sig -> return sig
-    Nothing -> failSizeCheck "decodeSigKES" "signature" bs (sigSizeKES (Proxy :: Proxy v))
+decodeSigKES = decodeFixedSized
 {-# INLINE decodeSigKES #-}
+{-# DEPRECATED decodeSigKES "Use `decodeFixedSized` instead" #-}
 
 decodeSignKeyKES ::
   forall v s m.
@@ -534,6 +544,12 @@ deriving instance KESAlgorithm v => Eq (SignedKES v a)
 
 instance KESAlgorithm v => NoThunks (SignedKES v a)
 
+instance KESAlgorithm v => FixedSizeCodec (SignedKES v a) where
+  type FixedSize (SignedKES v a) = FixedSize (SigKES v)
+
+  rawEncodeFixedSized (SignedKES x) = rawEncodeFixedSized x
+  rawDecodeFixedSized bs = SignedKES <$> rawDecodeFixedSized bs
+
 -- use generic instance
 
 signedKES ::
@@ -565,11 +581,13 @@ unsoundPureSignedKES ::
 unsoundPureSignedKES ctxt time a key = SignedKES $ unsoundPureSignKES ctxt time a key
 
 encodeSignedKES :: KESAlgorithm v => SignedKES v a -> Encoding
-encodeSignedKES (SignedKES s) = encodeSigKES s
+encodeSignedKES = encodeFixedSized
+{-# DEPRECATED encodeSignedKES "Use `encodeFixedSized` instead" #-}
 
 decodeSignedKES :: KESAlgorithm v => Decoder s (SignedKES v a)
-decodeSignedKES = SignedKES <$> decodeSigKES
+decodeSignedKES = decodeFixedSized
 {-# INLINE decodeSignedKES #-}
+{-# DEPRECATED decodeSignedKES "Use `decodeFixedSized` instead" #-}
 
 -- | A sign key bundled with its associated period.
 data SignKeyWithPeriodKES v = SignKeyWithPeriodKES

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/CompactSingle.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/CompactSingle.hs
@@ -46,8 +46,13 @@ module Cardano.Crypto.KES.CompactSingle (
   SigKES (..),
 ) where
 
-import Control.Monad (guard, (<$!>))
-import qualified Data.ByteString as BS
+import Cardano.Binary.FixedSizeCodec (
+  FixedSizeCodec (..),
+  decodeFixedSized,
+  encodeFixedSized,
+  guardFixedSized,
+ )
+import Control.Monad ((<$!>))
 import Data.Proxy (Proxy (..))
 import GHC.Generics (Generic)
 import GHC.TypeLits (KnownNat, type (+))
@@ -115,33 +120,10 @@ instance
   -- raw serialise/deserialise
   --
 
-  type VerKeySizeKES (CompactSingleKES d) = VerKeySizeDSIGN d
   type SignKeySizeKES (CompactSingleKES d) = SignKeySizeDSIGN d
-  type SigSizeKES (CompactSingleKES d) = SigSizeDSIGN d + VerKeySizeDSIGN d
 
   hashVerKeyKES (VerKeyCompactSingleKES vk) =
     castHash (hashVerKeyDSIGN vk)
-
-  rawSerialiseVerKeyKES (VerKeyCompactSingleKES vk) = rawSerialiseVerKeyDSIGN vk
-  rawSerialiseSigKES (SigCompactSingleKES sig vk) =
-    rawSerialiseSigDSIGN sig <> rawSerialiseVerKeyDSIGN vk
-
-  rawDeserialiseVerKeyKES = fmap VerKeyCompactSingleKES . rawDeserialiseVerKeyDSIGN
-  rawDeserialiseSigKES b = do
-    guard (BS.length b == fromIntegral @Word @Int size_total)
-    sigma <- rawDeserialiseSigDSIGN b_sig
-    vk <- rawDeserialiseVerKeyDSIGN b_vk
-    return (SigCompactSingleKES sigma vk)
-    where
-      b_sig = slice off_sig size_sig b
-      b_vk = slice off_vk size_vk b
-
-      size_sig = sigSizeDSIGN (Proxy :: Proxy d)
-      size_vk = verKeySizeDSIGN (Proxy :: Proxy d)
-      size_total = sigSizeKES (Proxy :: Proxy (CompactSingleKES d))
-
-      off_sig = 0 :: Word
-      off_vk = size_sig
 
   deriveVerKeyKES (SignKeyCompactSingleKES v) =
     VerKeyCompactSingleKES <$!> deriveVerKeyDSIGNM v
@@ -196,11 +178,6 @@ instance
   unsoundPureSignKeyKESToSoundSignKeyKES =
     unsoundPureSignKeyKESToSoundSignKeyKESViaSer
 
-  rawSerialiseUnsoundPureSignKeyKES (UnsoundPureSignKeyCompactSingleKES sk) =
-    rawSerialiseSignKeyDSIGN sk
-  rawDeserialiseUnsoundPureSignKeyKES b =
-    UnsoundPureSignKeyCompactSingleKES <$> rawDeserialiseSignKeyDSIGN b
-
 instance
   ( KESAlgorithm (CompactSingleKES d)
   , DSIGNMAlgorithm d
@@ -223,6 +200,44 @@ instance
   rawDeserialiseSignKeyKESWith allocator bs = fmap SignKeyCompactSingleKES <$> rawDeserialiseSignKeyDSIGNMWith allocator bs
 
 --
+-- FixedSizeCodec instances
+--
+
+instance DSIGNAlgorithm d => FixedSizeCodec (VerKeyKES (CompactSingleKES d)) where
+  type FixedSize (VerKeyKES (CompactSingleKES d)) = VerKeySizeDSIGN d
+  rawEncodeFixedSized (VerKeyCompactSingleKES vk) = rawEncodeFixedSized vk
+  rawDecodeFixedSized bs = VerKeyCompactSingleKES <$> rawDecodeFixedSized bs
+  {-# INLINE rawDecodeFixedSized #-}
+
+instance
+  (DSIGNAlgorithm d, KnownNat (SigSizeDSIGN d + VerKeySizeDSIGN d)) =>
+  FixedSizeCodec (SigKES (CompactSingleKES d))
+  where
+  type FixedSize (SigKES (CompactSingleKES d)) = SigSizeDSIGN d + VerKeySizeDSIGN d
+  rawEncodeFixedSized (SigCompactSingleKES sig vk) =
+    rawEncodeFixedSized sig <> rawEncodeFixedSized vk
+  rawDecodeFixedSized b = guardFixedSized b $ do
+    sigma <- rawDecodeFixedSized b_sig
+    vk <- rawDecodeFixedSized b_vk
+    return (SigCompactSingleKES sigma vk)
+    where
+      b_sig = slice off_sig size_sig b
+      b_vk = slice off_vk size_vk b
+
+      size_sig = sigSizeDSIGN (Proxy :: Proxy d)
+      size_vk = verKeySizeDSIGN (Proxy :: Proxy d)
+
+      off_sig = 0 :: Word
+      off_vk = size_sig
+  {-# INLINE rawDecodeFixedSized #-}
+
+instance DSIGNAlgorithm d => FixedSizeCodec (UnsoundPureSignKeyKES (CompactSingleKES d)) where
+  type FixedSize (UnsoundPureSignKeyKES (CompactSingleKES d)) = SignKeySizeKES (CompactSingleKES d)
+  rawEncodeFixedSized (UnsoundPureSignKeyCompactSingleKES sk) = rawEncodeFixedSized sk
+  rawDecodeFixedSized bs = UnsoundPureSignKeyCompactSingleKES <$> rawDecodeFixedSized bs
+  {-# INLINE rawDecodeFixedSized #-}
+
+--
 -- VerKey instances
 --
 
@@ -233,14 +248,14 @@ instance
   (DSIGNMAlgorithm d, KnownNat (SigSizeDSIGN d + VerKeySizeDSIGN d)) =>
   ToCBOR (VerKeyKES (CompactSingleKES d))
   where
-  toCBOR = encodeVerKeyKES
+  toCBOR = encodeFixedSized
   encodedSizeExpr _size = encodedVerKeyKESSizeExpr
 
 instance
   (DSIGNMAlgorithm d, KnownNat (SigSizeDSIGN d + VerKeySizeDSIGN d)) =>
   FromCBOR (VerKeyKES (CompactSingleKES d))
   where
-  fromCBOR = decodeVerKeyKES
+  fromCBOR = decodeFixedSized
 
 instance DSIGNMAlgorithm d => NoThunks (VerKeyKES (CompactSingleKES d))
 
@@ -266,14 +281,14 @@ instance
   (DSIGNMAlgorithm d, KnownNat (SigSizeKES (CompactSingleKES d))) =>
   ToCBOR (SigKES (CompactSingleKES d))
   where
-  toCBOR = encodeSigKES
+  toCBOR = encodeFixedSized
   encodedSizeExpr _size = encodedSigKESSizeExpr
 
 instance
   (DSIGNMAlgorithm d, KnownNat (SigSizeKES (CompactSingleKES d))) =>
   FromCBOR (SigKES (CompactSingleKES d))
   where
-  fromCBOR = decodeSigKES
+  fromCBOR = decodeFixedSized
 
 --
 -- UnsoundPureSignKey instances
@@ -287,14 +302,14 @@ instance
   (UnsoundDSIGNMAlgorithm d, KnownNat (SigSizeDSIGN d + VerKeySizeDSIGN d)) =>
   ToCBOR (UnsoundPureSignKeyKES (CompactSingleKES d))
   where
-  toCBOR = encodeUnsoundPureSignKeyKES
+  toCBOR = encodeFixedSized
   encodedSizeExpr _size _skProxy = encodedSignKeyKESSizeExpr (Proxy :: Proxy (SignKeyKES (CompactSingleKES d)))
 
 instance
   (UnsoundDSIGNMAlgorithm d, KnownNat (SigSizeDSIGN d + VerKeySizeDSIGN d)) =>
   FromCBOR (UnsoundPureSignKeyKES (CompactSingleKES d))
   where
-  fromCBOR = decodeUnsoundPureSignKeyKES
+  fromCBOR = decodeFixedSized
 
 instance DSIGNAlgorithm d => NoThunks (UnsoundPureSignKeyKES (CompactSingleKES d))
 

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/CompactSingle.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/CompactSingle.hs
@@ -224,8 +224,8 @@ instance
       b_sig = slice off_sig size_sig b
       b_vk = slice off_vk size_vk b
 
-      size_sig = sigSizeDSIGN (Proxy :: Proxy d)
-      size_vk = verKeySizeDSIGN (Proxy :: Proxy d)
+      size_sig = fixedSize (Proxy :: Proxy (SigDSIGN d))
+      size_vk = fixedSize (Proxy :: Proxy (VerKeyDSIGN d))
 
       off_sig = 0 :: Word
       off_vk = size_sig

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/CompactSum.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/CompactSum.hs
@@ -84,6 +84,12 @@ module Cardano.Crypto.KES.CompactSum (
   CompactSum7KES,
 ) where
 
+import Cardano.Binary.FixedSizeCodec (
+  FixedSizeCodec (..),
+  decodeFixedSized,
+  encodeFixedSized,
+  guardFixedSized,
+ )
 import Control.Monad (guard, (<$!>))
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Internal as BS
@@ -106,6 +112,7 @@ import Cardano.Crypto.Seed
 import Control.DeepSeq (NFData (..))
 import Control.Monad.Trans (lift)
 import Control.Monad.Trans.Maybe (MaybeT (..), runMaybeT)
+import Data.Typeable (Typeable)
 import Foreign.C.Types (CSize)
 import Foreign.Ptr (castPtr)
 import GHC.TypeLits (KnownNat, type (*), type (+))
@@ -227,43 +234,11 @@ instance
   -- raw serialise/deserialise
   --
 
-  type VerKeySizeKES (CompactSumKES h d) = HashSize h
   type
     SignKeySizeKES (CompactSumKES h d) =
       SignKeySizeKES d
         + SeedSizeKES d
         + VerKeySizeKES d * 2
-  type
-    SigSizeKES (CompactSumKES h d) =
-      SigSizeKES d
-        + VerKeySizeKES d
-
-  rawSerialiseVerKeyKES (VerKeyCompactSumKES vk) = hashToBytes vk
-
-  rawSerialiseSigKES (SigCompactSumKES sigma vk_other) =
-    mconcat
-      [ rawSerialiseSigKES sigma
-      , rawSerialiseVerKeyKES vk_other
-      ]
-
-  rawDeserialiseVerKeyKES = fmap VerKeyCompactSumKES . hashFromBytes
-
-  rawDeserialiseSigKES b = do
-    guard (BS.length b == fromIntegral @Word @Int size_total)
-    sigma <- rawDeserialiseSigKES b_sig
-    vk <- rawDeserialiseVerKeyKES b_vk
-    return (SigCompactSumKES sigma vk)
-    where
-      b_sig = slice off_sig size_sig b
-      b_vk = slice off_vk size_vk b
-
-      size_sig = sigSizeKES (Proxy :: Proxy d)
-      size_vk = verKeySizeKES (Proxy :: Proxy d)
-      size_total = sigSizeKES (Proxy :: Proxy (CompactSumKES h d))
-
-      off_sig = 0 :: Word
-      off_vk = size_sig
-
   deriveVerKeyKES (SignKeyCompactSumKES _ _ vk_0 vk_1) =
     return $! VerKeyCompactSumKES (hashPairOfVKeys (vk_0, vk_1))
 
@@ -393,6 +368,81 @@ instance
         | otherwise = (vk_other, verKeyFromSigKES ctxt t' sigma)
 
 --
+-- FixedSizeCodec instances
+--
+
+instance HashAlgorithm h => FixedSizeCodec (VerKeyKES (CompactSumKES h d)) where
+  type FixedSize (VerKeyKES (CompactSumKES h d)) = HashSize h
+  rawEncodeFixedSized (VerKeyCompactSumKES vk) = hashToBytes vk
+  rawDecodeFixedSized bs = VerKeyCompactSumKES <$> hashFromByteStringM bs
+  {-# INLINE rawDecodeFixedSized #-}
+
+instance
+  ( KESAlgorithm d
+  , KnownNat (SigSizeKES d + VerKeySizeKES d)
+  , Typeable h
+  ) =>
+  FixedSizeCodec (SigKES (CompactSumKES h d))
+  where
+  type FixedSize (SigKES (CompactSumKES h d)) = SigSizeKES d + VerKeySizeKES d
+  rawEncodeFixedSized (SigCompactSumKES sigma vk_other) =
+    mconcat
+      [ rawEncodeFixedSized sigma
+      , rawEncodeFixedSized vk_other
+      ]
+  rawDecodeFixedSized b = guardFixedSized b $ do
+    sigma <- rawDecodeFixedSized b_sig
+    vk <- rawDecodeFixedSized b_vk
+    return (SigCompactSumKES sigma vk)
+    where
+      b_sig = slice off_sig size_sig b
+      b_vk = slice off_vk size_vk b
+
+      size_sig = sigSizeKES (Proxy :: Proxy d)
+      size_vk = verKeySizeKES (Proxy :: Proxy d)
+
+      off_sig = 0 :: Word
+      off_vk = size_sig
+  {-# INLINE rawDecodeFixedSized #-}
+
+instance
+  ( KESAlgorithm (CompactSumKES h d)
+  , UnsoundPureKESAlgorithm d
+  , KnownNat (SignKeySizeKES d + SeedSizeKES d + VerKeySizeKES d * 2)
+  ) =>
+  FixedSizeCodec (UnsoundPureSignKeyKES (CompactSumKES h d))
+  where
+  type FixedSize (UnsoundPureSignKeyKES (CompactSumKES h d)) = SignKeySizeKES (CompactSumKES h d)
+  rawEncodeFixedSized (UnsoundPureSignKeyCompactSumKES sk r_1 vk_0 vk_1) =
+    mconcat
+      [ rawEncodeFixedSized sk
+      , getSeedBytes r_1
+      , rawEncodeFixedSized vk_0
+      , rawEncodeFixedSized vk_1
+      ]
+  rawDecodeFixedSized b = guardFixedSized b $ do
+    sk <- rawDecodeFixedSized b_sk
+    let r = mkSeedFromBytes b_r
+    vk_0 <- rawDecodeFixedSized b_vk0
+    vk_1 <- rawDecodeFixedSized b_vk1
+    return (UnsoundPureSignKeyCompactSumKES sk r vk_0 vk_1)
+    where
+      b_sk = slice off_sk size_sk b
+      b_r = slice off_r size_r b
+      b_vk0 = slice off_vk0 size_vk b
+      b_vk1 = slice off_vk1 size_vk b
+
+      size_sk = signKeySizeKES (Proxy :: Proxy d)
+      size_r = seedSizeKES (Proxy :: Proxy d)
+      size_vk = verKeySizeKES (Proxy :: Proxy d)
+
+      off_sk = 0 :: Word
+      off_r = size_sk
+      off_vk0 = off_r + size_r
+      off_vk1 = off_vk0 + size_vk
+  {-# INLINE rawDecodeFixedSized #-}
+
+--
 -- VerKey instances
 --
 
@@ -415,7 +465,7 @@ instance
   ) =>
   ToCBOR (VerKeyKES (CompactSumKES h d))
   where
-  toCBOR = encodeVerKeyKES
+  toCBOR = encodeFixedSized
   encodedSizeExpr _size = encodedVerKeyKESSizeExpr
 
 instance
@@ -427,7 +477,7 @@ instance
   ) =>
   FromCBOR (VerKeyKES (CompactSumKES h d))
   where
-  fromCBOR = decodeVerKeyKES
+  fromCBOR = decodeFixedSized
 
 --
 -- SignKey instances
@@ -442,12 +492,12 @@ instance
 --
 -- instance (OptimizedKESAlgorithm d, HashAlgorithm h, HashSize h ~ SeedSizeKES d)
 --       => ToCBOR (SignKeyKES (CompactSumKES h d)) where
---   toCBOR = encodeSignKeyKES
+--   toCBOR = encodeFixedSized
 --   encodedSizeExpr _size = encodedSignKeyKESSizeExpr
 --
 -- instance (OptimizedKESAlgorithm d, HashAlgorithm h, HashSize h ~ SeedSizeKES d)
 --       => FromCBOR (SignKeyKES (CompactSumKES h d)) where
---   fromCBOR = decodeSignKeyKES
+--   fromCBOR = decodeFixedSized
 
 --
 -- Sig instances
@@ -467,7 +517,7 @@ instance
   ) =>
   ToCBOR (SigKES (CompactSumKES h d))
   where
-  toCBOR = encodeSigKES
+  toCBOR = encodeFixedSized
   encodedSizeExpr _size = encodedSigKESSizeExpr
 
 instance
@@ -479,7 +529,7 @@ instance
   ) =>
   FromCBOR (SigKES (CompactSumKES h d))
   where
-  fromCBOR = decodeSigKES
+  fromCBOR = decodeFixedSized
 
 --
 -- Unsound pure KES API
@@ -547,39 +597,6 @@ instance
       <*> pure vk_0
       <*> pure vk_1
 
-  rawSerialiseUnsoundPureSignKeyKES (UnsoundPureSignKeyCompactSumKES sk r_1 vk_0 vk_1) =
-    let ssk = rawSerialiseUnsoundPureSignKeyKES sk
-        sr1 = getSeedBytes r_1
-     in mconcat
-          [ ssk
-          , sr1
-          , rawSerialiseVerKeyKES vk_0
-          , rawSerialiseVerKeyKES vk_1
-          ]
-
-  rawDeserialiseUnsoundPureSignKeyKES b = do
-    guard (BS.length b == fromIntegral @Word @Int size_total)
-    sk <- rawDeserialiseUnsoundPureSignKeyKES b_sk
-    let r = mkSeedFromBytes b_r
-    vk_0 <- rawDeserialiseVerKeyKES b_vk0
-    vk_1 <- rawDeserialiseVerKeyKES b_vk1
-    return (UnsoundPureSignKeyCompactSumKES sk r vk_0 vk_1)
-    where
-      b_sk = slice off_sk size_sk b
-      b_r = slice off_r size_r b
-      b_vk0 = slice off_vk0 size_vk b
-      b_vk1 = slice off_vk1 size_vk b
-
-      size_sk = signKeySizeKES (Proxy :: Proxy d)
-      size_r = seedSizeKES (Proxy :: Proxy d)
-      size_vk = verKeySizeKES (Proxy :: Proxy d)
-      size_total = signKeySizeKES (Proxy :: Proxy (CompactSumKES h d))
-
-      off_sk = 0 :: Word
-      off_r = size_sk
-      off_vk0 = off_r + size_r
-      off_vk1 = off_vk0 + size_vk
-
 --
 -- UnsoundPureSignKey instances
 --
@@ -598,7 +615,7 @@ instance
   ) =>
   ToCBOR (UnsoundPureSignKeyKES (CompactSumKES h d))
   where
-  toCBOR = encodeUnsoundPureSignKeyKES
+  toCBOR = encodeFixedSized
   encodedSizeExpr _size _skProxy = encodedSignKeyKESSizeExpr (Proxy :: Proxy (SignKeyKES (CompactSumKES h d)))
 
 instance
@@ -610,7 +627,7 @@ instance
   ) =>
   FromCBOR (UnsoundPureSignKeyKES (CompactSumKES h d))
   where
-  fromCBOR = decodeUnsoundPureSignKeyKES
+  fromCBOR = decodeFixedSized
 
 instance
   (NoThunks (UnsoundPureSignKeyKES d), KESAlgorithm d) =>

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/CompactSum.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/CompactSum.hs
@@ -316,8 +316,8 @@ instance
       mconcat
         [ ssk
         , sr1
-        , rawSerialiseVerKeyKES vk_0
-        , rawSerialiseVerKeyKES vk_1
+        , rawEncodeFixedSized vk_0
+        , rawEncodeFixedSized vk_1
         ]
 
   {-# NOINLINE rawDeserialiseSignKeyKESWith #-}
@@ -325,8 +325,8 @@ instance
     guard (BS.length b == fromIntegral @Word @Int size_total)
     sk <- MaybeT $ rawDeserialiseSignKeyKESWith allocator b_sk
     r <- MaybeT $ mlsbFromByteStringCheckWith allocator b_r
-    vk_0 <- MaybeT . return $ rawDeserialiseVerKeyKES b_vk0
-    vk_1 <- MaybeT . return $ rawDeserialiseVerKeyKES b_vk1
+    vk_0 <- MaybeT . return $ rawDecodeFixedSized b_vk0
+    vk_1 <- MaybeT . return $ rawDecodeFixedSized b_vk1
     return (SignKeyCompactSumKES sk (MLockedSeed r) vk_0 vk_1)
     where
       b_sk = slice off_sk size_sk b
@@ -336,7 +336,7 @@ instance
 
       size_sk = signKeySizeKES (Proxy :: Proxy d)
       size_r = seedSizeKES (Proxy :: Proxy d)
-      size_vk = verKeySizeKES (Proxy :: Proxy d)
+      size_vk = fixedSize (Proxy :: Proxy (VerKeyKES d))
       size_total = signKeySizeKES (Proxy :: Proxy (CompactSumKES h d))
 
       off_sk = 0 :: Word
@@ -398,8 +398,8 @@ instance
       b_sig = slice off_sig size_sig b
       b_vk = slice off_vk size_vk b
 
-      size_sig = sigSizeKES (Proxy :: Proxy d)
-      size_vk = verKeySizeKES (Proxy :: Proxy d)
+      size_sig = fixedSize (Proxy :: Proxy (SigKES d))
+      size_vk = fixedSize (Proxy :: Proxy (VerKeyKES d))
 
       off_sig = 0 :: Word
       off_vk = size_sig
@@ -434,7 +434,7 @@ instance
 
       size_sk = signKeySizeKES (Proxy :: Proxy d)
       size_r = seedSizeKES (Proxy :: Proxy d)
-      size_vk = verKeySizeKES (Proxy :: Proxy d)
+      size_vk = fixedSize (Proxy :: Proxy (VerKeyKES d))
 
       off_sk = 0 :: Word
       off_r = size_sk

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Mock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Mock.hs
@@ -190,11 +190,11 @@ instance KnownNat t => UnsoundKESAlgorithm (MockKES t) where
 instance KnownNat t => FixedSizeCodec (SignKeyKES (MockKES t)) where
   type FixedSize (SignKeyKES (MockKES t)) = 16
   rawEncodeFixedSized (SignKeyMockKES vk t) =
-    rawSerialiseVerKeyKES vk
+    rawEncodeFixedSized vk
       <> writeBinaryWord64 (fromIntegral @Period @Word64 t)
   rawDecodeFixedSized bs = guardFixedSized bs $ do
     let (vkb, tb) = BS.splitAt 8 bs
-    vk <- case rawDeserialiseVerKeyKES vkb of
+    vk <- case rawDecodeFixedSized vkb of
       Just x -> pure x
       Nothing -> fail "rawDeserialiseSignKeyMockKES: Failed to deserialise VerKeyKES"
     let t = fromIntegral @Word64 @Period (readBinaryWord64 tb)
@@ -270,15 +270,15 @@ instance KnownNat t => DirectDeserialise (SignKeyKES (MockKES t)) where
 
 instance KnownNat t => DirectSerialise (VerKeyKES (MockKES t)) where
   directSerialise push sk = do
-    let bs = rawSerialiseVerKeyKES sk
+    let bs = rawEncodeFixedSized sk
     unpackByteStringCStringLen bs $ \(cstr, len) -> push cstr (fromIntegral @Int @CSize len)
 
 instance KnownNat t => DirectDeserialise (VerKeyKES (MockKES t)) where
   directDeserialise pull = do
-    let len = fromIntegral @Word @Int $ verKeySizeKES (Proxy @(MockKES t))
+    let len = fromIntegral @Word @Int $ fixedSize (Proxy @(VerKeyKES (MockKES t)))
     fptr <- mallocForeignPtrBytes len
     withForeignPtr fptr $ \ptr ->
       pull (castPtr ptr) (fromIntegral @Int @CSize len)
     let bs = BS.fromForeignPtr (unsafeRawForeignPtr fptr) 0 len
     maybe (error "directDeserialise @(VerKeyKES (MockKES t))") return $
-      rawDeserialiseVerKeyKES bs
+      rawDecodeFixedSized bs

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Mock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Mock.hs
@@ -9,6 +9,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 -- | Mock key evolving signatures.
 module Cardano.Crypto.KES.Mock (
@@ -20,6 +21,12 @@ module Cardano.Crypto.KES.Mock (
 )
 where
 
+import Cardano.Binary.FixedSizeCodec (
+  FixedSizeCodec (..),
+  decodeFixedSized,
+  encodeFixedSized,
+  guardFixedSized,
+ )
 import qualified Data.ByteString.Internal as BS
 import Data.Proxy (Proxy (..))
 import Data.Word (Word64)
@@ -31,7 +38,6 @@ import NoThunks.Class (NoThunks)
 import Control.DeepSeq (NFData)
 import Control.Exception (assert)
 
-import Cardano.Base.Bytes (splitsAt)
 import Cardano.Binary (FromCBOR (..), ToCBOR (..))
 
 import Cardano.Crypto.DirectSerialise
@@ -49,6 +55,7 @@ import Cardano.Crypto.Libsodium.Memory (
  )
 import Cardano.Crypto.Seed
 import Cardano.Crypto.Util
+import qualified Data.ByteString as BS
 import Foreign.C.Types (CSize)
 
 data MockKES (t :: Nat)
@@ -91,10 +98,6 @@ instance KnownNat t => KESAlgorithm (MockKES t) where
 
   algorithmNameKES proxy = "mock_" ++ show (totalPeriodsKES proxy)
 
-  type VerKeySizeKES (MockKES t) = 8
-  type SignKeySizeKES (MockKES t) = 16
-  type SigSizeKES (MockKES t) = 24
-
   --
   -- Core algorithm operations
   --
@@ -111,32 +114,6 @@ instance KnownNat t => KESAlgorithm (MockKES t) where
         Left "KES verification failed"
 
   type TotalPeriodsKES (MockKES t) = t
-
-  --
-  -- raw serialise/deserialise
-  --
-
-  rawSerialiseVerKeyKES (VerKeyMockKES vk) =
-    writeBinaryWord64 vk
-
-  rawSerialiseSigKES (SigMockKES h sk) =
-    hashToBytes h
-      <> rawSerialiseSignKeyMockKES sk
-
-  rawDeserialiseVerKeyKES bs
-    | [vkb] <- splitsAt [8] bs
-    , let vk = readBinaryWord64 vkb =
-        Just $! VerKeyMockKES vk
-    | otherwise =
-        Nothing
-
-  rawDeserialiseSigKES bs
-    | [hb, skb] <- splitsAt [8, 16] bs
-    , Just h <- hashFromBytes hb
-    , Just sk <- rawDeserialiseSignKeyMockKES skb =
-        Just $! SigMockKES h sk
-    | otherwise =
-        Nothing
 
   deriveVerKeyKES (SignKeyMockKES vk _) = return $! vk
 
@@ -203,64 +180,82 @@ instance KnownNat t => UnsoundPureKESAlgorithm (MockKES t) where
   unsoundPureSignKeyKESToSoundSignKeyKES (UnsoundPureSignKeyMockKES vk t) =
     return $ SignKeyMockKES vk t
 
-  rawSerialiseUnsoundPureSignKeyKES (UnsoundPureSignKeyMockKES vk t) =
-    rawSerialiseSignKeyMockKES (SignKeyMockKES vk t)
-
-  rawDeserialiseUnsoundPureSignKeyKES bs = do
-    SignKeyMockKES vt t <- rawDeserialiseSignKeyMockKES bs
-    return $ UnsoundPureSignKeyMockKES vt t
-
 instance KnownNat t => UnsoundKESAlgorithm (MockKES t) where
   rawSerialiseSignKeyKES sk =
-    return $ rawSerialiseSignKeyMockKES sk
+    return $ rawEncodeFixedSized sk
 
   rawDeserialiseSignKeyKESWith _alloc bs =
-    return $ rawDeserialiseSignKeyMockKES bs
+    return $ rawDecodeFixedSized bs
 
-rawDeserialiseSignKeyMockKES ::
-  KnownNat t =>
-  ByteString ->
-  Maybe (SignKeyKES (MockKES t))
-rawDeserialiseSignKeyMockKES bs
-  | [vkb, tb] <- splitsAt [8, 8] bs
-  , Just vk <- rawDeserialiseVerKeyKES vkb
-  , let t = fromIntegral @Word64 @Period (readBinaryWord64 tb) =
-      Just $! SignKeyMockKES vk t
-  | otherwise =
-      Nothing
+instance KnownNat t => FixedSizeCodec (SignKeyKES (MockKES t)) where
+  type FixedSize (SignKeyKES (MockKES t)) = 16
+  rawEncodeFixedSized (SignKeyMockKES vk t) =
+    rawSerialiseVerKeyKES vk
+      <> writeBinaryWord64 (fromIntegral @Period @Word64 t)
+  rawDecodeFixedSized bs = guardFixedSized bs $ do
+    let (vkb, tb) = BS.splitAt 8 bs
+    vk <- case rawDeserialiseVerKeyKES vkb of
+      Just x -> pure x
+      Nothing -> fail "rawDeserialiseSignKeyMockKES: Failed to deserialise VerKeyKES"
+    let t = fromIntegral @Word64 @Period (readBinaryWord64 tb)
+    pure $! SignKeyMockKES vk t
 
-rawSerialiseSignKeyMockKES ::
-  KnownNat t =>
-  SignKeyKES (MockKES t) ->
-  ByteString
-rawSerialiseSignKeyMockKES (SignKeyMockKES vk t) =
-  rawSerialiseVerKeyKES vk
-    <> writeBinaryWord64 (fromIntegral @Period @Word64 t)
+instance KnownNat t => FixedSizeCodec (VerKeyKES (MockKES t)) where
+  type FixedSize (VerKeyKES (MockKES t)) = 8
+  rawEncodeFixedSized (VerKeyMockKES vk) =
+    writeBinaryWord64 vk
+  rawDecodeFixedSized bs = guardFixedSized bs $ do
+    let vk = readBinaryWord64 bs
+    return $! VerKeyMockKES vk
+  {-# INLINE rawDecodeFixedSized #-}
+
+instance KnownNat t => FixedSizeCodec (SigKES (MockKES t)) where
+  type FixedSize (SigKES (MockKES t)) = 24
+  rawEncodeFixedSized (SigMockKES h sk) =
+    hashToBytes h
+      <> rawEncodeFixedSized sk
+  rawDecodeFixedSized bs = guardFixedSized bs $ do
+    let (hb, skb) = BS.splitAt 8 bs
+    h <- case hashFromBytes hb of
+      Just x -> pure x
+      Nothing -> fail "SigKES (MockKES t): Failed to decode hash"
+    sk <- rawDecodeFixedSized skb
+    return $! SigMockKES h sk
+  {-# INLINE rawDecodeFixedSized #-}
+
+instance KnownNat t => FixedSizeCodec (UnsoundPureSignKeyKES (MockKES t)) where
+  type FixedSize (UnsoundPureSignKeyKES (MockKES t)) = FixedSize (SignKeyKES (MockKES t))
+  rawEncodeFixedSized (UnsoundPureSignKeyMockKES vk t) =
+    rawEncodeFixedSized (SignKeyMockKES vk t)
+  rawDecodeFixedSized bs = do
+    SignKeyMockKES vt t <- rawDecodeFixedSized bs
+    return $! UnsoundPureSignKeyMockKES vt t
+  {-# INLINE rawDecodeFixedSized #-}
 
 instance KnownNat t => ToCBOR (VerKeyKES (MockKES t)) where
-  toCBOR = encodeVerKeyKES
+  toCBOR = encodeFixedSized
   encodedSizeExpr _size = encodedVerKeyKESSizeExpr
 
 instance KnownNat t => FromCBOR (VerKeyKES (MockKES t)) where
-  fromCBOR = decodeVerKeyKES
+  fromCBOR = decodeFixedSized
 
 instance KnownNat t => ToCBOR (SigKES (MockKES t)) where
-  toCBOR = encodeSigKES
+  toCBOR = encodeFixedSized
   encodedSizeExpr _size = encodedSigKESSizeExpr
 
 instance KnownNat t => FromCBOR (SigKES (MockKES t)) where
-  fromCBOR = decodeSigKES
+  fromCBOR = decodeFixedSized
 
 instance KnownNat t => ToCBOR (UnsoundPureSignKeyKES (MockKES t)) where
-  toCBOR = encodeUnsoundPureSignKeyKES
+  toCBOR = encodeFixedSized
   encodedSizeExpr _size _skProxy = encodedSignKeyKESSizeExpr (Proxy :: Proxy (SignKeyKES (MockKES t)))
 
 instance KnownNat t => FromCBOR (UnsoundPureSignKeyKES (MockKES t)) where
-  fromCBOR = decodeUnsoundPureSignKeyKES
+  fromCBOR = decodeFixedSized
 
 instance KnownNat t => DirectSerialise (SignKeyKES (MockKES t)) where
   directSerialise put sk = do
-    let bs = rawSerialiseSignKeyMockKES sk
+    let bs = rawEncodeFixedSized sk
     unpackByteStringCStringLen bs $ \(cstr, len) -> put cstr (fromIntegral @Int @CSize len)
 
 instance KnownNat t => DirectDeserialise (SignKeyKES (MockKES t)) where
@@ -271,7 +266,7 @@ instance KnownNat t => DirectDeserialise (SignKeyKES (MockKES t)) where
       pull (castPtr ptr) (fromIntegral @Int @CSize len)
     let bs = BS.fromForeignPtr (unsafeRawForeignPtr fptr) 0 len
     maybe (error "directDeserialise @(SignKeyKES (MockKES t))") return $
-      rawDeserialiseSignKeyMockKES bs
+      rawDecodeFixedSized bs
 
 instance KnownNat t => DirectSerialise (VerKeyKES (MockKES t)) where
   directSerialise push sk = do

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/NeverUsed.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/NeverUsed.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
 module Cardano.Crypto.KES.NeverUsed (
@@ -16,6 +17,7 @@ where
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks)
 
+import Cardano.Binary.FixedSizeCodec (FixedSizeCodec (..), guardFixedSized)
 import Cardano.Crypto.KES.Class
 
 -- | KES never used
@@ -42,15 +44,7 @@ instance KESAlgorithm NeverKES where
 
   type TotalPeriodsKES NeverKES = 0
 
-  type VerKeySizeKES NeverKES = 0
   type SignKeySizeKES NeverKES = 0
-  type SigSizeKES NeverKES = 0
-
-  rawSerialiseVerKeyKES _ = mempty
-  rawSerialiseSigKES _ = mempty
-
-  rawDeserialiseVerKeyKES _ = Just NeverUsedVerKeyKES
-  rawDeserialiseSigKES _ = Just NeverUsedSigKES
 
   deriveVerKeyKES _ = return NeverUsedVerKeyKES
 
@@ -61,9 +55,30 @@ instance KESAlgorithm NeverKES where
 
   forgetSignKeyKESWith _ = const $ return ()
 
+instance FixedSizeCodec (VerKeyKES NeverKES) where
+  type FixedSize (VerKeyKES NeverKES) = 0
+  rawEncodeFixedSized _ = mempty
+  rawDecodeFixedSized bs = guardFixedSized bs $ do
+    return NeverUsedVerKeyKES
+  {-# INLINE rawDecodeFixedSized #-}
+
+instance FixedSizeCodec (SigKES NeverKES) where
+  type FixedSize (SigKES NeverKES) = 0
+  rawEncodeFixedSized _ = mempty
+  rawDecodeFixedSized bs = guardFixedSized bs $ do
+    return NeverUsedSigKES
+  {-# INLINE rawDecodeFixedSized #-}
+
 instance UnsoundKESAlgorithm NeverKES where
   rawSerialiseSignKeyKES _ = return mempty
   rawDeserialiseSignKeyKESWith _ _ = return $ Just NeverUsedSignKeyKES
+
+instance FixedSizeCodec (UnsoundPureSignKeyKES NeverKES) where
+  type FixedSize (UnsoundPureSignKeyKES NeverKES) = SignKeySizeKES NeverKES
+  rawEncodeFixedSized _ = mempty
+  rawDecodeFixedSized bs = guardFixedSized bs $ do
+    return NeverUsedUnsoundPureSignKeyKES
+  {-# INLINE rawDecodeFixedSized #-}
 
 instance UnsoundPureKESAlgorithm NeverKES where
   data UnsoundPureSignKeyKES NeverKES = NeverUsedUnsoundPureSignKeyKES
@@ -74,5 +89,3 @@ instance UnsoundPureKESAlgorithm NeverKES where
   unsoundPureDeriveVerKeyKES _ = NeverUsedVerKeyKES
   unsoundPureUpdateKES _ = error "KES not available"
   unsoundPureSignKeyKESToSoundSignKeyKES _ = return NeverUsedSignKeyKES
-  rawSerialiseUnsoundPureSignKeyKES _ = mempty
-  rawDeserialiseUnsoundPureSignKeyKES _ = Just NeverUsedUnsoundPureSignKeyKES

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Simple.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Simple.hs
@@ -213,7 +213,7 @@ instance
       convertSK =
         fmap (fromMaybe (error "unsoundPureSignKeyKESToSoundSignKeyKES: deserialisation failed"))
           . rawDeserialiseSignKeyDSIGNM
-          . rawSerialiseSignKeyDSIGN
+          . rawEncodeFixedSized
 
 instance
   (UnsoundDSIGNMAlgorithm d, KnownNat t, KESAlgorithm (SimpleKES d t)) =>
@@ -228,7 +228,7 @@ instance
 
   rawDeserialiseSignKeyKESWith allocator bs
     | let duration = fromIntegral @Natural @Int (natVal (Proxy :: Proxy t))
-          sizeKey = fromIntegral @Word @Int (signKeySizeDSIGN (Proxy :: Proxy d))
+          sizeKey = fromIntegral @Word @Int (fixedSize (Proxy :: Proxy (SignKeyDSIGN d)))
     , skbs <- splitsAt (replicate duration sizeKey) bs
     , length skbs == duration =
         runMaybeT $ do
@@ -249,7 +249,7 @@ instance
     BS.concat [rawEncodeFixedSized vk | vk <- Vec.toList vks]
   rawDecodeFixedSized bs = guardFixedSized bs $ do
     let duration = fromIntegral @Natural @Int (natVal (Proxy :: Proxy t))
-        sizeKey = fromIntegral @Word @Int (verKeySizeDSIGN (Proxy :: Proxy d))
+        sizeKey = fromIntegral @Word @Int (fixedSize (Proxy :: Proxy (VerKeyDSIGN d)))
         vkbs = splitsAt (replicate duration sizeKey) bs
     unless (length vkbs == duration) $
       fail "VerKeyKES (SimpleKES d t): vkbs length is not equal to duration"
@@ -278,7 +278,7 @@ instance
     foldMap rawEncodeFixedSized sks
   rawDecodeFixedSized bs = guardFixedSized bs $ do
     let duration = fromIntegral @Natural @Int (natVal (Proxy :: Proxy t))
-        sizeKey = fromIntegral @Word @Int (signKeySizeDSIGN (Proxy :: Proxy d))
+        sizeKey = fromIntegral @Word @Int (fixedSize (Proxy :: Proxy (SignKeyDSIGN d)))
         skbs = splitsAt (replicate duration sizeKey) bs
     unless (length skbs == duration) $
       fail "UnsoundPureSignKeyKES (SimpleKES d t): vkbs length is not equal to duration"

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Simple.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Simple.hs
@@ -25,7 +25,13 @@ module Cardano.Crypto.KES.Simple (
 )
 where
 
-import Control.Monad ((<$!>))
+import Cardano.Binary.FixedSizeCodec (
+  FixedSizeCodec (..),
+  decodeFixedSized,
+  encodeFixedSized,
+  guardFixedSized,
+ )
+import Control.Monad (unless, (<$!>))
 import Control.Monad.Trans.Maybe
 import qualified Data.ByteString as BS
 import Data.Proxy (Proxy (..))
@@ -132,27 +138,7 @@ instance
   -- raw serialise/deserialise
   --
 
-  type VerKeySizeKES (SimpleKES d t) = VerKeySizeDSIGN d * t
   type SignKeySizeKES (SimpleKES d t) = SignKeySizeDSIGN d * t
-  type SigSizeKES (SimpleKES d t) = SigSizeDSIGN d
-
-  rawSerialiseVerKeyKES (VerKeySimpleKES vks) =
-    BS.concat [rawSerialiseVerKeyDSIGN vk | vk <- Vec.toList vks]
-
-  rawSerialiseSigKES (SigSimpleKES sig) =
-    rawSerialiseSigDSIGN sig
-
-  rawDeserialiseVerKeyKES bs
-    | let duration = fromIntegral @Natural @Int (natVal (Proxy :: Proxy t))
-          sizeKey = fromIntegral @Word @Int (verKeySizeDSIGN (Proxy :: Proxy d))
-    , vkbs <- splitsAt (replicate duration sizeKey) bs
-    , length vkbs == duration
-    , Just vks <- mapM rawDeserialiseVerKeyDSIGN vkbs =
-        Just $! VerKeySimpleKES (Vec.fromList vks)
-    | otherwise =
-        Nothing
-
-  rawDeserialiseSigKES = fmap SigSimpleKES . rawDeserialiseSigDSIGN
 
   deriveVerKeyKES (SignKeySimpleKES sks) =
     VerKeySimpleKES <$!> Vec.mapM deriveVerKeyDSIGNM sks
@@ -229,20 +215,6 @@ instance
           . rawDeserialiseSignKeyDSIGNM
           . rawSerialiseSignKeyDSIGN
 
-  rawSerialiseUnsoundPureSignKeyKES (UnsoundPureSignKeySimpleKES sks) =
-    foldMap rawSerialiseSignKeyDSIGN sks
-
-  rawDeserialiseUnsoundPureSignKeyKES bs
-    | let duration = fromIntegral @Natural @Int (natVal (Proxy :: Proxy t))
-          sizeKey = fromIntegral @Word @Int (signKeySizeDSIGN (Proxy :: Proxy d))
-          skbs = splitsAt (replicate duration sizeKey) bs
-    , length skbs == duration =
-        do
-          sks <- mapM rawDeserialiseSignKeyDSIGN skbs
-          return $! UnsoundPureSignKeySimpleKES (Vec.fromList sks)
-    | otherwise =
-        Nothing
-
 instance
   (UnsoundDSIGNMAlgorithm d, KnownNat t, KESAlgorithm (SimpleKES d t)) =>
   UnsoundKESAlgorithm (SimpleKES d t)
@@ -264,6 +236,55 @@ instance
           return $! SignKeySimpleKES (Vec.fromList sks)
     | otherwise =
         return Nothing
+
+instance
+  ( DSIGNAlgorithm d
+  , KnownNat t
+  , KnownNat (VerKeySizeDSIGN d * t)
+  ) =>
+  FixedSizeCodec (VerKeyKES (SimpleKES d t))
+  where
+  type FixedSize (VerKeyKES (SimpleKES d t)) = VerKeySizeDSIGN d * t
+  rawEncodeFixedSized (VerKeySimpleKES vks) =
+    BS.concat [rawEncodeFixedSized vk | vk <- Vec.toList vks]
+  rawDecodeFixedSized bs = guardFixedSized bs $ do
+    let duration = fromIntegral @Natural @Int (natVal (Proxy :: Proxy t))
+        sizeKey = fromIntegral @Word @Int (verKeySizeDSIGN (Proxy :: Proxy d))
+        vkbs = splitsAt (replicate duration sizeKey) bs
+    unless (length vkbs == duration) $
+      fail "VerKeyKES (SimpleKES d t): vkbs length is not equal to duration"
+    vks <- mapM rawDecodeFixedSized vkbs
+    return $! VerKeySimpleKES (Vec.fromList vks)
+  {-# INLINE rawDecodeFixedSized #-}
+
+instance
+  (DSIGNAlgorithm d, KnownNat t) =>
+  FixedSizeCodec (SigKES (SimpleKES d t))
+  where
+  type FixedSize (SigKES (SimpleKES d t)) = SigSizeDSIGN d
+  rawEncodeFixedSized (SigSimpleKES sig) = rawEncodeFixedSized sig
+  rawDecodeFixedSized bs = SigSimpleKES <$> rawDecodeFixedSized bs
+  {-# INLINE rawDecodeFixedSized #-}
+
+instance
+  ( DSIGNAlgorithm d
+  , KnownNat t
+  , KnownNat (SignKeySizeDSIGN d * t)
+  ) =>
+  FixedSizeCodec (UnsoundPureSignKeyKES (SimpleKES d t))
+  where
+  type FixedSize (UnsoundPureSignKeyKES (SimpleKES d t)) = SignKeySizeKES (SimpleKES d t)
+  rawEncodeFixedSized (UnsoundPureSignKeySimpleKES sks) =
+    foldMap rawEncodeFixedSized sks
+  rawDecodeFixedSized bs = guardFixedSized bs $ do
+    let duration = fromIntegral @Natural @Int (natVal (Proxy :: Proxy t))
+        sizeKey = fromIntegral @Word @Int (signKeySizeDSIGN (Proxy :: Proxy d))
+        skbs = splitsAt (replicate duration sizeKey) bs
+    unless (length skbs == duration) $
+      fail "UnsoundPureSignKeyKES (SimpleKES d t): vkbs length is not equal to duration"
+    sks <- mapM rawDecodeFixedSized skbs
+    return $! UnsoundPureSignKeySimpleKES (Vec.fromList sks)
+  {-# INLINE rawDecodeFixedSized #-}
 
 deriving instance DSIGNMAlgorithm d => Show (VerKeyKES (SimpleKES d t))
 deriving instance (DSIGNMAlgorithm d, Show (SignKeyDSIGNM d)) => Show (SignKeyKES (SimpleKES d t))
@@ -289,7 +310,7 @@ instance
   ) =>
   ToCBOR (VerKeyKES (SimpleKES d t))
   where
-  toCBOR = encodeVerKeyKES
+  toCBOR = encodeFixedSized
   encodedSizeExpr _size = encodedVerKeyKESSizeExpr
 
 instance
@@ -301,7 +322,7 @@ instance
   ) =>
   FromCBOR (VerKeyKES (SimpleKES d t))
   where
-  fromCBOR = decodeVerKeyKES
+  fromCBOR = decodeFixedSized
 
 instance
   ( DSIGNMAlgorithm d
@@ -312,7 +333,7 @@ instance
   ) =>
   ToCBOR (SigKES (SimpleKES d t))
   where
-  toCBOR = encodeSigKES
+  toCBOR = encodeFixedSized
   encodedSizeExpr _size = encodedSigKESSizeExpr
 
 instance
@@ -324,7 +345,7 @@ instance
   ) =>
   FromCBOR (SigKES (SimpleKES d t))
   where
-  fromCBOR = decodeSigKES
+  fromCBOR = decodeFixedSized
 
 instance DirectSerialise (VerKeyDSIGN d) => DirectSerialise (VerKeyKES (SimpleKES d t)) where
   directSerialise push (VerKeySimpleKES vks) =

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Single.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Single.hs
@@ -36,8 +36,14 @@ module Cardano.Crypto.KES.Single (
   SigKES (..),
 ) where
 
+import Cardano.Binary.FixedSizeCodec (
+  FixedSizeCodec (..),
+  decodeFixedSized,
+  encodeFixedSized,
+ )
 import Data.Proxy (Proxy (..))
 import GHC.Generics (Generic)
+import GHC.TypeLits (KnownNat)
 import NoThunks.Class (NoThunks)
 
 import Control.DeepSeq (NFData)
@@ -63,7 +69,13 @@ deriving via
   instance
     NFData (SignKeyDSIGNM d) => NFData (SignKeyKES (SingleKES d))
 
-instance DSIGNMAlgorithm d => KESAlgorithm (SingleKES d) where
+instance
+  ( DSIGNMAlgorithm d
+  , KnownNat (FixedSize (VerKeyDSIGN d))
+  , KnownNat (FixedSize (SigDSIGN d))
+  ) =>
+  KESAlgorithm (SingleKES d)
+  where
   type SeedSizeKES (SingleKES d) = SeedSizeDSIGN d
 
   --
@@ -97,20 +109,10 @@ instance DSIGNMAlgorithm d => KESAlgorithm (SingleKES d) where
   -- raw serialise/deserialise
   --
 
-  type VerKeySizeKES (SingleKES d) = VerKeySizeDSIGN d
   type SignKeySizeKES (SingleKES d) = SignKeySizeDSIGN d
-  type SigSizeKES (SingleKES d) = SigSizeDSIGN d
 
   hashVerKeyKES (VerKeySingleKES vk) =
     castHash (hashVerKeyDSIGN vk)
-
-  rawSerialiseVerKeyKES (VerKeySingleKES vk) = rawSerialiseVerKeyDSIGN vk
-  rawSerialiseSigKES (SigSingleKES sig) = rawSerialiseSigDSIGN sig
-
-  rawDeserialiseVerKeyKES = fmap VerKeySingleKES . rawDeserialiseVerKeyDSIGN
-  {-# INLINE rawDeserialiseVerKeyKES #-}
-  rawDeserialiseSigKES = fmap SigSingleKES . rawDeserialiseSigDSIGN
-  {-# INLINE rawDeserialiseSigKES #-}
 
   deriveVerKeyKES (SignKeySingleKES v) =
     VerKeySingleKES <$!> deriveVerKeyDSIGNM v
@@ -167,11 +169,6 @@ instance
   unsoundPureSignKeyKESToSoundSignKeyKES =
     unsoundPureSignKeyKESToSoundSignKeyKESViaSer
 
-  rawSerialiseUnsoundPureSignKeyKES (UnsoundPureSignKeySingleKES sk) =
-    rawSerialiseSignKeyDSIGN sk
-  rawDeserialiseUnsoundPureSignKeyKES b =
-    UnsoundPureSignKeySingleKES <$> rawDeserialiseSignKeyDSIGN b
-
 instance
   (KESAlgorithm (SingleKES d), UnsoundDSIGNMAlgorithm d) =>
   UnsoundKESAlgorithm (SingleKES d)
@@ -183,6 +180,28 @@ instance
     fmap SignKeySingleKES <$> rawDeserialiseSignKeyDSIGNMWith allocator bs
 
 --
+-- FixedSizeCodec instances
+--
+
+instance DSIGNAlgorithm d => FixedSizeCodec (VerKeyKES (SingleKES d)) where
+  type FixedSize (VerKeyKES (SingleKES d)) = FixedSize (VerKeyDSIGN d)
+  rawEncodeFixedSized (VerKeySingleKES vk) = rawEncodeFixedSized vk
+  rawDecodeFixedSized bs = VerKeySingleKES <$> rawDecodeFixedSized bs
+  {-# INLINE rawDecodeFixedSized #-}
+
+instance DSIGNAlgorithm d => FixedSizeCodec (SigKES (SingleKES d)) where
+  type FixedSize (SigKES (SingleKES d)) = FixedSize (SigDSIGN d)
+  rawEncodeFixedSized (SigSingleKES sig) = rawEncodeFixedSized sig
+  rawDecodeFixedSized bs = SigSingleKES <$> rawDecodeFixedSized bs
+  {-# INLINE rawDecodeFixedSized #-}
+
+instance DSIGNAlgorithm d => FixedSizeCodec (UnsoundPureSignKeyKES (SingleKES d)) where
+  type FixedSize (UnsoundPureSignKeyKES (SingleKES d)) = SignKeySizeKES (SingleKES d)
+  rawEncodeFixedSized (UnsoundPureSignKeySingleKES sk) = rawEncodeFixedSized sk
+  rawDecodeFixedSized bs = UnsoundPureSignKeySingleKES <$> rawDecodeFixedSized bs
+  {-# INLINE rawDecodeFixedSized #-}
+
+--
 -- VerKey instances
 --
 
@@ -190,11 +209,11 @@ deriving instance DSIGNAlgorithm d => Show (VerKeyKES (SingleKES d))
 deriving instance DSIGNAlgorithm d => Eq (VerKeyKES (SingleKES d))
 
 instance DSIGNMAlgorithm d => ToCBOR (VerKeyKES (SingleKES d)) where
-  toCBOR = encodeVerKeyKES
+  toCBOR = encodeFixedSized
   encodedSizeExpr _size = encodedVerKeyKESSizeExpr
 
 instance DSIGNMAlgorithm d => FromCBOR (VerKeyKES (SingleKES d)) where
-  fromCBOR = decodeVerKeyKES
+  fromCBOR = decodeFixedSized
   {-# INLINE fromCBOR #-}
 
 instance DSIGNMAlgorithm d => NoThunks (VerKeyKES (SingleKES d))
@@ -215,11 +234,11 @@ deriving instance DSIGNAlgorithm d => Eq (SigKES (SingleKES d))
 instance DSIGNAlgorithm d => NoThunks (SigKES (SingleKES d))
 
 instance DSIGNMAlgorithm d => ToCBOR (SigKES (SingleKES d)) where
-  toCBOR = encodeSigKES
+  toCBOR = encodeFixedSized
   encodedSizeExpr _size = encodedSigKESSizeExpr
 
 instance DSIGNMAlgorithm d => FromCBOR (SigKES (SingleKES d)) where
-  fromCBOR = decodeSigKES
+  fromCBOR = decodeFixedSized
 
 --
 -- UnsoundPureSignKey instances
@@ -229,11 +248,11 @@ deriving instance DSIGNAlgorithm d => Show (UnsoundPureSignKeyKES (SingleKES d))
 deriving instance Eq (SignKeyDSIGN d) => Eq (UnsoundPureSignKeyKES (SingleKES d))
 
 instance UnsoundDSIGNMAlgorithm d => ToCBOR (UnsoundPureSignKeyKES (SingleKES d)) where
-  toCBOR = encodeUnsoundPureSignKeyKES
+  toCBOR = encodeFixedSized
   encodedSizeExpr _size _skProxy = encodedSignKeyKESSizeExpr (Proxy :: Proxy (SignKeyKES (SingleKES d)))
 
 instance UnsoundDSIGNMAlgorithm d => FromCBOR (UnsoundPureSignKeyKES (SingleKES d)) where
-  fromCBOR = decodeUnsoundPureSignKeyKES
+  fromCBOR = decodeFixedSized
 
 instance DSIGNAlgorithm d => NoThunks (UnsoundPureSignKeyKES (SingleKES d))
 

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Sum.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Sum.hs
@@ -282,8 +282,8 @@ instance
       mconcat
         [ ssk
         , sr1
-        , rawSerialiseVerKeyKES vk_0
-        , rawSerialiseVerKeyKES vk_1
+        , rawEncodeFixedSized vk_0
+        , rawEncodeFixedSized vk_1
         ]
 
   {-# NOINLINE rawDeserialiseSignKeyKESWith #-}
@@ -291,8 +291,8 @@ instance
     guard (BS.length b == fromIntegral @Word @Int size_total)
     sk <- MaybeT $ rawDeserialiseSignKeyKESWith allocator b_sk
     r <- MaybeT $ mlsbFromByteStringCheckWith allocator b_r
-    vk_0 <- MaybeT . return $ rawDeserialiseVerKeyKES b_vk0
-    vk_1 <- MaybeT . return $ rawDeserialiseVerKeyKES b_vk1
+    vk_0 <- MaybeT . return $ rawDecodeFixedSized b_vk0
+    vk_1 <- MaybeT . return $ rawDecodeFixedSized b_vk1
     return (SignKeySumKES sk (MLockedSeed r) vk_0 vk_1)
     where
       b_sk = slice off_sk size_sk b
@@ -302,7 +302,7 @@ instance
 
       size_sk = signKeySizeKES (Proxy :: Proxy d)
       size_r = seedSizeKES (Proxy :: Proxy d)
-      size_vk = verKeySizeKES (Proxy :: Proxy d)
+      size_vk = fixedSize (Proxy :: Proxy (VerKeyKES d))
       size_total = signKeySizeKES (Proxy :: Proxy (SumKES h d))
 
       off_sk = 0 :: Word
@@ -344,8 +344,8 @@ instance
       b_vk0 = slice off_vk0 size_vk b
       b_vk1 = slice off_vk1 size_vk b
 
-      size_sig = sigSizeKES (Proxy :: Proxy d)
-      size_vk = verKeySizeKES (Proxy :: Proxy d)
+      size_sig = fixedSize (Proxy :: Proxy (SigKES d))
+      size_vk = fixedSize (Proxy :: Proxy (VerKeyKES d))
 
       off_sig = 0 :: Word
       off_vk0 = size_sig
@@ -381,7 +381,7 @@ instance
 
       size_sk = signKeySizeKES (Proxy :: Proxy d)
       size_r = seedSizeKES (Proxy :: Proxy d)
-      size_vk = verKeySizeKES (Proxy :: Proxy d)
+      size_vk = fixedSize (Proxy :: Proxy (VerKeyKES d))
 
       off_sk = 0 :: Word
       off_r = size_sk

--- a/cardano-crypto-class/src/Cardano/Crypto/KES/Sum.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/KES/Sum.hs
@@ -50,6 +50,12 @@ module Cardano.Crypto.KES.Sum (
   Sum7KES,
 ) where
 
+import Cardano.Binary.FixedSizeCodec (
+  FixedSizeCodec (..),
+  decodeFixedSized,
+  encodeFixedSized,
+  guardFixedSized,
+ )
 import Control.Monad (guard, (<$!>))
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Internal as BS
@@ -71,6 +77,7 @@ import Cardano.Crypto.Seed
 
 import Control.DeepSeq (NFData (..))
 import Control.Monad.Trans.Maybe (MaybeT (..), runMaybeT)
+import Data.Typeable (Typeable)
 import Foreign.C.Types (CSize)
 import Foreign.Ptr (castPtr)
 import GHC.TypeLits (KnownNat, type (*), type (+))
@@ -194,48 +201,11 @@ instance
   -- raw serialise/deserialise
   --
 
-  type VerKeySizeKES (SumKES h d) = HashSize h
   type
     SignKeySizeKES (SumKES h d) =
       SignKeySizeKES d
         + SeedSizeKES d
         + 2 * VerKeySizeKES d
-  type
-    SigSizeKES (SumKES h d) =
-      SigSizeKES d
-        + VerKeySizeKES d * 2
-
-  rawSerialiseVerKeyKES (VerKeySumKES vk) = hashToBytes vk
-
-  rawSerialiseSigKES (SigSumKES sigma vk_0 vk_1) =
-    mconcat
-      [ rawSerialiseSigKES sigma
-      , rawSerialiseVerKeyKES vk_0
-      , rawSerialiseVerKeyKES vk_1
-      ]
-
-  rawDeserialiseVerKeyKES = fmap VerKeySumKES . hashFromBytes
-  {-# INLINE rawDeserialiseVerKeyKES #-}
-
-  rawDeserialiseSigKES b = do
-    guard (BS.length b == fromIntegral @Word @Int size_total)
-    sigma <- rawDeserialiseSigKES b_sig
-    vk_0 <- rawDeserialiseVerKeyKES b_vk0
-    vk_1 <- rawDeserialiseVerKeyKES b_vk1
-    return (SigSumKES sigma vk_0 vk_1)
-    where
-      b_sig = slice off_sig size_sig b
-      b_vk0 = slice off_vk0 size_vk b
-      b_vk1 = slice off_vk1 size_vk b
-
-      size_sig = sigSizeKES (Proxy :: Proxy d)
-      size_vk = verKeySizeKES (Proxy :: Proxy d)
-      size_total = sigSizeKES (Proxy :: Proxy (SumKES h d))
-
-      off_sig = 0 :: Word
-      off_vk0 = size_sig
-      off_vk1 = off_vk0 + size_vk
-  {-# INLINEABLE rawDeserialiseSigKES #-}
 
   deriveVerKeyKES (SignKeySumKES _ _ vk_0 vk_1) =
     return $! VerKeySumKES (hashPairOfVKeys (vk_0, vk_1))
@@ -341,6 +311,85 @@ instance
       off_vk1 = off_vk0 + size_vk
 
 --
+-- FixedSizeCodec instances
+--
+
+instance HashAlgorithm h => FixedSizeCodec (VerKeyKES (SumKES h d)) where
+  type FixedSize (VerKeyKES (SumKES h d)) = HashSize h
+  rawEncodeFixedSized (VerKeySumKES vk) = hashToBytes vk
+  rawDecodeFixedSized bs = VerKeySumKES <$> hashFromByteStringM bs
+  {-# INLINE rawDecodeFixedSized #-}
+
+instance
+  ( KESAlgorithm d
+  , KnownNat (SigSizeKES d + VerKeySizeKES d * 2)
+  , Typeable h
+  ) =>
+  FixedSizeCodec (SigKES (SumKES h d))
+  where
+  type FixedSize (SigKES (SumKES h d)) = SigSizeKES d + VerKeySizeKES d * 2
+  rawEncodeFixedSized (SigSumKES sigma vk_0 vk_1) =
+    mconcat
+      [ rawEncodeFixedSized sigma
+      , rawEncodeFixedSized vk_0
+      , rawEncodeFixedSized vk_1
+      ]
+  rawDecodeFixedSized b = guardFixedSized b $ do
+    sigma <- rawDecodeFixedSized b_sig
+    vk_0 <- rawDecodeFixedSized b_vk0
+    vk_1 <- rawDecodeFixedSized b_vk1
+    return (SigSumKES sigma vk_0 vk_1)
+    where
+      b_sig = slice off_sig size_sig b
+      b_vk0 = slice off_vk0 size_vk b
+      b_vk1 = slice off_vk1 size_vk b
+
+      size_sig = sigSizeKES (Proxy :: Proxy d)
+      size_vk = verKeySizeKES (Proxy :: Proxy d)
+
+      off_sig = 0 :: Word
+      off_vk0 = size_sig
+      off_vk1 = off_vk0 + size_vk
+  {-# INLINE rawDecodeFixedSized #-}
+
+instance
+  ( KESAlgorithm (SumKES h d)
+  , UnsoundPureKESAlgorithm d
+  , KnownNat ((SignKeySizeKES d + SeedSizeKES d) + 2 * VerKeySizeKES d)
+  ) =>
+  FixedSizeCodec (UnsoundPureSignKeyKES (SumKES h d))
+  where
+  type FixedSize (UnsoundPureSignKeyKES (SumKES h d)) = SignKeySizeKES (SumKES h d)
+  rawEncodeFixedSized (UnsoundPureSignKeySumKES sk r_1 vk_0 vk_1) =
+    mconcat
+      [ rawEncodeFixedSized sk
+      , getSeedBytes r_1
+      , rawEncodeFixedSized vk_0
+      , rawEncodeFixedSized vk_1
+      ]
+  rawDecodeFixedSized b = guardFixedSized b $ do
+    sk <- rawDecodeFixedSized b_sk
+    let r = mkSeedFromBytes b_r
+    vk_0 <- rawDecodeFixedSized b_vk0
+    vk_1 <- rawDecodeFixedSized b_vk1
+    return (UnsoundPureSignKeySumKES sk r vk_0 vk_1)
+    where
+      b_sk = slice off_sk size_sk b
+      b_r = slice off_r size_r b
+      b_vk0 = slice off_vk0 size_vk b
+      b_vk1 = slice off_vk1 size_vk b
+
+      size_sk = signKeySizeKES (Proxy :: Proxy d)
+      size_r = seedSizeKES (Proxy :: Proxy d)
+      size_vk = verKeySizeKES (Proxy :: Proxy d)
+
+      off_sk = 0 :: Word
+      off_r = size_sk
+      off_vk0 = off_r + size_r
+      off_vk1 = off_vk0 + size_vk
+  {-# INLINE rawDecodeFixedSized #-}
+
+--
 -- VerKey instances
 --
 
@@ -351,14 +400,14 @@ instance
   (KESAlgorithm (SumKES h d), SodiumHashAlgorithm h, HashSize h ~ SeedSizeKES d) =>
   ToCBOR (VerKeyKES (SumKES h d))
   where
-  toCBOR = encodeVerKeyKES
+  toCBOR = encodeFixedSized
   encodedSizeExpr _size = encodedVerKeyKESSizeExpr
 
 instance
   (KESAlgorithm (SumKES h d), SodiumHashAlgorithm h, HashSize h ~ SeedSizeKES d) =>
   FromCBOR (VerKeyKES (SumKES h d))
   where
-  fromCBOR = decodeVerKeyKES
+  fromCBOR = decodeFixedSized
   {-# INLINE fromCBOR #-}
 
 instance KESAlgorithm d => NoThunks (VerKeyKES (SumKES h d))
@@ -372,12 +421,12 @@ instance KESAlgorithm d => NoThunks (VerKeyKES (SumKES h d))
 --
 -- instance (KESAlgorithm d, HashAlgorithm h, HashSize h ~ SeedSizeKES d)
 --       => ToCBOR (SignKeyKES (SumKES h d)) where
---   toCBOR = encodeSignKeyKES
+--   toCBOR = encodeFixedSized
 --   encodedSizeExpr _size = encodedSignKeyKESSizeExpr
 --
 -- instance (KESAlgorithm d, HashAlgorithm h, HashSize h ~ SeedSizeKES d)
 --       => FromCBOR (SignKeyKES (SumKES h d)) where
---   fromCBOR = decodeSignKeyKES
+--   fromCBOR = decodeFixedSized
 
 deriving via
   OnlyCheckWhnfNamed "SignKeyKES (SumKES h d)" (SignKeyKES (SumKES h d))
@@ -397,14 +446,14 @@ instance
   (KESAlgorithm (SumKES h d), SodiumHashAlgorithm h, HashSize h ~ SeedSizeKES d) =>
   ToCBOR (SigKES (SumKES h d))
   where
-  toCBOR = encodeSigKES
+  toCBOR = encodeFixedSized
   encodedSizeExpr _size = encodedSigKESSizeExpr
 
 instance
   (KESAlgorithm (SumKES h d), SodiumHashAlgorithm h, HashSize h ~ SeedSizeKES d) =>
   FromCBOR (SigKES (SumKES h d))
   where
-  fromCBOR = decodeSigKES
+  fromCBOR = decodeFixedSized
 
 --
 -- Unsound pure KES API
@@ -469,39 +518,6 @@ instance
       <*> pure vk_0
       <*> pure vk_1
 
-  rawSerialiseUnsoundPureSignKeyKES (UnsoundPureSignKeySumKES sk r_1 vk_0 vk_1) =
-    let ssk = rawSerialiseUnsoundPureSignKeyKES sk
-        sr1 = getSeedBytes r_1
-     in mconcat
-          [ ssk
-          , sr1
-          , rawSerialiseVerKeyKES vk_0
-          , rawSerialiseVerKeyKES vk_1
-          ]
-
-  rawDeserialiseUnsoundPureSignKeyKES b = do
-    guard (BS.length b == fromIntegral @Word @Int size_total)
-    sk <- rawDeserialiseUnsoundPureSignKeyKES b_sk
-    let r = mkSeedFromBytes b_r
-    vk_0 <- rawDeserialiseVerKeyKES b_vk0
-    vk_1 <- rawDeserialiseVerKeyKES b_vk1
-    return (UnsoundPureSignKeySumKES sk r vk_0 vk_1)
-    where
-      b_sk = slice off_sk size_sk b
-      b_r = slice off_r size_r b
-      b_vk0 = slice off_vk0 size_vk b
-      b_vk1 = slice off_vk1 size_vk b
-
-      size_sk = signKeySizeKES (Proxy :: Proxy d)
-      size_r = seedSizeKES (Proxy :: Proxy d)
-      size_vk = verKeySizeKES (Proxy :: Proxy d)
-      size_total = signKeySizeKES (Proxy :: Proxy (SumKES h d))
-
-      off_sk = 0 :: Word
-      off_r = size_sk
-      off_vk0 = off_r + size_r
-      off_vk1 = off_vk0 + size_vk
-
 --
 -- UnsoundPureSignKey instances
 --
@@ -519,7 +535,7 @@ instance
   ) =>
   ToCBOR (UnsoundPureSignKeyKES (SumKES h d))
   where
-  toCBOR = encodeUnsoundPureSignKeyKES
+  toCBOR = encodeFixedSized
   encodedSizeExpr _size _skProxy = encodedSignKeyKESSizeExpr (Proxy :: Proxy (SignKeyKES (SumKES h d)))
 
 instance
@@ -530,7 +546,7 @@ instance
   ) =>
   FromCBOR (UnsoundPureSignKeyKES (SumKES h d))
   where
-  fromCBOR = decodeUnsoundPureSignKeyKES
+  fromCBOR = decodeFixedSized
 
 instance
   (NoThunks (UnsoundPureSignKeyKES d), KESAlgorithm d) =>

--- a/cardano-crypto-class/src/Cardano/Crypto/PackedBytes/Internal.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/PackedBytes/Internal.hs
@@ -27,7 +27,6 @@ module Cardano.Crypto.PackedBytes.Internal
   , xorPackedBytes
   ) where
 
-import Codec.CBOR.Decoding as D (decodeBytes)
 import Cardano.Base.Bytes (byteArrayToByteString)
 import Cardano.Binary (FromCBOR (..), ToCBOR (..), Size)
 import Control.DeepSeq (NFData(..))
@@ -57,6 +56,8 @@ import GHC.ST
 import GHC.TypeLits
 import GHC.Word
 import NoThunks.Class
+import Cardano.Binary.FixedSizeCodec (FixedSizeCodec (..), decodeFixedSized)
+import qualified Data.MemPack as MP
 
 #include "MachDeps.h"
 
@@ -151,7 +152,14 @@ instance KnownNat n => MemPack (PackedBytes n) where
       (\addr# -> accursedUnutterablePerformIO $ packPinnedPtr (Ptr (addr# `plusAddr#` curPos#)))
   {-# INLINE unpackM #-}
 
+instance KnownNat n => FixedSizeCodec (PackedBytes n) where
+  type FixedSize (PackedBytes n) = n
+  rawDecodeFixedSized = packByteString
+  rawEncodeFixedSized = MP.packByteString
+
 instance KnownNat n => ToCBOR (PackedBytes n) where
+  -- The `toCBOR` implementation for `PackedBytes` does not use
+  -- `rawEncodeFixedSized` to prevent redundant copying of the bytestring
   toCBOR = toCBOR . unpackBytes
   {-# INLINE toCBOR #-}
 
@@ -162,7 +170,7 @@ instance KnownNat n => ToCBOR (PackedBytes n) where
       packedBytesSize = fromInteger (natVal' (proxy# @n))
 
 instance KnownNat n => FromCBOR (PackedBytes n) where
-  fromCBOR = D.decodeBytes >>= packByteString
+  fromCBOR = decodeFixedSized
   {-# INLINE fromCBOR #-}
 
 instance KnownNat n => Storable (PackedBytes n) where

--- a/cardano-crypto-class/src/Cardano/Crypto/PinnedSizedBytes.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/PinnedSizedBytes.hs
@@ -1,6 +1,8 @@
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE KindSignatures #-}
@@ -9,6 +11,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskellQuotes #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE UnboxedTuples #-}
 
 module Cardano.Crypto.PinnedSizedBytes (
@@ -23,6 +26,7 @@ module Cardano.Crypto.PinnedSizedBytes (
   psbToByteArray,
   psbFromByteString,
   psbFromByteStringM,
+  psbFromByteStringForM,
   psbFromByteStringCheck,
   psbToByteString,
 
@@ -81,11 +85,20 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Short as SBS
 import qualified Data.Primitive as Prim
 
+import Cardano.Binary.FixedSizeCodec (
+  FixedSizeCodec (..),
+  decodeFixedSized,
+  encodeFixedSized,
+  guardFixedSized,
+ )
 import Cardano.Crypto.Libsodium.C (c_sodium_compare)
 import Cardano.Crypto.PackedBytes.Internal (PackedBytes, packBytes)
 import Cardano.Crypto.Util (decodeHexString)
 import Cardano.Foreign
+import Control.Monad.Trans.Fail (errorFail)
+import qualified Data.ByteString.Unsafe as BS
 import Data.MemPack.Buffer (byteArrayToShortByteString)
+import GHC.Stack (HasCallStack)
 
 {- HLINT ignore "Reduce duplication" -}
 
@@ -135,7 +148,7 @@ instance KnownNat n => Ord (PinnedSizedBytes n) where
       size = fromInteger (natVal (Proxy :: Proxy n))
 
 instance KnownNat n => ToCBOR (PinnedSizedBytes n) where
-  toCBOR = toCBOR . psbToByteString
+  toCBOR = encodeFixedSized
   {-# INLINE toCBOR #-}
 
   encodedSizeExpr _size proxy =
@@ -145,17 +158,13 @@ instance KnownNat n => ToCBOR (PinnedSizedBytes n) where
       pinnedBytesSize = fromInteger (natVal (Proxy @n))
 
 instance KnownNat n => FromCBOR (PinnedSizedBytes n) where
-  fromCBOR = do
-    bs <- fromCBOR
-    case psbFromByteStringCheck bs of
-      Nothing ->
-        fail $
-          "Size mismatch. Expected: " <> show size <> " number of bytes, but got: " <> show (BS.length bs)
-      Just psb -> pure psb
-    where
-      size :: Int
-      size = fromInteger (natVal (Proxy :: Proxy n))
+  fromCBOR = decodeFixedSized
   {-# INLINE fromCBOR #-}
+
+instance KnownNat n => FixedSizeCodec (PinnedSizedBytes n) where
+  type FixedSize (PinnedSizedBytes n) = n
+  rawEncodeFixedSized = psbToByteString
+  rawDecodeFixedSized = psbFromByteStringM
 
 -- | This instance is meant to be used with @TemplateHaskell@
 --
@@ -180,7 +189,14 @@ instance KnownNat n => IsString (Q (TExp (PinnedSizedBytes n))) where
     let n = fromInteger $ natVal (Proxy :: Proxy n)
     case decodeHexString hexStr n of
       Left err -> fail $ "<PinnedSizedBytes>: " ++ err
-      Right _ -> examineSplice [||either error psbFromByteString (decodeHexString hexStr n)||]
+      Right _ ->
+        examineSplice
+          [||
+          either
+            error
+            (errorFail @String . rawDecodeFixedSized)
+            (decodeHexString hexStr n)
+          ||]
 
 instance KnownNat n => IsString (Code Q (PinnedSizedBytes n)) where
   fromString = Code . fromString
@@ -226,37 +242,31 @@ psbFromBytes ws0 = PSB (pinnedByteArrayFromListN size ws)
 
 -- | Convert a ByteString into PinnedSizedBytes. Input should contain the exact
 -- number of bytes as expected by type level @n@ size, otherwise error.
-psbFromByteString :: KnownNat n => BS.ByteString -> PinnedSizedBytes n
-psbFromByteString bs =
-  case psbFromByteStringCheck bs of
-    Nothing -> error $ "psbFromByteString: Size mismatch, got: " ++ show (BS.length bs)
-    Just psb -> psb
+psbFromByteString :: (HasCallStack, KnownNat n) => BS.ByteString -> PinnedSizedBytes n
+psbFromByteString = errorFail @String . psbFromByteStringM
 
-psbFromByteStringCheck :: forall n. KnownNat n => BS.ByteString -> Maybe (PinnedSizedBytes n)
+psbFromByteStringForM ::
+  forall a m.
+  ( MonadFail m
+  , KnownNat (FixedSize a)
+  ) =>
+  Proxy a -> BS.ByteString -> m (PinnedSizedBytes (FixedSize a))
+psbFromByteStringForM _ = psbFromByteStringM @(FixedSize a)
+
+psbFromByteStringCheck :: KnownNat n => BS.ByteString -> Maybe (PinnedSizedBytes n)
 psbFromByteStringCheck = psbFromByteStringM
 
 psbFromByteStringM ::
   forall n m.
-  (KnownNat n, MonadFail m) =>
+  (MonadFail m, KnownNat n) =>
   BS.ByteString -> m (PinnedSizedBytes n)
-psbFromByteStringM bs
-  | n == size = pure $
-      unsafeDupablePerformIO $
-        BS.useAsCStringLen bs $ \(Ptr addr#, _) -> do
-          marr@(MutableByteArray marr#) <- newPinnedByteArray size
-          primitive_ $ copyAddrToByteArray# addr# marr# 0# (case size of I# s -> s)
-          arr <- unsafeFreezeByteArray marr
-          return (PSB arr)
-  | otherwise =
-      fail $
-        "Supplied ByteString with size: "
-          <> show n
-          <> " did not match the expected number of bytes: "
-          <> show size
-  where
-    n = BS.length bs
-    size :: Int
-    size = fromInteger (natVal (Proxy :: Proxy n))
+psbFromByteStringM bs =
+  guardFixedSized bs $ do
+    unsafeDupablePerformIO . BS.unsafeUseAsCStringLen bs $ \(Ptr addr#, size) -> do
+      marr@(MutableByteArray marr#) <- newPinnedByteArray size
+      primitive_ $ copyAddrToByteArray# addr# marr# 0# (case size of I# s -> s)
+      arr <- unsafeFreezeByteArray marr
+      return (pure $ PSB arr)
 
 {-# DEPRECATED psbZero "This is not referentially transparent" #-}
 psbZero :: KnownNat n => PinnedSizedBytes n

--- a/cardano-crypto-class/src/Cardano/Crypto/VRF/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/VRF/Class.hs
@@ -18,6 +18,9 @@
 module Cardano.Crypto.VRF.Class (
   -- * VRF algorithm class
   VRFAlgorithm (..),
+  sizeVerKeyVRF,
+  sizeSignKeyVRF,
+  sizeCertVRF,
 
   -- ** VRF output
   OutputVRF (..),
@@ -72,7 +75,7 @@ import Data.Typeable (Typeable)
 import GHC.Exts (Constraint)
 import GHC.Generics (Generic)
 import GHC.Stack
-import GHC.TypeLits (ErrorMessage (..), TypeError)
+import GHC.TypeLits (ErrorMessage (..), KnownNat, Nat, TypeError, natVal)
 import NoThunks.Class (NoThunks, OnlyCheckWhnfNamed (..))
 import Numeric.Natural (Natural)
 
@@ -89,6 +92,9 @@ class
   , NoThunks (CertVRF v)
   , NoThunks (VerKeyVRF v)
   , NoThunks (SignKeyVRF v)
+  , KnownNat (VerKeySizeVRF v)
+  , KnownNat (SignKeySizeVRF v)
+  , KnownNat (CertSizeVRF v)
   ) =>
   VRFAlgorithm v
   where
@@ -99,6 +105,10 @@ class
   data VerKeyVRF v :: Type
   data SignKeyVRF v :: Type
   data CertVRF v :: Type
+
+  type VerKeySizeVRF v :: Nat
+  type SignKeySizeVRF v :: Nat
+  type CertSizeVRF v :: Nat
 
   --
   -- Metadata and basic key operations
@@ -161,9 +171,6 @@ class
   -- Serialisation/(de)serialisation in fixed-size raw format
   --
 
-  sizeVerKeyVRF :: proxy v -> Word
-  sizeSignKeyVRF :: proxy v -> Word
-  sizeCertVRF :: proxy v -> Word
   sizeOutputVRF :: proxy v -> Word
 
   rawSerialiseVerKeyVRF :: VerKeyVRF v -> ByteString
@@ -187,11 +194,17 @@ class
     , rawDeserialiseVerKeyVRF
     , rawDeserialiseSignKeyVRF
     , rawDeserialiseCertVRF
-    , sizeVerKeyVRF
-    , sizeSignKeyVRF
-    , sizeCertVRF
     , sizeOutputVRF
     #-}
+
+sizeVerKeyVRF :: forall v proxy. KnownNat (VerKeySizeVRF v) => proxy v -> Word
+sizeVerKeyVRF _ = fromInteger @Word . natVal $ Proxy @(VerKeySizeVRF v)
+
+sizeSignKeyVRF :: forall v proxy. KnownNat (SignKeySizeVRF v) => proxy v -> Word
+sizeSignKeyVRF _ = fromInteger @Word . natVal $ Proxy @(SignKeySizeVRF v)
+
+sizeCertVRF :: forall v proxy. KnownNat (CertSizeVRF v) => proxy v -> Word
+sizeCertVRF _ = fromInteger @Word . natVal $ Proxy @(CertSizeVRF v)
 
 --
 -- Do not provide Ord instances for keys, see #38

--- a/cardano-crypto-class/src/Cardano/Crypto/VRF/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/VRF/Class.hs
@@ -129,7 +129,7 @@ class
   deriveVerKeyVRF :: SignKeyVRF v -> VerKeyVRF v
 
   hashVerKeyVRF :: HashAlgorithm h => VerKeyVRF v -> Hash h (VerKeyVRF v)
-  hashVerKeyVRF = hashWith rawSerialiseVerKeyVRF
+  hashVerKeyVRF = hashWith rawEncodeFixedSized
 
   --
   -- Core algorithm operations
@@ -207,15 +207,25 @@ class
     , sizeOutputVRF
     #-}
 
+{-# DEPRECATED rawSerialiseVerKeyVRF "Use `rawEncodeFixedSized` instead" #-}
+{-# DEPRECATED rawSerialiseSignKeyVRF "Use `rawEncodeFixedSized` instead" #-}
+{-# DEPRECATED rawSerialiseCertVRF "Use `rawEncodeFixedSized` instead" #-}
+{-# DEPRECATED rawDeserialiseVerKeyVRF "Use `rawDecodeFixedSized` instead" #-}
+{-# DEPRECATED rawDeserialiseSignKeyVRF "Use `rawDecodeFixedSized` instead" #-}
+{-# DEPRECATED rawDeserialiseCertVRF "Use `rawDecodeFixedSized` instead" #-}
+
 sizeVerKeyVRF ::
   forall v proxy. FixedSizeCodec (VerKeyVRF v) => proxy v -> Word
 sizeVerKeyVRF _ = fixedSize $ Proxy @(VerKeyVRF v)
+{-# DEPRECATED sizeVerKeyVRF "Use `fixedSize` instead" #-}
 
 sizeSignKeyVRF :: forall v proxy. FixedSizeCodec (SignKeyVRF v) => proxy v -> Word
 sizeSignKeyVRF _ = fixedSize $ Proxy @(SignKeyVRF v)
+{-# DEPRECATED sizeSignKeyVRF "Use `fixedSize` instead" #-}
 
 sizeCertVRF :: forall v proxy. FixedSizeCodec (CertVRF v) => proxy v -> Word
 sizeCertVRF _ = fixedSize $ Proxy @(CertVRF v)
+{-# DEPRECATED sizeCertVRF "Use `fixedSize` instead" #-}
 
 --
 -- Do not provide Ord instances for keys, see #38
@@ -275,15 +285,15 @@ mkTestOutputVRF = OutputVRF . naturalToByteArray sz
 --
 
 encodeVerKeyVRF :: VRFAlgorithm v => VerKeyVRF v -> Encoding
-encodeVerKeyVRF = encodeBytes . rawSerialiseVerKeyVRF
+encodeVerKeyVRF = encodeBytes . rawEncodeFixedSized
 {-# DEPRECATED encodeVerKeyVRF "Use `encodeFixedSized` instead" #-}
 
 encodeSignKeyVRF :: VRFAlgorithm v => SignKeyVRF v -> Encoding
-encodeSignKeyVRF = encodeBytes . rawSerialiseSignKeyVRF
+encodeSignKeyVRF = encodeBytes . rawEncodeFixedSized
 {-# DEPRECATED encodeSignKeyVRF "Use `encodeFixedSized` instead" #-}
 
 encodeCertVRF :: VRFAlgorithm v => CertVRF v -> Encoding
-encodeCertVRF = encodeBytes . rawSerialiseCertVRF
+encodeCertVRF = encodeBytes . rawEncodeFixedSized
 {-# DEPRECATED encodeCertVRF "Use `encodeFixedSized` instead" #-}
 
 decodeVerKeyVRF :: forall v s. VRFAlgorithm v => Decoder s (VerKeyVRF v)
@@ -324,7 +334,7 @@ instance (VRFAlgorithm v, Typeable a) => ToCBOR (CertifiedVRF v a) where
   encodedSizeExpr _size proxy =
     1
       + certifiedOutputSize (certifiedOutput <$> proxy)
-      + fromIntegral @Word @Size (sizeCertVRF (Proxy :: Proxy v))
+      + fromIntegral @Word @Size (fixedSize (Proxy @(CertVRF v)))
     where
       certifiedOutputSize :: Proxy (OutputVRF v) -> Size
       certifiedOutputSize _proxy =
@@ -362,29 +372,23 @@ verifyCertified ctxt vk a CertifiedVRF {certifiedOutput, certifiedProof} =
 -- 'Size' expressions for 'ToCBOR' instances
 --
 
--- | 'Size' expression for 'VerKeyVRF' which is using 'sizeVerKeyVRF' encoded as
--- 'Size'.
 encodedVerKeyVRFSizeExpr :: forall v. VRFAlgorithm v => Proxy (VerKeyVRF v) -> Size
 encodedVerKeyVRFSizeExpr _proxy =
   -- 'encodeBytes' envelope
-  fromIntegral @Integer @Size (withWordSize (sizeVerKeyVRF (Proxy :: Proxy v)))
+  fromIntegral @Integer @Size (withWordSize (fixedSize (Proxy @(VerKeyVRF v))))
     -- payload
-    + fromIntegral @Word @Size (sizeVerKeyVRF (Proxy :: Proxy v))
+    + fromIntegral @Word @Size (fixedSize (Proxy @(VerKeyVRF v)))
 
--- | 'Size' expression for 'SignKeyVRF' which is using 'sizeSignKeyVRF' encoded
--- as 'Size'
 encodedSignKeyVRFSizeExpr :: forall v. VRFAlgorithm v => Proxy (SignKeyVRF v) -> Size
 encodedSignKeyVRFSizeExpr _proxy =
   -- 'encodeBytes' envelope
-  fromIntegral @Integer @Size (withWordSize (sizeSignKeyVRF (Proxy :: Proxy v)))
+  fromIntegral @Integer @Size (withWordSize (fixedSize (Proxy @(SignKeyVRF v))))
     -- payload
-    + fromIntegral @Word @Size (sizeSignKeyVRF (Proxy :: Proxy v))
+    + fromIntegral @Word @Size (fixedSize (Proxy @(SignKeyVRF v)))
 
--- | 'Size' expression for 'CertVRF' which is using 'sizeCertVRF' encoded as
--- 'Size'.
 encodedCertVRFSizeExpr :: forall v. VRFAlgorithm v => Proxy (CertVRF v) -> Size
 encodedCertVRFSizeExpr _proxy =
   -- 'encodeBytes' envelope
-  fromIntegral @Integer @Size (withWordSize (sizeCertVRF (Proxy :: Proxy v)))
+  fromIntegral @Integer @Size (withWordSize (fixedSize (Proxy @(CertVRF v))))
     -- payload
-    + fromIntegral @Word @Size (sizeCertVRF (Proxy :: Proxy v))
+    + fromIntegral @Word @Size (fixedSize (Proxy @(CertVRF v)))

--- a/cardano-crypto-class/src/Cardano/Crypto/VRF/Class.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/VRF/Class.hs
@@ -54,11 +54,16 @@ import Cardano.Binary (
   FromCBOR (..),
   Size,
   ToCBOR (..),
-  decodeBytes,
   encodeBytes,
   encodeListLen,
   enforceSize,
   withWordSize,
+ )
+import Cardano.Binary.FixedSizeCodec (
+  FixedSizeCodec (..),
+  decodeFixedSized,
+  encodeFixedSized,
+  fixedSize,
  )
 import Cardano.Crypto.Hash.Class (Hash, HashAlgorithm, hashWith)
 import Cardano.Crypto.Seed (Seed)
@@ -66,7 +71,6 @@ import Cardano.Crypto.Util (Empty, byteArrayToNatural, naturalToByteArray)
 import Control.DeepSeq (NFData)
 import Data.Array.Byte (ByteArray)
 import Data.ByteString (ByteString)
-import qualified Data.ByteString as BS
 import Data.ByteString.Short as SBS (fromShort)
 import Data.Kind (Type)
 import Data.MemPack.Buffer (byteArrayToShortByteString)
@@ -75,7 +79,7 @@ import Data.Typeable (Typeable)
 import GHC.Exts (Constraint)
 import GHC.Generics (Generic)
 import GHC.Stack
-import GHC.TypeLits (ErrorMessage (..), KnownNat, Nat, TypeError, natVal)
+import GHC.TypeLits (ErrorMessage (..), KnownNat, Nat, TypeError)
 import NoThunks.Class (NoThunks, OnlyCheckWhnfNamed (..))
 import Numeric.Natural (Natural)
 
@@ -95,6 +99,9 @@ class
   , KnownNat (VerKeySizeVRF v)
   , KnownNat (SignKeySizeVRF v)
   , KnownNat (CertSizeVRF v)
+  , FixedSizeCodec (CertVRF v)
+  , FixedSizeCodec (VerKeyVRF v)
+  , FixedSizeCodec (SignKeyVRF v)
   ) =>
   VRFAlgorithm v
   where
@@ -107,8 +114,11 @@ class
   data CertVRF v :: Type
 
   type VerKeySizeVRF v :: Nat
+  type VerKeySizeVRF v = FixedSize (VerKeyVRF v)
   type SignKeySizeVRF v :: Nat
+  type SignKeySizeVRF v = FixedSize (SignKeyVRF v)
   type CertSizeVRF v :: Nat
+  type CertSizeVRF v = FixedSize (CertVRF v)
 
   --
   -- Metadata and basic key operations
@@ -174,12 +184,18 @@ class
   sizeOutputVRF :: proxy v -> Word
 
   rawSerialiseVerKeyVRF :: VerKeyVRF v -> ByteString
+  rawSerialiseVerKeyVRF = rawEncodeFixedSized
   rawSerialiseSignKeyVRF :: SignKeyVRF v -> ByteString
+  rawSerialiseSignKeyVRF = rawEncodeFixedSized
   rawSerialiseCertVRF :: CertVRF v -> ByteString
+  rawSerialiseCertVRF = rawEncodeFixedSized
 
   rawDeserialiseVerKeyVRF :: ByteString -> Maybe (VerKeyVRF v)
+  rawDeserialiseVerKeyVRF = rawDecodeFixedSized
   rawDeserialiseSignKeyVRF :: ByteString -> Maybe (SignKeyVRF v)
+  rawDeserialiseSignKeyVRF = rawDecodeFixedSized
   rawDeserialiseCertVRF :: ByteString -> Maybe (CertVRF v)
+  rawDeserialiseCertVRF = rawDecodeFixedSized
 
   {-# MINIMAL
     algorithmNameVRF
@@ -188,23 +204,18 @@ class
     , verifyVRF
     , seedSizeVRF
     , (genKeyVRF | genKeyPairVRF)
-    , rawSerialiseVerKeyVRF
-    , rawSerialiseSignKeyVRF
-    , rawSerialiseCertVRF
-    , rawDeserialiseVerKeyVRF
-    , rawDeserialiseSignKeyVRF
-    , rawDeserialiseCertVRF
     , sizeOutputVRF
     #-}
 
-sizeVerKeyVRF :: forall v proxy. KnownNat (VerKeySizeVRF v) => proxy v -> Word
-sizeVerKeyVRF _ = fromInteger @Word . natVal $ Proxy @(VerKeySizeVRF v)
+sizeVerKeyVRF ::
+  forall v proxy. FixedSizeCodec (VerKeyVRF v) => proxy v -> Word
+sizeVerKeyVRF _ = fixedSize $ Proxy @(VerKeyVRF v)
 
-sizeSignKeyVRF :: forall v proxy. KnownNat (SignKeySizeVRF v) => proxy v -> Word
-sizeSignKeyVRF _ = fromInteger @Word . natVal $ Proxy @(SignKeySizeVRF v)
+sizeSignKeyVRF :: forall v proxy. FixedSizeCodec (SignKeyVRF v) => proxy v -> Word
+sizeSignKeyVRF _ = fixedSize $ Proxy @(SignKeyVRF v)
 
-sizeCertVRF :: forall v proxy. KnownNat (CertSizeVRF v) => proxy v -> Word
-sizeCertVRF _ = fromInteger @Word . natVal $ Proxy @(CertSizeVRF v)
+sizeCertVRF :: forall v proxy. FixedSizeCodec (CertVRF v) => proxy v -> Word
+sizeCertVRF _ = fixedSize $ Proxy @(CertVRF v)
 
 --
 -- Do not provide Ord instances for keys, see #38
@@ -265,68 +276,30 @@ mkTestOutputVRF = OutputVRF . naturalToByteArray sz
 
 encodeVerKeyVRF :: VRFAlgorithm v => VerKeyVRF v -> Encoding
 encodeVerKeyVRF = encodeBytes . rawSerialiseVerKeyVRF
+{-# DEPRECATED encodeVerKeyVRF "Use `encodeFixedSized` instead" #-}
 
 encodeSignKeyVRF :: VRFAlgorithm v => SignKeyVRF v -> Encoding
 encodeSignKeyVRF = encodeBytes . rawSerialiseSignKeyVRF
+{-# DEPRECATED encodeSignKeyVRF "Use `encodeFixedSized` instead" #-}
 
 encodeCertVRF :: VRFAlgorithm v => CertVRF v -> Encoding
 encodeCertVRF = encodeBytes . rawSerialiseCertVRF
+{-# DEPRECATED encodeCertVRF "Use `encodeFixedSized` instead" #-}
 
 decodeVerKeyVRF :: forall v s. VRFAlgorithm v => Decoder s (VerKeyVRF v)
-decodeVerKeyVRF = do
-  bs <- decodeBytes
-  case rawDeserialiseVerKeyVRF bs of
-    Just vk -> return vk
-    Nothing
-      | actual /= expected ->
-          fail
-            ( "decodeVerKeyVRF: wrong length, expected "
-                ++ show expected
-                ++ " bytes but got "
-                ++ show actual
-            )
-      | otherwise -> fail "decodeVerKeyVRF: cannot decode key"
-      where
-        expected = fromIntegral @Word @Int (sizeVerKeyVRF (Proxy :: Proxy v))
-        actual = BS.length bs
-{-# INLINEABLE decodeVerKeyVRF #-}
+decodeVerKeyVRF = decodeFixedSized
+{-# INLINE decodeVerKeyVRF #-}
+{-# DEPRECATED decodeVerKeyVRF "Use `decodeFixedSized` instead" #-}
 
 decodeSignKeyVRF :: forall v s. VRFAlgorithm v => Decoder s (SignKeyVRF v)
-decodeSignKeyVRF = do
-  bs <- decodeBytes
-  case rawDeserialiseSignKeyVRF bs of
-    Just sk -> return sk
-    Nothing
-      | actual /= expected ->
-          fail
-            ( "decodeSignKeyVRF: wrong length, expected "
-                ++ show expected
-                ++ " bytes but got "
-                ++ show actual
-            )
-      | otherwise -> fail "decodeSignKeyVRF: cannot decode key"
-      where
-        expected = fromIntegral @Word @Int (sizeSignKeyVRF (Proxy :: Proxy v))
-        actual = BS.length bs
+decodeSignKeyVRF = decodeFixedSized
+{-# INLINE decodeSignKeyVRF #-}
+{-# DEPRECATED decodeSignKeyVRF "Use `decodeFixedSized` instead" #-}
 
 decodeCertVRF :: forall v s. VRFAlgorithm v => Decoder s (CertVRF v)
-decodeCertVRF = do
-  bs <- decodeBytes
-  case rawDeserialiseCertVRF bs of
-    Just crt -> return crt
-    Nothing
-      | actual /= expected ->
-          fail
-            ( "decodeCertVRF: wrong length, expected "
-                ++ show expected
-                ++ " bytes but got "
-                ++ show actual
-            )
-      | otherwise -> fail "decodeCertVRF: cannot decode key"
-      where
-        expected = fromIntegral @Word @Int (sizeCertVRF (Proxy :: Proxy v))
-        actual = BS.length bs
-{-# INLINEABLE decodeCertVRF #-}
+decodeCertVRF = decodeFixedSized
+{-# INLINE decodeCertVRF #-}
+{-# DEPRECATED decodeCertVRF "Use `decodeFixedSized` instead" #-}
 
 data CertifiedVRF v a = CertifiedVRF
   { certifiedOutput :: !(OutputVRF v)
@@ -346,7 +319,7 @@ instance (VRFAlgorithm v, Typeable a) => ToCBOR (CertifiedVRF v a) where
   toCBOR cvrf =
     encodeListLen 2
       <> toCBOR (certifiedOutput cvrf)
-      <> encodeCertVRF (certifiedProof cvrf)
+      <> encodeFixedSized (certifiedProof cvrf)
 
   encodedSizeExpr _size proxy =
     1
@@ -362,7 +335,7 @@ instance (VRFAlgorithm v, Typeable a) => FromCBOR (CertifiedVRF v a) where
     CertifiedVRF
       <$ enforceSize "CertifiedVRF" 2
       <*> fromCBOR
-      <*> decodeCertVRF
+      <*> decodeFixedSized
   {-# INLINE fromCBOR #-}
 
 evalCertified ::

--- a/cardano-crypto-class/src/Cardano/Crypto/VRF/Mock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/VRF/Mock.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
@@ -13,13 +14,18 @@ module Cardano.Crypto.VRF.Mock (
 )
 where
 
+import Cardano.Binary.FixedSizeCodec (
+  FixedSizeCodec (..),
+  decodeFixedSized,
+  encodeFixedSized,
+  guardFixedSized,
+ )
 import Control.DeepSeq (NFData)
 import Data.Proxy (Proxy (..))
 import Data.Word (Word64)
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks)
 
-import Cardano.Base.Bytes (splitsAt)
 import Cardano.Binary (FromCBOR (..), ToCBOR (..))
 
 import Cardano.Crypto.Hash
@@ -42,10 +48,6 @@ instance VRFAlgorithm MockVRF where
 
   newtype CertVRF MockVRF = CertMockVRF Word64
     deriving (Show, Eq, Ord, Generic, NoThunks, NFData)
-
-  type VerKeySizeVRF MockVRF = 8
-  type SignKeySizeVRF MockVRF = 8
-  type CertSizeVRF MockVRF = 8
 
   --
   -- Metadata and basic key operations
@@ -80,55 +82,44 @@ instance VRFAlgorithm MockVRF where
     where
       sk = runMonadRandomWithSeed seed getRandomWord64
 
-  --
-  -- raw serialise/deserialise
-  --
-
-  rawSerialiseVerKeyVRF (VerKeyMockVRF k) = writeBinaryWord64 k
-  rawSerialiseSignKeyVRF (SignKeyMockVRF k) = writeBinaryWord64 k
-  rawSerialiseCertVRF (CertMockVRF k) = writeBinaryWord64 k
-
-  rawDeserialiseVerKeyVRF bs
-    | [kb] <- splitsAt [8] bs
-    , let k = readBinaryWord64 kb =
-        Just $! VerKeyMockVRF k
-    | otherwise =
-        Nothing
-
-  rawDeserialiseSignKeyVRF bs
-    | [kb] <- splitsAt [8] bs
-    , let k = readBinaryWord64 kb =
-        Just $! SignKeyMockVRF k
-    | otherwise =
-        Nothing
-
-  rawDeserialiseCertVRF bs
-    | [kb] <- splitsAt [8] bs
-    , let k = readBinaryWord64 kb =
-        Just $! CertMockVRF k
-    | otherwise =
-        Nothing
-
 instance ToCBOR (VerKeyVRF MockVRF) where
-  toCBOR = encodeVerKeyVRF
+  toCBOR = encodeFixedSized
   encodedSizeExpr _size = encodedVerKeyVRFSizeExpr
 
 instance FromCBOR (VerKeyVRF MockVRF) where
-  fromCBOR = decodeVerKeyVRF
+  fromCBOR = decodeFixedSized
 
 instance ToCBOR (SignKeyVRF MockVRF) where
-  toCBOR = encodeSignKeyVRF
+  toCBOR = encodeFixedSized
   encodedSizeExpr _size = encodedSignKeyVRFSizeExpr
 
 instance FromCBOR (SignKeyVRF MockVRF) where
-  fromCBOR = decodeSignKeyVRF
+  fromCBOR = decodeFixedSized
 
 instance ToCBOR (CertVRF MockVRF) where
-  toCBOR = encodeCertVRF
+  toCBOR = encodeFixedSized
   encodedSizeExpr _size = encodedCertVRFSizeExpr
 
 instance FromCBOR (CertVRF MockVRF) where
-  fromCBOR = decodeCertVRF
+  fromCBOR = decodeFixedSized
+
+instance FixedSizeCodec (VerKeyVRF MockVRF) where
+  type FixedSize (VerKeyVRF MockVRF) = 8
+  rawEncodeFixedSized (VerKeyMockVRF k) = writeBinaryWord64 k
+  rawDecodeFixedSized bs = guardFixedSized bs $ pure $! VerKeyMockVRF (readBinaryWord64 bs)
+  {-# INLINE rawDecodeFixedSized #-}
+
+instance FixedSizeCodec (SignKeyVRF MockVRF) where
+  type FixedSize (SignKeyVRF MockVRF) = 8
+  rawEncodeFixedSized (SignKeyMockVRF k) = writeBinaryWord64 k
+  rawDecodeFixedSized bs = guardFixedSized bs $ pure $! SignKeyMockVRF (readBinaryWord64 bs)
+  {-# INLINE rawDecodeFixedSized #-}
+
+instance FixedSizeCodec (CertVRF MockVRF) where
+  type FixedSize (CertVRF MockVRF) = 8
+  rawEncodeFixedSized (CertMockVRF k) = writeBinaryWord64 k
+  rawDecodeFixedSized bs = guardFixedSized bs $ pure $! CertMockVRF (readBinaryWord64 bs)
+  {-# INLINE rawDecodeFixedSized #-}
 
 evalVRF' ::
   SignableRepresentation a =>

--- a/cardano-crypto-class/src/Cardano/Crypto/VRF/Mock.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/VRF/Mock.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -42,6 +43,10 @@ instance VRFAlgorithm MockVRF where
   newtype CertVRF MockVRF = CertMockVRF Word64
     deriving (Show, Eq, Ord, Generic, NoThunks, NFData)
 
+  type VerKeySizeVRF MockVRF = 8
+  type SignKeySizeVRF MockVRF = 8
+  type CertSizeVRF MockVRF = 8
+
   --
   -- Metadata and basic key operations
   --
@@ -78,10 +83,6 @@ instance VRFAlgorithm MockVRF where
   --
   -- raw serialise/deserialise
   --
-
-  sizeVerKeyVRF _ = 8
-  sizeSignKeyVRF _ = 8
-  sizeCertVRF _ = 8
 
   rawSerialiseVerKeyVRF (VerKeyMockVRF k) = writeBinaryWord64 k
   rawSerialiseSignKeyVRF (SignKeyMockVRF k) = writeBinaryWord64 k

--- a/cardano-crypto-class/src/Cardano/Crypto/VRF/NeverUsed.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/VRF/NeverUsed.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleInstances #-}
@@ -42,6 +43,10 @@ instance VRFAlgorithm NeverVRF where
   data CertVRF NeverVRF = NeverUsedCertVRF
     deriving (Show, Eq, Ord, Generic, NoThunks)
 
+  type VerKeySizeVRF NeverVRF = 0
+  type SignKeySizeVRF NeverVRF = 0
+  type CertSizeVRF NeverVRF = 0
+
   algorithmNameVRF _ = "never"
 
   deriveVerKeyVRF _ = NeverUsedVerKeyVRF
@@ -54,10 +59,6 @@ instance VRFAlgorithm NeverVRF where
 
   genKeyVRF _ = NeverUsedSignKeyVRF
   seedSizeVRF _ = 0
-
-  sizeVerKeyVRF _ = 0
-  sizeSignKeyVRF _ = 0
-  sizeCertVRF _ = 0
 
   rawSerialiseVerKeyVRF _ = mempty
   rawSerialiseSignKeyVRF _ = mempty

--- a/cardano-crypto-class/src/Cardano/Crypto/VRF/NeverUsed.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/VRF/NeverUsed.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
 
 module Cardano.Crypto.VRF.NeverUsed (
@@ -12,7 +13,9 @@ module Cardano.Crypto.VRF.NeverUsed (
 )
 where
 
+import Cardano.Binary.FixedSizeCodec (FixedSizeCodec (..), guardFixedSized)
 import Control.DeepSeq (NFData (..))
+import qualified Data.ByteString as BS
 import GHC.Generics (Generic)
 import NoThunks.Class (NoThunks)
 
@@ -43,10 +46,6 @@ instance VRFAlgorithm NeverVRF where
   data CertVRF NeverVRF = NeverUsedCertVRF
     deriving (Show, Eq, Ord, Generic, NoThunks)
 
-  type VerKeySizeVRF NeverVRF = 0
-  type SignKeySizeVRF NeverVRF = 0
-  type CertSizeVRF NeverVRF = 0
-
   algorithmNameVRF _ = "never"
 
   deriveVerKeyVRF _ = NeverUsedVerKeyVRF
@@ -60,10 +59,23 @@ instance VRFAlgorithm NeverVRF where
   genKeyVRF _ = NeverUsedSignKeyVRF
   seedSizeVRF _ = 0
 
-  rawSerialiseVerKeyVRF _ = mempty
-  rawSerialiseSignKeyVRF _ = mempty
-  rawSerialiseCertVRF _ = mempty
+instance FixedSizeCodec (VerKeyVRF NeverVRF) where
+  type FixedSize (VerKeyVRF NeverVRF) = 0
+  rawEncodeFixedSized _ = BS.empty
+  rawDecodeFixedSized bs = guardFixedSized bs $ do
+    pure NeverUsedVerKeyVRF
+  {-# INLINE rawDecodeFixedSized #-}
 
-  rawDeserialiseVerKeyVRF _ = Just NeverUsedVerKeyVRF
-  rawDeserialiseSignKeyVRF _ = Just NeverUsedSignKeyVRF
-  rawDeserialiseCertVRF _ = Just NeverUsedCertVRF
+instance FixedSizeCodec (SignKeyVRF NeverVRF) where
+  type FixedSize (SignKeyVRF NeverVRF) = 0
+  rawEncodeFixedSized _ = BS.empty
+  rawDecodeFixedSized bs = guardFixedSized bs $ do
+    pure NeverUsedSignKeyVRF
+  {-# INLINE rawDecodeFixedSized #-}
+
+instance FixedSizeCodec (CertVRF NeverVRF) where
+  type FixedSize (CertVRF NeverVRF) = 0
+  rawEncodeFixedSized _ = BS.empty
+  rawDecodeFixedSized bs = guardFixedSized bs $ do
+    pure NeverUsedCertVRF
+  {-# INLINE rawDecodeFixedSized #-}

--- a/cardano-crypto-class/src/Cardano/Crypto/VRF/Simple.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/VRF/Simple.hs
@@ -126,6 +126,10 @@ instance VRFAlgorithm SimpleVRF where
     deriving anyclass (NoThunks)
     deriving anyclass (NFData)
 
+  type VerKeySizeVRF SimpleVRF = 32
+  type SignKeySizeVRF SimpleVRF = 16
+  type CertSizeVRF SimpleVRF = 64
+
   --
   -- Metadata and basic key operations
   --
@@ -134,10 +138,6 @@ instance VRFAlgorithm SimpleVRF where
 
   deriveVerKeyVRF (SignKeySimpleVRF k) =
     VerKeySimpleVRF $ pow k
-
-  sizeVerKeyVRF _ = 32
-  sizeSignKeyVRF _ = 16
-  sizeCertVRF _ = 64
 
   --
   -- Core algorithm operations

--- a/cardano-crypto-class/src/Cardano/Crypto/VRF/Simple.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/VRF/Simple.hs
@@ -19,6 +19,12 @@ where
 
 import Cardano.Base.Bytes (splitsAt)
 import Cardano.Binary (Encoding, FromCBOR (..), ToCBOR (..))
+import Cardano.Binary.FixedSizeCodec (
+  FixedSizeCodec (..),
+  decodeFixedSized,
+  encodeFixedSized,
+  guardFixedSized,
+ )
 import Cardano.Crypto.Hash
 import Cardano.Crypto.Seed
 import Cardano.Crypto.Util
@@ -27,6 +33,7 @@ import Control.DeepSeq (NFData, force)
 import qualified Crypto.PubKey.ECC.Prim as C
 import qualified Crypto.PubKey.ECC.Types as C
 import Data.Array.Byte (ByteArray)
+import qualified Data.ByteString as BS
 import Data.Proxy (Proxy (..))
 import GHC.Generics (Generic)
 import NoThunks.Class (InspectHeap (..), NoThunks)
@@ -126,10 +133,6 @@ instance VRFAlgorithm SimpleVRF where
     deriving anyclass (NoThunks)
     deriving anyclass (NFData)
 
-  type VerKeySizeVRF SimpleVRF = 32
-  type SignKeySizeVRF SimpleVRF = 16
-  type CertSizeVRF SimpleVRF = 64
-
   --
   -- Metadata and basic key operations
   --
@@ -184,71 +187,67 @@ instance VRFAlgorithm SimpleVRF where
     SignKeySimpleVRF
       (runMonadRandomWithSeed seed (C.scalarGenerate curve))
 
-  --
-  -- raw serialise/deserialise
-  --
+instance ToCBOR (VerKeyVRF SimpleVRF) where
+  toCBOR = encodeFixedSized
+  encodedSizeExpr _size = encodedVerKeyVRFSizeExpr
 
-  -- All the integers here are 15 or 16 bytes big, we round up to 16.
+instance FromCBOR (VerKeyVRF SimpleVRF) where
+  fromCBOR = decodeFixedSized
 
-  rawSerialiseVerKeyVRF (VerKeySimpleVRF (Point C.PointO)) =
-    error "rawSerialiseVerKeyVRF: Point at infinity"
-  rawSerialiseVerKeyVRF (VerKeySimpleVRF (Point (C.Point p1 p2))) =
+instance ToCBOR (SignKeyVRF SimpleVRF) where
+  toCBOR = encodeFixedSized
+  encodedSizeExpr _size = encodedSignKeyVRFSizeExpr
+
+instance FromCBOR (SignKeyVRF SimpleVRF) where
+  fromCBOR = decodeFixedSized
+
+instance ToCBOR (CertVRF SimpleVRF) where
+  toCBOR = encodeFixedSized
+  encodedSizeExpr _size = encodedCertVRFSizeExpr
+
+instance FromCBOR (CertVRF SimpleVRF) where
+  fromCBOR = decodeFixedSized
+
+-- All the integers here are 15 or 16 bytes big, we round up to 16.
+
+instance FixedSizeCodec (VerKeyVRF SimpleVRF) where
+  type FixedSize (VerKeyVRF SimpleVRF) = 32
+  rawEncodeFixedSized (VerKeySimpleVRF (Point C.PointO)) =
+    error "rawEncodeFixedSized: Point at infinity"
+  rawEncodeFixedSized (VerKeySimpleVRF (Point (C.Point p1 p2))) =
     writeBinaryNatural 16 (fromInteger p1)
       <> writeBinaryNatural 16 (fromInteger p2)
+  rawDecodeFixedSized bs = guardFixedSized bs $ do
+    let p1 = toInteger (readBinaryNatural (BS.take 16 bs))
+        p2 = toInteger (readBinaryNatural (BS.drop 16 bs))
+    pure $! VerKeySimpleVRF (Point (C.Point p1 p2))
+  {-# INLINE rawDecodeFixedSized #-}
 
-  rawSerialiseSignKeyVRF (SignKeySimpleVRF sk) =
+instance FixedSizeCodec (SignKeyVRF SimpleVRF) where
+  type FixedSize (SignKeyVRF SimpleVRF) = 16
+  rawEncodeFixedSized (SignKeySimpleVRF sk) =
     writeBinaryNatural 16 (fromInteger sk)
+  rawDecodeFixedSized bs = guardFixedSized bs $ do
+    let sk = toInteger (readBinaryNatural bs)
+    pure $! SignKeySimpleVRF sk
+  {-# INLINE rawDecodeFixedSized #-}
 
-  rawSerialiseCertVRF (CertSimpleVRF (Point C.PointO) _ _) =
-    error "rawSerialiseCertVRF: Point at infinity"
-  rawSerialiseCertVRF (CertSimpleVRF (Point (C.Point p1 p2)) c s) =
+instance FixedSizeCodec (CertVRF SimpleVRF) where
+  type FixedSize (CertVRF SimpleVRF) = 64
+  rawEncodeFixedSized (CertSimpleVRF (Point C.PointO) _ _) =
+    error "rawEncodeFixedSized: Point at infinity"
+  rawEncodeFixedSized (CertSimpleVRF (Point (C.Point p1 p2)) c s) =
     writeBinaryNatural 16 (fromInteger p1)
       <> writeBinaryNatural 16 (fromInteger p2)
       <> writeBinaryNatural 16 c
       <> writeBinaryNatural 16 (fromInteger s)
-
-  rawDeserialiseVerKeyVRF bs
-    | [p1b, p2b] <- splitsAt [16, 16] bs
-    , let p1 = toInteger (readBinaryNatural p1b)
-          p2 = toInteger (readBinaryNatural p2b) =
-        Just $! VerKeySimpleVRF (Point (C.Point p1 p2))
-    | otherwise =
-        Nothing
-
-  rawDeserialiseSignKeyVRF bs
-    | [skb] <- splitsAt [16] bs
-    , let sk = toInteger (readBinaryNatural skb) =
-        Just $! SignKeySimpleVRF sk
-    | otherwise =
-        Nothing
-
-  rawDeserialiseCertVRF bs
-    | [p1b, p2b, cb, sb] <- splitsAt [16, 16, 16, 16] bs
-    , let p1 = toInteger (readBinaryNatural p1b)
-          p2 = toInteger (readBinaryNatural p2b)
-          c = readBinaryNatural cb
-          s = toInteger (readBinaryNatural sb) =
-        Just $! CertSimpleVRF (Point (C.Point p1 p2)) c s
-    | otherwise =
-        Nothing
-
-instance ToCBOR (VerKeyVRF SimpleVRF) where
-  toCBOR = encodeVerKeyVRF
-  encodedSizeExpr _size = encodedVerKeyVRFSizeExpr
-
-instance FromCBOR (VerKeyVRF SimpleVRF) where
-  fromCBOR = decodeVerKeyVRF
-
-instance ToCBOR (SignKeyVRF SimpleVRF) where
-  toCBOR = encodeSignKeyVRF
-  encodedSizeExpr _size = encodedSignKeyVRFSizeExpr
-
-instance FromCBOR (SignKeyVRF SimpleVRF) where
-  fromCBOR = decodeSignKeyVRF
-
-instance ToCBOR (CertVRF SimpleVRF) where
-  toCBOR = encodeCertVRF
-  encodedSizeExpr _size = encodedCertVRFSizeExpr
-
-instance FromCBOR (CertVRF SimpleVRF) where
-  fromCBOR = decodeCertVRF
+  rawDecodeFixedSized bs = do
+    case splitsAt [16, 16, 16, 16] bs of
+      [p1b, p2b, cb, sb] -> do
+        let p1 = toInteger (readBinaryNatural p1b)
+            p2 = toInteger (readBinaryNatural p2b)
+            c = readBinaryNatural cb
+            s = toInteger (readBinaryNatural sb)
+        pure $! CertSimpleVRF (Point (C.Point p1 p2)) c s
+      _ -> fail "CertVRF SimpleVRF: invalid size"
+  {-# INLINE rawDecodeFixedSized #-}

--- a/cardano-crypto-class/testlib/Test/Crypto/DSIGN.hs
+++ b/cardano-crypto-class/testlib/Test/Crypto/DSIGN.hs
@@ -54,9 +54,6 @@ import Cardano.Crypto.DSIGN (
   Ed25519DSIGN,
   Ed448DSIGN,
   aggregateVerKeysDSIGN,
-  verKeySizeDSIGN,
-  signKeySizeDSIGN,
-  sigSizeDSIGN,
   seedSizeDSIGN,
 
   DSIGNMAlgorithm (..),
@@ -72,7 +69,6 @@ import Cardano.Crypto.DSIGN (
 
   DSIGNAggregatable (..),
   BLS12381SignContext,
-  possessionProofSizeDSIGN
   )
 import Cardano.Crypto.DSIGN.BLS12381.Internal (BLS12381SignContext (..))
 import Cardano.Binary (FromCBOR, ToCBOR)
@@ -87,8 +83,8 @@ import Test.Crypto.Util (
   shrinkBadInputFor,
   Message,
   prop_keygen_context_changes_verkey,
-  prop_raw_serialise,
-  prop_raw_deserialise,
+  prop_raw_serialise_fixed_sized,
+  prop_size_serialise_fixed_sized,
   prop_bad_cbor_bytes,
   prop_cbor_fixed_sized,
   prop_cbor,
@@ -101,7 +97,9 @@ import Test.Crypto.Util (
   withLock,
   directSerialiseToBS,
   directDeserialiseFromBS,
-  hexBS, prop_size_serialise_fixed_sized,
+  hexBS, 
+  prop_size_serialise_fixed_sized,
+  prop_raw_deserialise_fixed_sized,
   )
 import Cardano.Crypto.Libsodium.MLockedSeed
 
@@ -124,7 +122,7 @@ import Cardano.Crypto.Hash (SHA3_256, HashAlgorithm (HashSize), Blake2b_256, SHA
 import Cardano.Crypto.DSIGN.Class (DSIGNAlgorithm(..))
 import Cardano.Crypto.DSIGN.BLS12381 (BLS12381MinSigDSIGN)
 import Cardano.Crypto.DSIGN.BLS12381 (BLS12381MinVerKeyDSIGN)
-import Cardano.Binary.FixedSizeCodec (FixedSizeCodec(..))
+import Cardano.Binary.FixedSizeCodec (FixedSizeCodec(..), fixedSize)
 #endif
 
 blsGenKeyWithContextGen :: Gen (Maybe BS.ByteString)
@@ -225,22 +223,22 @@ tests lock =
             genC1  = blsCompress (blsGenerator @Curve1)
             genC2  = blsCompress (blsGenerator @Curve2)
         it "BLS12381MinVerKeyDSIGN: mu1 zero, mu2 zero" $
-          rawDeserialisePossessionProofDSIGN @(BLS12381DSIGN Curve1) (zeroC2 <> zeroC2)
+          rawDecodeFixedSized @(PossessionProofDSIGN (BLS12381DSIGN Curve1)) (zeroC2 <> zeroC2)
             `shouldBe` Nothing
         it "BLS12381MinVerKeyDSIGN: mu1 zero, mu2 non-zero" $
-          rawDeserialisePossessionProofDSIGN @(BLS12381DSIGN Curve1) (zeroC2 <> genC2)
+          rawDecodeFixedSized @(PossessionProofDSIGN (BLS12381DSIGN Curve1)) (zeroC2 <> genC2)
             `shouldBe` Nothing
         it "BLS12381MinVerKeyDSIGN: mu1 non-zero, mu2 zero" $
-          rawDeserialisePossessionProofDSIGN @(BLS12381DSIGN Curve1) (genC2 <> zeroC2)
+          rawDecodeFixedSized @(PossessionProofDSIGN (BLS12381DSIGN Curve1)) (genC2 <> zeroC2)
             `shouldBe` Nothing
         it "BLS12381MinSigDSIGN: mu1 zero, mu2 zero" $
-          rawDeserialisePossessionProofDSIGN @(BLS12381DSIGN Curve2) (zeroC1 <> zeroC1)
+          rawDecodeFixedSized @(PossessionProofDSIGN (BLS12381DSIGN Curve2)) (zeroC1 <> zeroC1)
             `shouldBe` Nothing
         it "BLS12381MinSigDSIGN: mu1 zero, mu2 non-zero" $
-          rawDeserialisePossessionProofDSIGN @(BLS12381DSIGN Curve2) (zeroC1 <> genC1)
+          rawDecodeFixedSized @(PossessionProofDSIGN (BLS12381DSIGN Curve2)) (zeroC1 <> genC1)
             `shouldBe` Nothing
         it "BLS12381MinSigDSIGN: mu1 non-zero, mu2 zero" $
-          rawDeserialisePossessionProofDSIGN @(BLS12381DSIGN Curve2) (genC1 <> zeroC1)
+          rawDecodeFixedSized @(PossessionProofDSIGN (BLS12381DSIGN Curve2)) (genC1 <> zeroC1)
             `shouldBe` Nothing
       describe "VerKey and SignKey deserialisation rejects zero" $ do
         let zeroC1 = blsCompress (blsZero @Curve1)
@@ -248,16 +246,16 @@ tests lock =
             -- Scalar size is 32 bytes for both curve variants
             zeroScalar = BS.replicate 32 0
         it "BLS12381MinVerKeyDSIGN: zero verification key rejected" $
-          rawDeserialiseVerKeyDSIGN @(BLS12381DSIGN Curve1) zeroC1
+          rawDecodeFixedSized @(VerKeyDSIGN (BLS12381DSIGN Curve1)) zeroC1
             `shouldBe` Nothing
         it "BLS12381MinSigDSIGN: zero verification key rejected" $
-          rawDeserialiseVerKeyDSIGN @(BLS12381DSIGN Curve2) zeroC2
+          rawDecodeFixedSized @(VerKeyDSIGN (BLS12381DSIGN Curve2)) zeroC2
             `shouldBe` Nothing
         it "BLS12381MinVerKeyDSIGN: zero signing key rejected" $
-          rawDeserialiseSignKeyDSIGN @(BLS12381DSIGN Curve1) zeroScalar
+          rawDecodeFixedSized @(SignKeyDSIGN (BLS12381DSIGN Curve1)) zeroScalar
             `shouldBe` Nothing
         it "BLS12381MinSigDSIGN: zero signing key rejected" $
-          rawDeserialiseSignKeyDSIGN @(BLS12381DSIGN Curve2) zeroScalar
+          rawDecodeFixedSized @(SignKeyDSIGN (BLS12381DSIGN Curve2)) zeroScalar
             `shouldBe` Nothing
 
 testDSIGNAlgorithmWithContext :: forall (v :: Type) (a :: Type).
@@ -295,20 +293,20 @@ testDSIGNAlgorithmWithContext proxy ctxMatters genContext genKeyCtx genMsg name 
       prop "VerKey serialization" .
         forAllShow genVerKey
                    ppShow $
-                   prop_raw_serialise rawSerialiseVerKeyDSIGN rawDeserialiseVerKeyDSIGN
-      prop "VerKey deserialization (wrong length)" $ prop_raw_deserialise (rawDeserialiseVerKeyDSIGN @v)
+                   prop_raw_serialise_fixed_sized
+      prop "VerKey deserialization (wrong length)" $ prop_raw_deserialise_fixed_sized @(VerKeyDSIGN v)
       prop "VerKey fail fromCBOR" $ prop_bad_cbor_bytes @(VerKeyDSIGN v)
       prop "SignKey serialization" .
         forAllShow (defaultSignKeyWithContextGen @v genKeyCtx)
                    ppShow $
-                   prop_raw_serialise rawSerialiseSignKeyDSIGN rawDeserialiseSignKeyDSIGN
-      prop "SignKey deserialization (wrong length)" $ prop_raw_deserialise (rawDeserialiseSignKeyDSIGN @v)
+                   prop_raw_serialise_fixed_sized
+      prop "SignKey deserialization (wrong length)" $ prop_raw_deserialise_fixed_sized @(SignKeyDSIGN v)
       prop "SignKey fail fromCBOR" $ prop_bad_cbor_bytes @(SignKeyDSIGN v)
       prop "Sig serialization" .
         forAllShow genSig
                    ppShow $
-                   prop_raw_serialise rawSerialiseSigDSIGN rawDeserialiseSigDSIGN
-      prop "Sig deserialization (wrong length)" $ prop_raw_deserialise (rawDeserialiseSigDSIGN @v)
+                   prop_raw_serialise_fixed_sized
+      prop "Sig deserialization (wrong length)" $ prop_raw_deserialise_fixed_sized @(SigDSIGN v)
       prop "VerKey fail fromCBOR" $ prop_bad_cbor_bytes @(SigDSIGN v)
     describe "size" $ do
       prop "VerKey" .
@@ -369,9 +367,9 @@ testDSIGNAlgorithmWithContext proxy ctxMatters genContext genKeyCtx genMsg name 
       prop "SignKey" . forAllShow (defaultSignKeyWithContextGen @v genKeyCtx) ppShow $ prop_no_thunks
       prop "Sig" . forAllShow genSig ppShow $ prop_no_thunks
       prop "VerKey rawSerialise" . forAllShow genVerKey ppShow $ \vk ->
-        prop_no_thunks (rawSerialiseVerKeyDSIGN vk)
+        prop_no_thunks (rawEncodeFixedSized vk)
       prop "VerKey rawDeserialise" . forAllShow genVerKey ppShow $ \vk ->
-        prop_no_thunks (fromJust $! rawDeserialiseVerKeyDSIGN @v . rawSerialiseVerKeyDSIGN $ vk)
+        prop_no_thunks (fromJust $! rawDecodeFixedSized @(VerKeyDSIGN v) . rawEncodeFixedSized $ vk)
   where
     genWrongKey :: Gen (ContextDSIGN v, a, SignKeyDSIGN v, SignKeyDSIGN v)
     genWrongKey = do
@@ -452,7 +450,7 @@ testDSIGNMAlgorithm lock _ n =
          prop "VerKey" $
             ioPropertyWithSK @v lock $ \sk -> do
               vk <- deriveVerKeyDSIGNM sk
-              return $ (rawDeserialiseVerKeyDSIGN . rawSerialiseVerKeyDSIGN $ vk) === Just vk
+              return $ (rawDecodeFixedSized . rawEncodeFixedSized $ vk) === Just vk
          prop "SignKey" $
             ioPropertyWithSK @v lock $ \sk -> do
               serialized <- rawSerialiseSignKeyDSIGNM sk
@@ -463,20 +461,20 @@ testDSIGNMAlgorithm lock _ n =
          prop "Sig" $ \(msg :: Message) ->
             ioPropertyWithSK @v lock $ \sk -> do
               sig <- signDSIGNM () msg sk
-              return $ (rawDeserialiseSigDSIGN . rawSerialiseSigDSIGN $ sig) === Just sig
+              return $ (rawDecodeFixedSized . rawEncodeFixedSized $ sig) === Just sig
        describe "size" $ do
          prop "VerKey" $
             ioPropertyWithSK @v lock $ \sk -> do
               vk <- deriveVerKeyDSIGNM sk
-              return $ (fromIntegral @Int @Word . BS.length . rawSerialiseVerKeyDSIGN $ vk) === verKeySizeDSIGN (Proxy @v)
+              return $ (fromIntegral @Int @Word . BS.length . rawEncodeFixedSized $ vk) === fixedSize (Proxy @(VerKeyDSIGN v))
          prop "SignKey" $
             ioPropertyWithSK @v lock $ \sk -> do
               serialized <- rawSerialiseSignKeyDSIGNM sk
-              evaluate ((fromIntegral @Int @Word . BS.length $ serialized) == signKeySizeDSIGN (Proxy @v))
+              evaluate ((fromIntegral @Int @Word . BS.length $ serialized) == fixedSize (Proxy @(SignKeyDSIGN v)))
          prop "Sig" $ \(msg :: Message) ->
             ioPropertyWithSK @v lock $ \sk -> do
               sig :: SigDSIGN v <- signDSIGNM () msg sk
-              return $ (fromIntegral @Int @Word . BS.length . rawSerialiseSigDSIGN $ sig) === sigSizeDSIGN (Proxy @v)
+              return $ (fromIntegral @Int @Word . BS.length . rawEncodeFixedSized $ sig) === fixedSize (Proxy @(SigDSIGN v))
 
        describe "direct CBOR" $ do
          prop "VerKey" $
@@ -527,12 +525,12 @@ testDSIGNMAlgorithm lock _ n =
          prop "VerKey" $
             ioPropertyWithSK @v lock $ \sk -> do
               vk :: VerKeyDSIGN v <- deriveVerKeyDSIGNM sk
-              serialized <- directSerialiseToBS (fromIntegral @Word @Int $ verKeySizeDSIGN (Proxy @v)) vk
+              serialized <- directSerialiseToBS (fromIntegral @Word @Int $ fixedSize (Proxy @(VerKeyDSIGN v))) vk
               vk' <- directDeserialiseFromBS serialized
               return $ vk === vk'
          prop "SignKey" $
             ioPropertyWithSK @v lock $ \sk -> do
-              serialized <- directSerialiseToBS (fromIntegral @Word @Int $ signKeySizeDSIGN (Proxy @v)) sk
+              serialized <- directSerialiseToBS (fromIntegral @Word @Int $ fixedSize (Proxy @(SignKeyDSIGN v))) sk
               sk' <- directDeserialiseFromBS serialized
               equals <- sk ==! sk'
               forgetSignKeyDSIGNM sk'
@@ -542,12 +540,12 @@ testDSIGNMAlgorithm lock _ n =
          prop "VerKey" $
             ioPropertyWithSK @v lock $ \sk -> do
               vk :: VerKeyDSIGN v <- deriveVerKeyDSIGNM sk
-              direct <- directSerialiseToBS (fromIntegral @Word @Int $ verKeySizeDSIGN (Proxy @v)) vk
-              let raw = rawSerialiseVerKeyDSIGN vk
+              direct <- directSerialiseToBS (fromIntegral @Word @Int $ fixedSize (Proxy @(VerKeyDSIGN v))) vk
+              let raw = rawEncodeFixedSized vk
               return $ direct === raw
          prop "SignKey" $
             ioPropertyWithSK @v lock $ \sk -> do
-              direct <- directSerialiseToBS (fromIntegral @Word @Int $ signKeySizeDSIGN (Proxy @v)) sk
+              direct <- directSerialiseToBS (fromIntegral @Word @Int $ fixedSize (Proxy @(SignKeyDSIGN v))) sk
               raw <- rawSerialiseSignKeyDSIGNM sk
               return $ direct === raw
 
@@ -574,21 +572,21 @@ testDSIGNMAlgorithm lock _ n =
           ioPropertyWithSK @v lock $ prop_no_thunks_IO . signDSIGNM () msg
        prop "SignKey DirectSerialise" $
           ioPropertyWithSK @v lock $ \sk -> do
-            direct <- directSerialiseToBS (fromIntegral @Word @Int $ signKeySizeDSIGN (Proxy @v)) sk
+            direct <- directSerialiseToBS (fromIntegral @Word @Int $ fixedSize (Proxy @(SignKeyDSIGN v))) sk
             prop_no_thunks_IO (return $! direct)
        prop "SignKey DirectDeserialise" $
           ioPropertyWithSK @v lock $ \sk -> do
-            direct <- directSerialiseToBS (fromIntegral @Word @Int $ signKeySizeDSIGN (Proxy @v)) sk
+            direct <- directSerialiseToBS (fromIntegral @Word @Int $ fixedSize (Proxy @(SignKeyDSIGN v))) sk
             prop_no_thunks_IO (directDeserialiseFromBS @IO @(SignKeyDSIGNM v) $! direct)
        prop "VerKey DirectSerialise" $
           ioPropertyWithSK @v lock $ \sk -> do
             vk <- deriveVerKeyDSIGNM sk
-            direct <- directSerialiseToBS (fromIntegral @Word @Int $ verKeySizeDSIGN (Proxy @v)) vk
+            direct <- directSerialiseToBS (fromIntegral @Word @Int $ fixedSize (Proxy @(VerKeyDSIGN v))) vk
             prop_no_thunks_IO (return $! direct)
        prop "VerKey DirectDeserialise" $
           ioPropertyWithSK @v lock $ \sk -> do
             vk <- deriveVerKeyDSIGNM sk
-            direct <- directSerialiseToBS (fromIntegral @Word @Int $ verKeySizeDSIGN (Proxy @v)) vk
+            direct <- directSerialiseToBS (fromIntegral @Word @Int $ fixedSize (Proxy @(VerKeyDSIGN v))) vk
             prop_no_thunks_IO (directDeserialiseFromBS @IO @(VerKeyDSIGN v) $! direct)
 
 -- | Wrap an IO action that requires a 'SignKeyDSIGNM' into one that takes an
@@ -739,7 +737,7 @@ instance Arbitrary (BadInputFor MessageHash) where
 testEcdsaInvalidMessageHash :: String -> Spec
 testEcdsaInvalidMessageHash name = testEnough . describe name $ do
     prop "MessageHash deserialization (wrong length)" $
-      prop_raw_deserialise $ rawDecodeFixedSized @MessageHash
+      prop_raw_deserialise_fixed_sized @MessageHash
     prop "MessageHash fail fromCBOR" $ prop_bad_cbor_bytes @MessageHash
 
 testEcdsaWithHashAlgorithm ::
@@ -779,7 +777,7 @@ prop_dsignm_verify_neg_msg lock _ a a' =
 
 instance DSIGNAggregatable v => Arbitrary (BadInputFor (PossessionProofDSIGN v)) where
   arbitrary =
-    genBadInputFor (fromIntegral @Word @Int $ possessionProofSizeDSIGN (Proxy @v))
+    genBadInputFor (fromIntegral @Word @Int $ fixedSize (Proxy @(PossessionProofDSIGN v)))
   shrink = shrinkBadInputFor
 
 testDSIGNAggregatableWithContext
@@ -800,8 +798,8 @@ testDSIGNAggregatableWithContext _ genContext genKeyCtx genMsg name = testEnough
   describe "serialization" $ do
     describe "raw" $ do
       prop "PoP serialization" .
-        forAllPoP $ prop_raw_serialise rawSerialisePossessionProofDSIGN rawDeserialisePossessionProofDSIGN
-      prop "PoP deserialization (wrong length)" $ prop_raw_deserialise (rawDeserialisePossessionProofDSIGN @v)
+        forAllPoP $ prop_raw_serialise_fixed_sized
+      prop "PoP deserialization (wrong length)" $ prop_raw_deserialise_fixed_sized @(PossessionProofDSIGN v)
       prop "PoP fail fromCBOR" $ prop_bad_cbor_bytes @(PossessionProofDSIGN v)
     describe "size" $ do
       prop "PoP" $ forAllPoP prop_size_serialise_fixed_sized
@@ -843,9 +841,9 @@ testDSIGNAggregatableWithContext _ genContext genKeyCtx genMsg name = testEnough
     describe "NoThunks" $ do
       prop "PoP" . forAllPoP $ prop_no_thunks
       prop "PoP rawSerialise" . forAllPoP $ \pop ->
-        prop_no_thunks (rawSerialisePossessionProofDSIGN pop)
+        prop_no_thunks (rawEncodeFixedSized pop)
       prop "PoP rawDeserialise" . forAllPoP $ \pop ->
-        prop_no_thunks (fromJust $! rawDeserialisePossessionProofDSIGN @v . rawSerialisePossessionProofDSIGN $ pop)
+        prop_no_thunks (fromJust $! rawDecodeFixedSized @(PossessionProofDSIGN v) . rawEncodeFixedSized $ pop)
   where
     forAllPoP
       :: Testable prop

--- a/cardano-crypto-class/testlib/Test/Crypto/DSIGN.hs
+++ b/cardano-crypto-class/testlib/Test/Crypto/DSIGN.hs
@@ -97,7 +97,7 @@ import Test.Crypto.Util (
   withLock,
   directSerialiseToBS,
   directDeserialiseFromBS,
-  hexBS, 
+  hexBS,
   prop_size_serialise_fixed_sized,
   prop_raw_deserialise_fixed_sized,
   )

--- a/cardano-crypto-class/testlib/Test/Crypto/DSIGN.hs
+++ b/cardano-crypto-class/testlib/Test/Crypto/DSIGN.hs
@@ -57,12 +57,6 @@ import Cardano.Crypto.DSIGN (
   verKeySizeDSIGN,
   signKeySizeDSIGN,
   sigSizeDSIGN,
-  encodeVerKeyDSIGN,
-  decodeVerKeyDSIGN,
-  encodeSignKeyDSIGN,
-  decodeSignKeyDSIGN,
-  encodeSigDSIGN,
-  decodeSigDSIGN,
   seedSizeDSIGN,
 
   DSIGNMAlgorithm (..),
@@ -78,9 +72,7 @@ import Cardano.Crypto.DSIGN (
 
   DSIGNAggregatable (..),
   BLS12381SignContext,
-  possessionProofSizeDSIGN,
-  encodePossessionProofDSIGN,
-  decodePossessionProofDSIGN
+  possessionProofSizeDSIGN
   )
 import Cardano.Crypto.DSIGN.BLS12381.Internal (BLS12381SignContext (..))
 import Cardano.Binary (FromCBOR, ToCBOR)
@@ -97,12 +89,11 @@ import Test.Crypto.Util (
   prop_keygen_context_changes_verkey,
   prop_raw_serialise,
   prop_raw_deserialise,
-  prop_size_serialise,
   prop_bad_cbor_bytes,
-  prop_cbor_with,
+  prop_cbor_fixed_sized,
   prop_cbor,
   prop_cbor_size,
-  prop_cbor_direct_vs_class,
+  prop_cbor_fixed_sized_vs_class,
   prop_no_thunks,
   prop_no_thunks_IO,
   arbitrarySeedOfSize,
@@ -110,7 +101,7 @@ import Test.Crypto.Util (
   withLock,
   directSerialiseToBS,
   directDeserialiseFromBS,
-  hexBS,
+  hexBS, prop_size_serialise_fixed_sized,
   )
 import Cardano.Crypto.Libsodium.MLockedSeed
 
@@ -122,7 +113,6 @@ import Cardano.Crypto.DSIGN (
   EcdsaSecp256k1DSIGN,
   SchnorrSecp256k1DSIGN,
   MessageHash,
-  toMessageHash,
   hashAndPack,
   )
 import Test.Crypto.Util (
@@ -134,6 +124,7 @@ import Cardano.Crypto.Hash (SHA3_256, HashAlgorithm (HashSize), Blake2b_256, SHA
 import Cardano.Crypto.DSIGN.Class (DSIGNAlgorithm(..))
 import Cardano.Crypto.DSIGN.BLS12381 (BLS12381MinSigDSIGN)
 import Cardano.Crypto.DSIGN.BLS12381 (BLS12381MinVerKeyDSIGN)
+import Cardano.Binary.FixedSizeCodec (FixedSizeCodec(..))
 #endif
 
 blsGenKeyWithContextGen :: Gen (Maybe BS.ByteString)
@@ -158,7 +149,7 @@ blsSignContextGen = do
 genEcdsaMsg :: Gen MessageHash
 genEcdsaMsg =
   Gen.suchThatMap (GHC.fromListN 32 <$> replicateM 32 arbitrary)
-                  toMessageHash
+                  rawDecodeFixedSized
 #endif
 
 defaultSignKeyWithContextGen
@@ -323,28 +314,28 @@ testDSIGNAlgorithmWithContext proxy ctxMatters genContext genKeyCtx genMsg name 
       prop "VerKey" .
         forAllShow genVerKey
                    ppShow $
-                   prop_size_serialise rawSerialiseVerKeyDSIGN (verKeySizeDSIGN (Proxy @v))
+                   prop_size_serialise_fixed_sized @(VerKeyDSIGN v)
       prop "SignKey" .
         forAllShow (defaultSignKeyWithContextGen @v genKeyCtx)
                    ppShow $
-                   prop_size_serialise rawSerialiseSignKeyDSIGN (signKeySizeDSIGN (Proxy @v))
+                   prop_size_serialise_fixed_sized  @(SignKeyDSIGN v)
       prop "Sig" .
         forAllShow genSig
                    ppShow $
-                   prop_size_serialise rawSerialiseSigDSIGN (sigSizeDSIGN (Proxy @v))
+                   prop_size_serialise_fixed_sized @(SigDSIGN v)
     describe "direct CBOR" $ do
       prop "VerKey" .
         forAllShow genVerKey
                    ppShow $
-                   prop_cbor_with encodeVerKeyDSIGN decodeVerKeyDSIGN
+                   prop_cbor_fixed_sized
       prop "SignKey" .
         forAllShow (defaultSignKeyWithContextGen @v genKeyCtx)
                    ppShow $
-                   prop_cbor_with encodeSignKeyDSIGN decodeSignKeyDSIGN
+                   prop_cbor_fixed_sized
       prop "Sig" .
         forAllShow genSig
                    ppShow $
-                   prop_cbor_with encodeSigDSIGN decodeSigDSIGN
+                   prop_cbor_fixed_sized
     describe "To/FromCBOR class" $ do
       prop "VerKey" . forAllShow genVerKey ppShow $ prop_cbor
       prop "SignKey" . forAllShow (defaultSignKeyWithContextGen @v genKeyCtx) ppShow $ prop_cbor
@@ -356,13 +347,13 @@ testDSIGNAlgorithmWithContext proxy ctxMatters genContext genKeyCtx genMsg name 
     describe "direct matches class" $ do
       prop "VerKey" .
         forAllShow genVerKey ppShow $
-        prop_cbor_direct_vs_class encodeVerKeyDSIGN
+        prop_cbor_fixed_sized_vs_class
       prop "SignKey" .
         forAllShow (defaultSignKeyWithContextGen @v genKeyCtx) ppShow $
-        prop_cbor_direct_vs_class encodeSignKeyDSIGN
+        prop_cbor_fixed_sized_vs_class
       prop "Sig" .
         forAllShow genSig ppShow $
-        prop_cbor_direct_vs_class encodeSigDSIGN
+        prop_cbor_fixed_sized_vs_class
     describe "verify" $ do
       prop "signing and verifying with matching keys" .
         forAllShow ((,,) <$> genContext <*> genMsg <*> defaultSignKeyWithContextGen @v genKeyCtx) ppShow $
@@ -491,13 +482,13 @@ testDSIGNMAlgorithm lock _ n =
          prop "VerKey" $
             ioPropertyWithSK @v lock $ \sk -> do
               vk :: VerKeyDSIGN v <- deriveVerKeyDSIGNM sk
-              return $ prop_cbor_with encodeVerKeyDSIGN decodeVerKeyDSIGN vk
+              return $ prop_cbor_fixed_sized vk
         -- No CBOR testing for SignKey: sign keys are stored in MLocked memory
         -- and require IO for access.
          prop "Sig" $ \(msg :: Message) -> do
             ioPropertyWithSK @v lock $ \sk -> do
               sig :: SigDSIGN v <- signDSIGNM () msg sk
-              return $ prop_cbor_with encodeSigDSIGN decodeSigDSIGN sig
+              return $ prop_cbor_fixed_sized sig
 
        describe "To/FromCBOR class" $ do
          prop "VerKey"  $
@@ -525,13 +516,13 @@ testDSIGNMAlgorithm lock _ n =
          prop "VerKey" $
             ioPropertyWithSK @v lock $ \sk -> do
               vk :: VerKeyDSIGN v <- deriveVerKeyDSIGNM sk
-              return $ prop_cbor_direct_vs_class encodeVerKeyDSIGN vk
+              return $ prop_cbor_fixed_sized_vs_class vk
         -- No CBOR testing for SignKey: sign keys are stored in MLocked memory
         -- and require IO for access.
          prop "Sig" $ \(msg :: Message) ->
             ioPropertyWithSK @v lock $ \sk -> do
               sig :: SigDSIGN v <- signDSIGNM () msg sk
-              return $ prop_cbor_direct_vs_class encodeSigDSIGN sig
+              return $ prop_cbor_fixed_sized_vs_class sig
        describe "DirectSerialise" $ do
          prop "VerKey" $
             ioPropertyWithSK @v lock $ \sk -> do
@@ -748,7 +739,7 @@ instance Arbitrary (BadInputFor MessageHash) where
 testEcdsaInvalidMessageHash :: String -> Spec
 testEcdsaInvalidMessageHash name = testEnough . describe name $ do
     prop "MessageHash deserialization (wrong length)" $
-      prop_raw_deserialise toMessageHash
+      prop_raw_deserialise $ rawDecodeFixedSized @MessageHash
     prop "MessageHash fail fromCBOR" $ prop_bad_cbor_bytes @MessageHash
 
 testEcdsaWithHashAlgorithm ::
@@ -813,18 +804,15 @@ testDSIGNAggregatableWithContext _ genContext genKeyCtx genMsg name = testEnough
       prop "PoP deserialization (wrong length)" $ prop_raw_deserialise (rawDeserialisePossessionProofDSIGN @v)
       prop "PoP fail fromCBOR" $ prop_bad_cbor_bytes @(PossessionProofDSIGN v)
     describe "size" $ do
-      prop "PoP" .
-        forAllPoP $ prop_size_serialise rawSerialisePossessionProofDSIGN (possessionProofSizeDSIGN (Proxy @v))
+      prop "PoP" $ forAllPoP prop_size_serialise_fixed_sized
     describe "direct CBOR" $ do
-      prop "PoP" .
-        forAllPoP $ prop_cbor_with encodePossessionProofDSIGN decodePossessionProofDSIGN
+      prop "PoP" $ forAllPoP prop_cbor_fixed_sized
     describe "To/FromCBOR class" $ do
-      prop "PoP" . forAllPoP $ prop_cbor
+      prop "PoP" $ forAllPoP prop_cbor
     describe "ToCBOR size" $ do
-      prop "PoP" . forAllPoP $ prop_cbor_size
+      prop "PoP" $ forAllPoP prop_cbor_size
     describe "direct matches class" $ do
-      prop "PoP" .
-        forAllPoP $ prop_cbor_direct_vs_class encodePossessionProofDSIGN
+      prop "PoP" $ forAllPoP prop_cbor_fixed_sized_vs_class
   describe "aggregate" $ do
     prop "aggregate verify positive" $
       withNumTests 1000 .

--- a/cardano-crypto-class/testlib/Test/Crypto/Instances.hs
+++ b/cardano-crypto-class/testlib/Test/Crypto/Instances.hs
@@ -66,9 +66,12 @@ instance KnownNat n => Arbitrary (PinnedSizedBytes n) where
     let size = fromIntegral @Integer @Int . natVal $ Proxy @n
     Gen.suchThatMap
       (fromListN size <$> Gen.vectorOf size arbitrary)
-      psbFromByteStringCheck
+      (psbFromByteStringForM $ Proxy @(PinnedSizedBytes n))
   shrink psb = case toList . psbToByteString $ psb of
-    bytes -> mapMaybe (psbFromByteStringCheck . fromList) . shrink $ bytes
+    bytes ->
+      mapMaybe
+        (psbFromByteStringForM (Proxy @(PinnedSizedBytes n)) . fromList . shrink)
+        bytes
 
 instance VRFAlgorithm v => Arbitrary (OutputVRF v) where
   arbitrary = do

--- a/cardano-crypto-class/testlib/Test/Crypto/Instances.hs
+++ b/cardano-crypto-class/testlib/Test/Crypto/Instances.hs
@@ -8,6 +8,7 @@ module Test.Crypto.Instances (
   withMLockedSeedFromPSB,
 ) where
 
+import Cardano.Binary.FixedSizeCodec (FixedSizeCodec (..), fixedSize)
 import Cardano.Crypto.DSIGN.Class hiding (Signable)
 import Cardano.Crypto.Libsodium
 import Cardano.Crypto.Libsodium.MLockedSeed
@@ -115,15 +116,15 @@ errorInvalidSize n = maybe (error $ "Impossible: Invalid size " ++ show n) pure
 
 instance DSIGNAlgorithm v => Arbitrary (SignKeyDSIGN v) where
   arbitrary = do
-    let n = fromIntegral (signKeySizeDSIGN (Proxy @v))
+    let n = fromIntegral (fixedSize (Proxy @(SignKeyDSIGN v)))
     bs <- genByteString n
-    errorInvalidSize n $ rawDeserialiseSignKeyDSIGN bs
+    errorInvalidSize n $ rawDecodeFixedSized bs
 
 instance DSIGNAlgorithm v => Arbitrary (SigDSIGN v) where
   arbitrary = do
-    let n = fromIntegral (sigSizeDSIGN (Proxy @v))
+    let n = fromIntegral (fixedSize (Proxy @(SigDSIGN v)))
     bs <- genByteString n
-    errorInvalidSize n $ rawDeserialiseSigDSIGN bs
+    errorInvalidSize n $ rawDecodeFixedSized bs
 
 instance DSIGNAlgorithm v => Arbitrary (SignedDSIGN v a) where
   arbitrary = SignedDSIGN <$> arbitrary

--- a/cardano-crypto-class/testlib/Test/Crypto/KES.hs
+++ b/cardano-crypto-class/testlib/Test/Crypto/KES.hs
@@ -38,6 +38,7 @@ import Control.Monad.Class.MonadThrow
 import Control.Monad.IO.Class (liftIO)
 import Control.Tracer
 
+import Cardano.Binary.FixedSizeCodec (rawDecodeFixedSized, rawEncodeFixedSized)
 import Cardano.Crypto.DSIGN hiding (Signable)
 import Cardano.Crypto.DirectSerialise (DirectDeserialise, DirectSerialise)
 import Cardano.Crypto.Hash
@@ -289,7 +290,7 @@ testKESAlgorithm lock n =
       prop "VerKey DirectSerialise" $
         ioPropertyWithSK @v lock $ \sk -> do
           vk :: VerKeyKES v <- deriveVerKeyKES sk
-          direct <- directSerialiseToBS (fromIntegral @Word @Int $ verKeySizeKES (Proxy @v)) vk
+          direct <- directSerialiseToBS (fromIntegral @Word @Int $ fixedSize (Proxy @(VerKeyKES v))) vk
           prop_no_thunks_IO (return $! direct)
       prop "SignKey DirectSerialise" $
         ioPropertyWithSK @v lock $ \sk -> do
@@ -298,7 +299,7 @@ testKESAlgorithm lock n =
       prop "VerKey DirectDeserialise" $
         ioPropertyWithSK @v lock $ \sk -> do
           vk :: VerKeyKES v <- deriveVerKeyKES sk
-          direct <- directSerialiseToBS (fromIntegral @Word @Int $ verKeySizeKES (Proxy @v)) $! vk
+          direct <- directSerialiseToBS (fromIntegral @Word @Int $ fixedSize (Proxy @(VerKeyKES v))) $! vk
           prop_no_thunks_IO (directDeserialiseFromBS @IO @(VerKeyKES v) $! direct)
       prop "SignKey DirectDeserialise" $
         ioPropertyWithSK @v lock $ \sk -> do
@@ -314,7 +315,7 @@ testKESAlgorithm lock n =
         prop "VerKey" $
           ioPropertyWithSK @v lock $ \sk -> do
             vk :: VerKeyKES v <- deriveVerKeyKES sk
-            return $ (rawDeserialiseVerKeyKES . rawSerialiseVerKeyKES $ vk) === Just vk
+            return $ (rawDecodeFixedSized . rawEncodeFixedSized $ vk) === Just vk
         prop "SignKey" $
           ioPropertyWithSK @v lock $ \sk -> do
             serialized <- rawSerialiseSignKeyKES sk
@@ -328,13 +329,14 @@ testKESAlgorithm lock n =
         prop "Sig" $ \(msg :: Message) ->
           ioPropertyWithSK @v lock $ \sk -> do
             sig :: SigKES v <- signKES () 0 msg sk
-            return $ (rawDeserialiseSigKES . rawSerialiseSigKES $ sig) === Just sig
+            return $ (rawDecodeFixedSized . rawEncodeFixedSized $ sig) === Just sig
       describe "size" $ do
         prop "VerKey" $
           ioPropertyWithSK @v lock $ \sk -> do
             vk :: VerKeyKES v <- deriveVerKeyKES sk
             return $
-              (fromIntegral @Int @Word . BS.length . rawSerialiseVerKeyKES $ vk) === verKeySizeKES (Proxy @v)
+              (fromIntegral @Int @Word . BS.length . rawEncodeFixedSized $ vk)
+                === fixedSize (Proxy @(VerKeyKES v))
         prop "SignKey" $
           ioPropertyWithSK @v lock $ \sk -> do
             serialized <- rawSerialiseSignKeyKES sk
@@ -342,7 +344,8 @@ testKESAlgorithm lock n =
         prop "Sig" $ \(msg :: Message) ->
           ioPropertyWithSK @v lock $ \sk -> do
             sig :: SigKES v <- signKES () 0 msg sk
-            return $ (fromIntegral @Int @Word . BS.length . rawSerialiseSigKES $ sig) === sigSizeKES (Proxy @v)
+            return $
+              (fromIntegral @Int @Word . BS.length . rawEncodeFixedSized $ sig) === fixedSize (Proxy @(SigKES v))
       describe "direct CBOR" $ do
         prop "VerKey" $
           ioPropertyWithSK @v lock $ \sk -> do
@@ -392,7 +395,7 @@ testKESAlgorithm lock n =
         prop "VerKey" $
           ioPropertyWithSK @v lock $ \sk -> do
             vk :: VerKeyKES v <- deriveVerKeyKES sk
-            serialized <- directSerialiseToBS (fromIntegral @Word @Int $ verKeySizeKES (Proxy @v)) vk
+            serialized <- directSerialiseToBS (fromIntegral @Word @Int $ fixedSize (Proxy @(VerKeyKES v))) vk
             vk' <- directDeserialiseFromBS serialized
             return $ vk === vk'
         prop "SignKey" $
@@ -411,8 +414,8 @@ testKESAlgorithm lock n =
         prop "VerKey" $
           ioPropertyWithSK @v lock $ \sk -> do
             vk :: VerKeyKES v <- deriveVerKeyKES sk
-            direct <- directSerialiseToBS (fromIntegral @Word @Int $ verKeySizeKES (Proxy @v)) vk
-            let raw = rawSerialiseVerKeyKES vk
+            direct <- directSerialiseToBS (fromIntegral @Word @Int $ fixedSize (Proxy @(VerKeyKES v))) vk
+            let raw = rawEncodeFixedSized vk
             return $ direct === raw
         prop "SignKey" $
           ioPropertyWithSK @v lock $ \sk -> do

--- a/cardano-crypto-class/testlib/Test/Crypto/KES.hs
+++ b/cardano-crypto-class/testlib/Test/Crypto/KES.hs
@@ -67,12 +67,12 @@ import Test.Crypto.Util (
   hexBS,
   noExceptionsThrown,
   prop_cbor,
-  prop_cbor_direct_vs_class,
+  prop_cbor_fixed_sized,
+  prop_cbor_fixed_sized_vs_class,
   prop_cbor_size,
-  prop_cbor_with,
   prop_no_thunks_IO,
-  prop_raw_serialise,
-  prop_size_serialise,
+  prop_raw_serialise_fixed_sized,
+  prop_size_serialise_fixed_sized,
   withLock,
  )
 
@@ -347,16 +347,16 @@ testKESAlgorithm lock n =
         prop "VerKey" $
           ioPropertyWithSK @v lock $ \sk -> do
             vk :: VerKeyKES v <- deriveVerKeyKES sk
-            return $ prop_cbor_with encodeVerKeyKES decodeVerKeyKES vk
+            return $ prop_cbor_fixed_sized vk
         -- No CBOR testing for SignKey: sign keys are stored in MLocked memory
         -- and require IO for access.
         prop "Sig" $ \(msg :: Message) ->
           ioPropertyWithSK @v lock $ \sk -> do
             sig :: SigKES v <- signKES () 0 msg sk
-            return $ prop_cbor_with encodeSigKES decodeSigKES sig
+            return $ prop_cbor_fixed_sized sig
         prop "UnsoundSignKeyKES" $ \seedPSB ->
           let sk :: UnsoundPureSignKeyKES v = mkUnsoundPureSignKeyKES seedPSB
-           in prop_cbor_with encodeUnsoundPureSignKeyKES decodeUnsoundPureSignKeyKES sk
+           in prop_cbor_fixed_sized sk
       describe "To/FromCBOR class" $ do
         prop "VerKey" $
           ioPropertyWithSK @v lock $ \sk -> do
@@ -381,13 +381,13 @@ testKESAlgorithm lock n =
         prop "VerKey" $
           ioPropertyWithSK @v lock $ \sk -> do
             vk :: VerKeyKES v <- deriveVerKeyKES sk
-            return $ prop_cbor_direct_vs_class encodeVerKeyKES vk
+            return $ prop_cbor_fixed_sized_vs_class vk
         -- No CBOR testing for SignKey: sign keys are stored in MLocked memory
         -- and require IO for access.
         prop "Sig" $ \(msg :: Message) ->
           ioPropertyWithSK @v lock $ \sk -> do
             sig :: SigKES v <- signKES () 0 msg sk
-            return $ prop_cbor_direct_vs_class encodeSigKES sig
+            return $ prop_cbor_fixed_sized_vs_class sig
       describe "DirectSerialise" $ do
         prop "VerKey" $
           ioPropertyWithSK @v lock $ \sk -> do
@@ -720,7 +720,7 @@ prop_verifyKES_negative_period seedPSB x =
     totalPeriods :: Word
     totalPeriods = totalPeriodsKES (Proxy :: Proxy v)
 
--- | Check 'prop_raw_serialise', 'prop_cbor_with' and 'prop_size_serialise'
+-- | Check 'prop_raw_serialise', 'prop_cbor_fixed_sized' and 'prop_size_serialise'
 -- for 'VerKeyKES' on /all/ the KES key evolutions.
 prop_serialise_VerKeyKES ::
   forall v.
@@ -736,20 +736,11 @@ prop_serialise_VerKeyKES seedPSB =
       return $
         counterexample ("period " ++ show t) $
           counterexample ("vkey " ++ show vk) $
-            prop_raw_serialise
-              rawSerialiseVerKeyKES
-              rawDeserialiseVerKeyKES
-              vk
-              .&. prop_cbor_with
-                encodeVerKeyKES
-                decodeVerKeyKES
-                vk
-              .&. prop_size_serialise
-                rawSerialiseVerKeyKES
-                (verKeySizeKES (Proxy @v))
-                vk
+            prop_raw_serialise_fixed_sized vk
+              .&. prop_cbor_fixed_sized vk
+              .&. prop_size_serialise_fixed_sized @(VerKeyKES v) vk
 
--- | Check 'prop_raw_serialise', 'prop_cbor_with' and 'prop_size_serialise'
+-- | Check 'prop_raw_serialise', 'prop_cbor_fixed_sized' and 'prop_size_serialise'
 -- for 'SigKES' on /all/ the KES key evolutions.
 prop_serialise_SigKES ::
   forall v.
@@ -769,18 +760,9 @@ prop_serialise_SigKES seedPSB x =
         counterexample ("period " ++ show t) $
           counterexample ("vkey " ++ show sk) $
             counterexample ("sig " ++ show sig) $
-              prop_raw_serialise
-                rawSerialiseSigKES
-                rawDeserialiseSigKES
-                sig
-                .&. prop_cbor_with
-                  encodeSigKES
-                  decodeSigKES
-                  sig
-                .&. prop_size_serialise
-                  rawSerialiseSigKES
-                  (sigSizeKES (Proxy @v))
-                  sig
+              prop_raw_serialise_fixed_sized sig
+                .&. prop_cbor_fixed_sized sig
+                .&. prop_size_serialise_fixed_sized @(SigKES v) sig
 
 --
 -- KES test utils

--- a/cardano-crypto-class/testlib/Test/Crypto/Regressions.hs
+++ b/cardano-crypto-class/testlib/Test/Crypto/Regressions.hs
@@ -8,11 +8,12 @@ module Test.Crypto.Regressions (
   ) where
 
 import Test.Hspec (Spec, describe, it, shouldBe)
-import Cardano.Crypto.DSIGN (rawDeserialiseVerKeyDSIGN)
+import Cardano.Crypto.DSIGN (DSIGNAlgorithm (..))
 import Cardano.Crypto.DSIGN.Ed25519 (Ed25519DSIGN)
 import qualified Data.ByteString as BS
 #ifdef SECP256K1_ENABLED
 import Cardano.Crypto.DSIGN.SchnorrSecp256k1 (SchnorrSecp256k1DSIGN)
+import Cardano.Binary.FixedSizeCodec (FixedSizeCodec(..))
 #endif
 
 tests :: Spec
@@ -21,8 +22,8 @@ tests = describe "Regressions" $ do
 #ifdef SECP256K1_ENABLED
     describe "Schnorr serialization" $ do
         it "Schnorr verkey deserialization fails on \"m\" literal" $ do
-          rawDeserialiseVerKeyDSIGN @SchnorrSecp256k1DSIGN "m" `shouldBe` Nothing
+          rawDecodeFixedSized @(VerKeyDSIGN SchnorrSecp256k1DSIGN) "m" `shouldBe` Nothing
 #endif
     describe "Ed25519 serialization" $ do
       it "Ed25519 sign key deserialization fails on 33 NUL bytes" $ do
-        rawDeserialiseVerKeyDSIGN @Ed25519DSIGN (BS.replicate 33 0) `shouldBe` Nothing
+        rawDecodeFixedSized @(SignKeyDSIGN Ed25519DSIGN) (BS.replicate 33 0) `shouldBe` Nothing

--- a/cardano-crypto-class/testlib/Test/Crypto/Util.hs
+++ b/cardano-crypto-class/testlib/Test/Crypto/Util.hs
@@ -106,9 +106,6 @@ import Cardano.Binary.FixedSizeCodec (
  )
 import Cardano.Crypto.DSIGN.Class (
   DSIGNAlgorithm (..),
-  sigSizeDSIGN,
-  signKeySizeDSIGN,
-  verKeySizeDSIGN,
  )
 import Cardano.Crypto.DirectSerialise
 import Cardano.Crypto.Hash.Class (Hash, HashAlgorithm, hashSize)
@@ -433,15 +430,15 @@ instance HashAlgorithm h => Arbitrary (BadInputFor (Hash h a)) where
   shrink = shrinkBadInputFor
 
 instance DSIGNAlgorithm v => Arbitrary (BadInputFor (VerKeyDSIGN v)) where
-  arbitrary = genBadInputFor (fromIntegral @Word @Int (verKeySizeDSIGN (Proxy :: Proxy v)))
+  arbitrary = genBadInputFor (fromIntegral @Word @Int (fixedSize (Proxy :: Proxy (VerKeyDSIGN v))))
   shrink = shrinkBadInputFor
 
 instance DSIGNAlgorithm v => Arbitrary (BadInputFor (SignKeyDSIGN v)) where
-  arbitrary = genBadInputFor (fromIntegral @Word @Int (signKeySizeDSIGN (Proxy :: Proxy v)))
+  arbitrary = genBadInputFor (fromIntegral @Word @Int (fixedSize (Proxy :: Proxy (SignKeyDSIGN v))))
   shrink = shrinkBadInputFor
 
 instance DSIGNAlgorithm v => Arbitrary (BadInputFor (SigDSIGN v)) where
-  arbitrary = genBadInputFor (fromIntegral @Word @Int (sigSizeDSIGN (Proxy :: Proxy v)))
+  arbitrary = genBadInputFor (fromIntegral @Word @Int (fixedSize (Proxy :: Proxy (SigDSIGN v))))
   shrink = shrinkBadInputFor
 
 -- Coercion around a phantom parameter here is dangerous, as there's an implicit

--- a/cardano-crypto-class/testlib/Test/Crypto/Util.hs
+++ b/cardano-crypto-class/testlib/Test/Crypto/Util.hs
@@ -20,13 +20,16 @@ module Test.Crypto.Util (
   ToCBOR (..),
   prop_cbor,
   prop_cbor_size,
-  prop_cbor_with,
+  prop_cbor_fixed_sized,
   prop_cbor_valid,
   prop_cbor_roundtrip,
   prop_raw_serialise,
+  prop_raw_serialise_fixed_sized,
   prop_raw_deserialise,
+  prop_raw_deserialise_fixed_sized,
   prop_size_serialise,
-  prop_cbor_direct_vs_class,
+  prop_size_serialise_fixed_sized,
+  prop_cbor_fixed_sized_vs_class,
   prop_bad_cbor_bytes,
 
   -- * NoThunks
@@ -94,6 +97,12 @@ import Cardano.Binary (
   serialize,
   szGreedy,
   szSimplify,
+ )
+import Cardano.Binary.FixedSizeCodec (
+  FixedSizeCodec (..),
+  decodeFixedSized,
+  encodeFixedSized,
+  fixedSize,
  )
 import Cardano.Crypto.DSIGN.Class (
   DSIGNAlgorithm (..),
@@ -266,7 +275,9 @@ prop_cbor ::
   (ToCBOR a, FromCBOR a, Eq a, Show a) =>
   a ->
   Property
-prop_cbor = prop_cbor_with toCBOR fromCBOR
+prop_cbor x =
+  prop_cbor_valid toCBOR x
+    .&&. prop_cbor_roundtrip toCBOR fromCBOR x
 
 prop_cbor_size :: forall a. ToCBOR a => a -> Property
 prop_cbor_size a =
@@ -280,15 +291,13 @@ prop_cbor_size a =
         Right x -> x
         Left err -> error . show . build $ err
 
-prop_cbor_with ::
-  (Eq a, Show a) =>
-  (a -> Encoding) ->
-  (forall s. Decoder s a) ->
+prop_cbor_fixed_sized ::
+  (FixedSizeCodec a, Eq a, Show a) =>
   a ->
   Property
-prop_cbor_with encoder decoder x =
-  prop_cbor_valid encoder x
-    .&&. prop_cbor_roundtrip encoder decoder x
+prop_cbor_fixed_sized x =
+  prop_cbor_valid encodeFixedSized x
+    .&&. prop_cbor_roundtrip encodeFixedSized decodeFixedSized x
 
 prop_cbor_valid :: (a -> Encoding) -> a -> Property
 prop_cbor_valid encoder x =
@@ -326,6 +335,9 @@ prop_raw_serialise serialise deserialise x =
     Just y -> y === x
     Nothing -> property False
 
+prop_raw_serialise_fixed_sized :: (Eq a, Show a, FixedSizeCodec a) => a -> Property
+prop_raw_serialise_fixed_sized = prop_raw_serialise rawEncodeFixedSized rawDecodeFixedSized
+
 prop_raw_deserialise ::
   forall (a :: Type).
   Show a =>
@@ -339,6 +351,13 @@ prop_raw_deserialise deserialise (BadInputFor forbiddenLen bs) =
     $ case deserialise bs of
       Nothing -> property True
       Just x -> counterexample (ppShow x) False
+
+prop_raw_deserialise_fixed_sized ::
+  forall (a :: Type).
+  (FixedSizeCodec a, Show a) =>
+  BadInputFor a ->
+  Property
+prop_raw_deserialise_fixed_sized = prop_raw_deserialise rawDecodeFixedSized
 
 prop_bad_cbor_bytes ::
   forall (a :: Type).
@@ -356,17 +375,19 @@ prop_bad_cbor_bytes (BadInputFor forbiddenLen bs) =
 -- | The crypto algorithm classes have direct encoding functions, and the key
 -- types are also typically a member of the 'ToCBOR' class. Where a 'ToCBOR'
 -- instance is provided then these should match.
-prop_cbor_direct_vs_class ::
-  ToCBOR a =>
-  (a -> Encoding) ->
+prop_cbor_fixed_sized_vs_class ::
+  (FixedSizeCodec a, ToCBOR a) =>
   a ->
   Property
-prop_cbor_direct_vs_class encoder x =
-  toFlatTerm (encoder x) === toFlatTerm (toCBOR x)
+prop_cbor_fixed_sized_vs_class x =
+  toFlatTerm (encodeFixedSized x) === toFlatTerm (toCBOR x)
 
 prop_size_serialise :: (a -> ByteString) -> Word -> a -> Property
 prop_size_serialise serialise size x =
   BS.length (serialise x) === fromIntegral @Word @Int size
+
+prop_size_serialise_fixed_sized :: forall a. FixedSizeCodec a => a -> Property
+prop_size_serialise_fixed_sized = prop_size_serialise rawEncodeFixedSized (fixedSize $ Proxy @a)
 
 --------------------------------------------------------------------------------
 -- NoThunks

--- a/cardano-crypto-class/testlib/Test/Crypto/Vector/Secp256k1DSIGN.hs
+++ b/cardano-crypto-class/testlib/Test/Crypto/Vector/Secp256k1DSIGN.hs
@@ -12,6 +12,7 @@ module Test.Crypto.Vector.Secp256k1DSIGN (
 where
 
 import Cardano.Binary (DecoderError (DecoderErrorDeserialiseFailure), FromCBOR, decodeFull')
+import Cardano.Binary.FixedSizeCodec (FixedSizeCodec (..))
 import Cardano.Crypto.DSIGN (
   DSIGNAlgorithm (
     ContextDSIGN,
@@ -27,7 +28,6 @@ import Cardano.Crypto.DSIGN (
   MessageHash,
   SchnorrSecp256k1DSIGN,
   hashAndPack,
-  toMessageHash,
  )
 import Cardano.Crypto.Hash.SHA3_256 (SHA3_256)
 import Codec.CBOR.Read (DeserialiseFailure (..))
@@ -256,7 +256,7 @@ mismatchSignKeyVerKeyTest vKey = it "Verification should not be successful when 
 wrongMessageHashLengthTest :: Spec
 wrongMessageHashLengthTest = it "toMessageHash should return Nothing when using invalid length message hash." $
   forM_ wrongLengthMessageHashTestVectors $ \msg -> do
-    let msgHash = toMessageHash msg
+    let msgHash = rawDecodeFixedSized @MessageHash msg
     assertBool "Test failed. Wrong message hash length is treated as right." $ isNothing msgHash
 
 -- Test for vKey, message and signature test vectors without using sign key

--- a/cardano-crypto-class/testlib/Test/Crypto/Vector/StringConstants.hs
+++ b/cardano-crypto-class/testlib/Test/Crypto/Vector/StringConstants.hs
@@ -20,33 +20,38 @@ import Data.Data (Proxy (Proxy))
 import GHC.TypeLits (natVal)
 
 invalidEcdsaVerKeyLengthError :: Integer -> String
-invalidEcdsaVerKeyLengthError = invalidVerKeyLengthError $ natVal $ Proxy @SECP256K1_ECDSA_PUBKEY_BYTES
+invalidEcdsaVerKeyLengthError =
+  wrongLengthError "VerKeyDSIGN EcdsaSecp256k1DSIGN" $ natVal $ Proxy @SECP256K1_ECDSA_PUBKEY_BYTES
 
 invalidSchnorrVerKeyLengthError :: Integer -> String
-invalidSchnorrVerKeyLengthError = invalidVerKeyLengthError $ natVal $ Proxy @SECP256K1_SCHNORR_PUBKEY_BYTES
-
-invalidVerKeyLengthError :: Integer -> Integer -> String
-invalidVerKeyLengthError expectedLength actualLength =
-  "decodeVerKeyDSIGN: wrong length, expected "
-    ++ show expectedLength
-    ++ " bytes but got "
-    ++ show actualLength
+invalidSchnorrVerKeyLengthError =
+  wrongLengthError "VerKeyDSIGN SchnorrSecp256k1DSIGN" $
+    natVal $
+      Proxy @SECP256K1_SCHNORR_PUBKEY_BYTES
 
 invalidEcdsaSigLengthError :: Integer -> String
-invalidEcdsaSigLengthError = invalidSigLengthError $ natVal $ Proxy @SECP256K1_ECDSA_SIGNATURE_BYTES
+invalidEcdsaSigLengthError =
+  wrongLengthError "SigDSIGN EcdsaSecp256k1DSIGN" $ natVal $ Proxy @SECP256K1_ECDSA_SIGNATURE_BYTES
 
+-- | The Schnorr signature decoder validates length via the underlying
+-- 'PinnedSizedBytes', so the error is tagged with that type rather than the
+-- DSIGN type.
 invalidSchnorrSigLengthError :: Integer -> String
-invalidSchnorrSigLengthError = invalidSigLengthError $ natVal $ Proxy @SECP256K1_SCHNORR_SIGNATURE_BYTES
+invalidSchnorrSigLengthError =
+  wrongLengthError ("PinnedSizedBytes " ++ show schnorrSigSize) schnorrSigSize
+  where
+    schnorrSigSize = natVal $ Proxy @SECP256K1_SCHNORR_SIGNATURE_BYTES
 
-invalidSigLengthError :: Integer -> Integer -> String
-invalidSigLengthError expectedLength actualLength =
-  "decodeSigDSIGN: wrong length, expected "
+wrongLengthError :: String -> Integer -> Integer -> String
+wrongLengthError typeName expectedLength actualLength =
+  typeName
+    ++ ": wrong length, expected "
     ++ show expectedLength
     ++ " bytes but got "
     ++ show actualLength
 
 cannotDecodeVerificationKeyError :: String
-cannotDecodeVerificationKeyError = "decodeVerKeyDSIGN: cannot decode key"
+cannotDecodeVerificationKeyError = "VerKeyDSIGN SchnorrSecp256k1DSIGN: deserialisation failed"
 
 unexpectedDecodingError :: String
 unexpectedDecodingError = "Test failed. Unexpected decoding error encountered."

--- a/cardano-crypto-class/testlib/Test/Crypto/Vector/StringConstants.hs
+++ b/cardano-crypto-class/testlib/Test/Crypto/Vector/StringConstants.hs
@@ -21,7 +21,7 @@ import GHC.TypeLits (natVal)
 
 invalidEcdsaVerKeyLengthError :: Integer -> String
 invalidEcdsaVerKeyLengthError =
-  wrongLengthError "VerKeyDSIGN EcdsaSecp256k1DSIGN" $ natVal $ Proxy @SECP256K1_ECDSA_PUBKEY_BYTES
+  wrongLengthError "PinnedSizedBytes 33" $ natVal $ Proxy @SECP256K1_ECDSA_PUBKEY_BYTES
 
 invalidSchnorrVerKeyLengthError :: Integer -> String
 invalidSchnorrVerKeyLengthError =
@@ -31,7 +31,7 @@ invalidSchnorrVerKeyLengthError =
 
 invalidEcdsaSigLengthError :: Integer -> String
 invalidEcdsaSigLengthError =
-  wrongLengthError "SigDSIGN EcdsaSecp256k1DSIGN" $ natVal $ Proxy @SECP256K1_ECDSA_SIGNATURE_BYTES
+  wrongLengthError "PinnedSizedBytes 64" $ natVal $ Proxy @SECP256K1_ECDSA_SIGNATURE_BYTES
 
 -- | The Schnorr signature decoder validates length via the underlying
 -- 'PinnedSizedBytes', so the error is tagged with that type rather than the

--- a/cardano-crypto-leios/CHANGELOG.md
+++ b/cardano-crypto-leios/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog for `cardano-crypto-leios`
 
-## 0.1.1.0
+## 0.1.0.1
 
-* Change lower bound of `cardano-crypto-class` to `>=2.6`
+* 
 
 ## 0.1.0.0
 

--- a/cardano-crypto-leios/CHANGELOG.md
+++ b/cardano-crypto-leios/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for `cardano-crypto-leios`
 
+## 0.1.1.0
+
+* Change lower bound of `cardano-crypto-class` to `>=2.6`
+
 ## 0.1.0.0
 
 * Initial version of `Cardano.Crypto.Leios` that introduces `LeiosCert`, `LeiosCommittee`, and `LeiosVoterId` types, as well as main functions to interact with the types: `resolveLeiosVoter`, `getLeiosVoterId`, `aggregateLeiosCert`, and `verifyLeiosCert`  being notable functions.

--- a/cardano-crypto-leios/cardano-crypto-leios.cabal
+++ b/cardano-crypto-leios/cardano-crypto-leios.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-crypto-leios
-version: 0.1.0.0
+version: 0.1.1.0
 synopsis: Crypto primitives for Leios
 description:
   Data types for the Leios cryptographic artifacts as specified in CIP-0164.
@@ -40,7 +40,7 @@ library
     bytestring,
     cardano-base >=0.1.6,
     cardano-binary,
-    cardano-crypto-class,
+    cardano-crypto-class >=2.6,
     cborg,
     containers,
     deepseq,
@@ -59,7 +59,7 @@ library testlib
   build-depends:
     QuickCheck,
     cardano-base:testlib,
-    cardano-crypto-class,
+    cardano-crypto-class >=2.6,
     cardano-crypto-leios,
     containers,
     vector,
@@ -78,7 +78,7 @@ test-suite tests
     bytestring,
     cardano-base:testlib,
     cardano-binary,
-    cardano-crypto-class,
+    cardano-crypto-class >=2.6,
     cardano-crypto-leios:{cardano-crypto-leios, testlib},
     cborg,
     containers,

--- a/cardano-crypto-leios/cardano-crypto-leios.cabal
+++ b/cardano-crypto-leios/cardano-crypto-leios.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-crypto-leios
-version: 0.1.1.0
+version: 0.1.0.1
 synopsis: Crypto primitives for Leios
 description:
   Data types for the Leios cryptographic artifacts as specified in CIP-0164.
@@ -40,7 +40,7 @@ library
     bytestring,
     cardano-base >=0.1.6,
     cardano-binary,
-    cardano-crypto-class >=2.6,
+    cardano-crypto-class >=2.5.2,
     cborg,
     containers,
     deepseq,
@@ -59,7 +59,7 @@ library testlib
   build-depends:
     QuickCheck,
     cardano-base:testlib,
-    cardano-crypto-class >=2.6,
+    cardano-crypto-class,
     cardano-crypto-leios,
     containers,
     vector,
@@ -77,8 +77,8 @@ test-suite tests
     base16-bytestring,
     bytestring,
     cardano-base:testlib,
-    cardano-binary,
-    cardano-crypto-class >=2.6,
+    cardano-binary >=1.9.1,
+    cardano-crypto-class >=2.5.2,
     cardano-crypto-leios:{cardano-crypto-leios, testlib},
     cborg,
     containers,

--- a/cardano-crypto-leios/src/Cardano/Crypto/Leios.hs
+++ b/cardano-crypto-leios/src/Cardano/Crypto/Leios.hs
@@ -56,17 +56,20 @@ module Cardano.Crypto.Leios (
 
 import Cardano.Base.Bytes (byteArrayFromByteString)
 import Cardano.Binary (matchSize, toCBOR)
-import Cardano.Binary.FixedSizeCodec (decodeFixedSized, encodeFixedSized)
+import Cardano.Binary.FixedSizeCodec (
+  FixedSizeCodec (..),
+  decodeFixedSized,
+  encodeFixedSized,
+  fixedSize,
+ )
 import Cardano.Crypto.DSIGN (
   DSIGNAggregatable (aggregateSigsDSIGN, uncheckedAggregateVerKeysDSIGN),
-  DSIGNAlgorithm (rawSerialiseSigDSIGN),
   SigDSIGN,
   SignKeyDSIGN,
   VerKeyDSIGN,
   verifyDSIGN,
  )
 import Cardano.Crypto.DSIGN.BLS12381 (BLS12381MinSigDSIGN, BLS12381SignContext, minSigPoPDST)
-import Cardano.Crypto.DSIGN.Class (sigSizeDSIGN)
 import Cardano.Crypto.Util (SignableRepresentation)
 import Codec.CBOR.Decoding (Decoder, decodeBreakOr, decodeBytes, decodeListLenOrIndef, decodeWord16)
 import Codec.CBOR.Encoding (Encoding, encodeListLen, encodeWord16)
@@ -116,11 +119,11 @@ leiosSignContext = minSigPoPDST
 
 -- | Size of a Leios signature in the chosen signature scheme.
 leiosSignatureSize :: Word
-leiosSignatureSize = sigSizeDSIGN (Proxy @LeiosDSIGN)
+leiosSignatureSize = fixedSize (Proxy @(SigDSIGN LeiosDSIGN))
 
 -- | Get the bytes of a Leios signature.
 leiosSignatureToBytes :: LeiosSignature -> ByteString
-leiosSignatureToBytes = rawSerialiseSigDSIGN
+leiosSignatureToBytes = rawEncodeFixedSized
 
 -- | A weight assigned to a committee voter, normalised so the total over a
 -- committee sums to @1@. Threshold checks in 'verifyLeiosCert' are against

--- a/cardano-crypto-leios/src/Cardano/Crypto/Leios.hs
+++ b/cardano-crypto-leios/src/Cardano/Crypto/Leios.hs
@@ -56,14 +56,13 @@ module Cardano.Crypto.Leios (
 
 import Cardano.Base.Bytes (byteArrayFromByteString)
 import Cardano.Binary (matchSize, toCBOR)
+import Cardano.Binary.FixedSizeCodec (decodeFixedSized, encodeFixedSized)
 import Cardano.Crypto.DSIGN (
   DSIGNAggregatable (aggregateSigsDSIGN, uncheckedAggregateVerKeysDSIGN),
   DSIGNAlgorithm (rawSerialiseSigDSIGN),
   SigDSIGN,
   SignKeyDSIGN,
   VerKeyDSIGN,
-  decodeSigDSIGN,
-  encodeSigDSIGN,
   verifyDSIGN,
  )
 import Cardano.Crypto.DSIGN.BLS12381 (BLS12381MinSigDSIGN, BLS12381SignContext, minSigPoPDST)
@@ -242,7 +241,7 @@ encodeLeiosCert :: LeiosCert -> Encoding
 encodeLeiosCert cert =
   encodeListLen 2
     <> encodeBitField cert.leiosCertSigners
-    <> encodeSigDSIGN cert.leiosCertSignature
+    <> encodeFixedSized cert.leiosCertSignature
 
 -- | Plain CBOR decoder for 'LeiosCert', matching the CDDL in 'LeiosCert'.
 -- Accepts both definite-length and indefinite-length encodings of the
@@ -256,7 +255,7 @@ decodeLeiosCert = do
   cert <-
     LeiosCert
       <$> decodeBitField
-      <*> decodeSigDSIGN
+      <*> decodeFixedSized
   when isIndef $ do
     isBreak <- decodeBreakOr
     unless isBreak $

--- a/cardano-crypto-leios/test/Test/Cardano/Crypto/Leios.hs
+++ b/cardano-crypto-leios/test/Test/Cardano/Crypto/Leios.hs
@@ -6,9 +6,9 @@
 module Test.Cardano.Crypto.Leios (spec, exampleCert) where
 
 import qualified Cardano.Binary as CBOR
+import Cardano.Binary.FixedSizeCodec (encodeFixedSized)
 import Cardano.Crypto.DSIGN (
   DSIGNAlgorithm (deriveVerKeyDSIGN),
-  encodeSigDSIGN,
   genKeyDSIGN,
   seedSizeDSIGN,
   signDSIGN,
@@ -109,7 +109,7 @@ prop_decode_indefinite_LeiosCert = forAll genLeiosCert $ \cert ->
   let indef =
         encodeListLenIndef
           <> encodeBitField (leiosCertSigners cert)
-          <> encodeSigDSIGN (leiosCertSignature cert)
+          <> encodeFixedSized (leiosCertSignature cert)
           <> encodeBreak
    in CBOR.decodeFullDecoder "LeiosCert" decodeLeiosCert (CBOR.serialize indef)
         === Right cert

--- a/cardano-crypto-praos/CHANGELOG.md
+++ b/cardano-crypto-praos/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog for `cardano-crypto-praos`
 
-## 2.2.3.1
+## 2.2.4.0
 
-*
+* Add `FixedSizeCodec` instances for `PraosVRF` and `PraosBatchCompatVRF`
 
 ## 2.2.3.0
 

--- a/cardano-crypto-praos/CHANGELOG.md
+++ b/cardano-crypto-praos/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 2.2.4.0
 
 * Add `FixedSizeCodec` instances for `PraosVRF` and `PraosBatchCompatVRF`
+* Add `FixedSizeCodec` instances for `Proof`, `SignKey`, `VerKey` in `Cardano.Crypto.VRF.Praos` and `Cardano.Crypto.VRF.PraosBatchCompat`
+* Deprecate `proofBytes`, `skBytes`, `vkBytes`, `proofFromBytes`, `skFromBytes`, `vkFromBytes` in favour of `rawEncodeFixedSized`/`rawDecodeFixedSized`
+* Export `SignKey` and `VerKey` from `Cardano.Crypto.VRF.PraosBatchCompat`
 
 ## 2.2.3.0
 

--- a/cardano-crypto-praos/cardano-crypto-praos.cabal
+++ b/cardano-crypto-praos/cardano-crypto-praos.cabal
@@ -117,6 +117,7 @@ library testlib
     QuickCheck,
     base,
     bytestring >=0.10.12.0,
+    cardano-binary,
     cardano-crypto-class:{cardano-crypto-class, testlib},
     cardano-crypto-praos,
     hspec,

--- a/cardano-crypto-praos/cardano-crypto-praos.cabal
+++ b/cardano-crypto-praos/cardano-crypto-praos.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-crypto-praos
-version: 2.2.3.0
+version: 2.2.4.0
 synopsis: Crypto primitives from libsodium
 description: VRF (and KES, tba) primitives from libsodium.
 license: Apache-2.0

--- a/cardano-crypto-praos/cardano-crypto-praos.cabal
+++ b/cardano-crypto-praos/cardano-crypto-praos.cabal
@@ -85,7 +85,7 @@ library
   build-depends:
     base,
     bytestring,
-    cardano-binary,
+    cardano-binary >=1.9.1,
     cardano-crypto-class >=2.3,
     deepseq,
     nothunks,

--- a/cardano-crypto-praos/src/Cardano/Crypto/VRF/Praos.hs
+++ b/cardano-crypto-praos/src/Cardano/Crypto/VRF/Praos.hs
@@ -469,14 +469,14 @@ prove sk msg =
 -- | Construct a BatchCompat vkey from praos, non-batchcompat
 vkToBatchCompat :: VerKeyVRF PraosVRF -> VerKeyVRF BC.PraosBatchCompatVRF
 vkToBatchCompat praosVk =
-  case rawDeserialiseVerKeyVRF (rawSerialiseVerKeyVRF praosVk) of
+  case rawDecodeFixedSized (rawEncodeFixedSized praosVk) of
     Just vk -> vk
     Nothing -> error "VerKeyVRF: Unable to convert PraosVK to BatchCompatVK."
 
 -- | Construct a BatchCompat skey from praos, non-batchcompat
 skToBatchCompat :: SignKeyVRF PraosVRF -> SignKeyVRF BC.PraosBatchCompatVRF
 skToBatchCompat praosSk =
-  case rawDeserialiseSignKeyVRF (rawSerialiseSignKeyVRF praosSk) of
+  case rawDecodeFixedSized (rawEncodeFixedSized praosSk) of
     Just sk -> sk
     Nothing -> error "SignKeyVRF: Unable to convert PraosSK to BatchCompatSK."
 

--- a/cardano-crypto-praos/src/Cardano/Crypto/VRF/Praos.hs
+++ b/cardano-crypto-praos/src/Cardano/Crypto/VRF/Praos.hs
@@ -60,6 +60,7 @@ module Cardano.Crypto.VRF.Praos (
 where
 
 import Cardano.Binary (FromCBOR (..), Size, ToCBOR (..))
+import Cardano.Binary.FixedSizeCodec (FixedSizeCodec (..))
 import Cardano.Crypto.RandomBytes (randombytes_buf)
 import Cardano.Crypto.Seed (getBytesFromSeedT)
 import Cardano.Crypto.Util (SignableRepresentation (..))
@@ -537,10 +538,6 @@ instance VRFAlgorithm PraosVRF where
 
   type Signable PraosVRF = SignableRepresentation
 
-  type VerKeySizeVRF PraosVRF = 32
-  type SignKeySizeVRF PraosVRF = 64
-  type CertSizeVRF PraosVRF = 80
-
   algorithmNameVRF = const "PraosVRF"
 
   deriveVerKeyVRF = coerce skToVerKey
@@ -564,11 +561,20 @@ instance VRFAlgorithm PraosVRF where
         !(!pk, !sk) = keypairFromSeed seed
      in (SignKeyPraosVRF sk, VerKeyPraosVRF pk)
 
-  rawSerialiseVerKeyVRF (VerKeyPraosVRF pk) = vkBytes pk
-  rawSerialiseSignKeyVRF (SignKeyPraosVRF sk) = skBytes sk
-  rawSerialiseCertVRF (CertPraosVRF proof) = proofBytes proof
-  rawDeserialiseVerKeyVRF = fmap VerKeyPraosVRF . vkFromBytes
-  {-# INLINE rawDeserialiseVerKeyVRF #-}
-  rawDeserialiseSignKeyVRF = fmap SignKeyPraosVRF . skFromBytes
-  rawDeserialiseCertVRF = fmap CertPraosVRF . proofFromBytes
-  {-# INLINE rawDeserialiseCertVRF #-}
+instance FixedSizeCodec (VerKeyVRF PraosVRF) where
+  type FixedSize (VerKeyVRF PraosVRF) = 32
+  rawEncodeFixedSized (VerKeyPraosVRF pk) = vkBytes pk
+  rawDecodeFixedSized bs = VerKeyPraosVRF <$> vkFromBytes bs
+  {-# INLINE rawDecodeFixedSized #-}
+
+instance FixedSizeCodec (SignKeyVRF PraosVRF) where
+  type FixedSize (SignKeyVRF PraosVRF) = 64
+  rawEncodeFixedSized (SignKeyPraosVRF sk) = skBytes sk
+  rawDecodeFixedSized bs = SignKeyPraosVRF <$> skFromBytes bs
+  {-# INLINE rawDecodeFixedSized #-}
+
+instance FixedSizeCodec (CertVRF PraosVRF) where
+  type FixedSize (CertVRF PraosVRF) = 80
+  rawEncodeFixedSized (CertPraosVRF proof) = proofBytes proof
+  rawDecodeFixedSized bs = CertPraosVRF <$> proofFromBytes bs
+  {-# INLINE rawDecodeFixedSized #-}

--- a/cardano-crypto-praos/src/Cardano/Crypto/VRF/Praos.hs
+++ b/cardano-crypto-praos/src/Cardano/Crypto/VRF/Praos.hs
@@ -537,6 +537,10 @@ instance VRFAlgorithm PraosVRF where
 
   type Signable PraosVRF = SignableRepresentation
 
+  type VerKeySizeVRF PraosVRF = 32
+  type SignKeySizeVRF PraosVRF = 64
+  type CertSizeVRF PraosVRF = 80
+
   algorithmNameVRF = const "PraosVRF"
 
   deriveVerKeyVRF = coerce skToVerKey
@@ -568,7 +572,3 @@ instance VRFAlgorithm PraosVRF where
   rawDeserialiseSignKeyVRF = fmap SignKeyPraosVRF . skFromBytes
   rawDeserialiseCertVRF = fmap CertPraosVRF . proofFromBytes
   {-# INLINE rawDeserialiseCertVRF #-}
-
-  sizeVerKeyVRF _ = fromIntegral @Int @Word verKeySizeVRF
-  sizeSignKeyVRF _ = fromIntegral @Int @Word signKeySizeVRF
-  sizeCertVRF _ = fromIntegral @Int @Word certSizeVRF

--- a/cardano-crypto-praos/src/Cardano/Crypto/VRF/Praos.hs
+++ b/cardano-crypto-praos/src/Cardano/Crypto/VRF/Praos.hs
@@ -60,7 +60,12 @@ module Cardano.Crypto.VRF.Praos (
 where
 
 import Cardano.Binary (FromCBOR (..), Size, ToCBOR (..))
-import Cardano.Binary.FixedSizeCodec (FixedSizeCodec (..))
+import Cardano.Binary.FixedSizeCodec (
+  FixedSizeCodec (..),
+  decodeFixedSized,
+  encodeFixedSized,
+  guardFixedSized,
+ )
 import Cardano.Crypto.RandomBytes (randombytes_buf)
 import Cardano.Crypto.Seed (getBytesFromSeedT)
 import Cardano.Crypto.Util (SignableRepresentation (..))
@@ -273,65 +278,104 @@ outputByteArray (Output op) =
 outputToOutputVRF :: Output -> OutputVRF v
 outputToOutputVRF = OutputVRF . outputByteArray
 
+instance FixedSizeCodec Proof where
+  type FixedSize Proof = 80
+  rawEncodeFixedSized (Proof op) = unsafePerformIO $ withForeignPtr op $ \ptr ->
+    BS.packCStringLen (castPtr ptr, certSizeVRF)
+  rawDecodeFixedSized bs =
+    guardFixedSized bs $
+      pure $!
+        unsafePerformIO $ do
+          proof <- mkProof
+          withForeignPtr (unProof proof) $ \ptr ->
+            copyFromByteString ptr bs certSizeVRF
+          return proof
+
+instance FixedSizeCodec VerKey where
+  type FixedSize VerKey = 32
+  rawEncodeFixedSized (VerKey op) = unsafePerformIO $ withForeignPtr op $ \ptr ->
+    BS.packCStringLen (castPtr ptr, verKeySizeVRF)
+  rawDecodeFixedSized bs =
+    guardFixedSized bs $
+      pure $!
+        unsafePerformIO $ do
+          pk <- mkVerKey
+          withForeignPtr (unVerKey pk) $ \ptr ->
+            copyFromByteString ptr bs verKeySizeVRF
+          return pk
+
+instance FixedSizeCodec SignKey where
+  type FixedSize SignKey = 64
+  rawEncodeFixedSized (SignKey op) = unsafePerformIO $ withForeignPtr op $ \ptr ->
+    BS.packCStringLen (castPtr ptr, signKeySizeVRF)
+  rawDecodeFixedSized bs =
+    guardFixedSized bs $
+      pure $!
+        unsafePerformIO $ do
+          sk <- mkSignKey
+          withForeignPtr (unSignKey sk) $ \ptr ->
+            copyFromByteString ptr bs signKeySizeVRF
+          return sk
+
 -- | Convert a proof into a 'ByteString' that we can inspect.
 proofBytes :: Proof -> ByteString
-proofBytes (Proof op) = unsafePerformIO $ withForeignPtr op $ \ptr ->
-  BS.packCStringLen (castPtr ptr, certSizeVRF)
+proofBytes = rawEncodeFixedSized
+{-# DEPRECATED proofBytes "Use `rawEncodeFixedSized` instead" #-}
 
 -- | Convert a verification key into a 'ByteString' that we can inspect.
 vkBytes :: VerKey -> ByteString
-vkBytes (VerKey op) = unsafePerformIO $ withForeignPtr op $ \ptr ->
-  BS.packCStringLen (castPtr ptr, verKeySizeVRF)
+vkBytes = rawEncodeFixedSized
+{-# DEPRECATED vkBytes "Use `rawEncodeFixedSized` instead" #-}
 
 -- | Convert a signing key into a 'ByteString' that we can inspect.
 skBytes :: SignKey -> ByteString
-skBytes (SignKey op) = unsafePerformIO $ withForeignPtr op $ \ptr ->
-  BS.packCStringLen (castPtr ptr, signKeySizeVRF)
+skBytes = rawEncodeFixedSized
+{-# DEPRECATED skBytes "Use `rawEncodeFixedSized` instead" #-}
 
 instance Show Proof where
-  show = show . proofBytes
+  show = show . rawEncodeFixedSized
 
 instance Eq Proof where
-  a == b = proofBytes a == proofBytes b
+  a == b = rawEncodeFixedSized a == rawEncodeFixedSized b
 
 instance Ord Proof where
-  compare = comparing proofBytes
+  compare = comparing rawEncodeFixedSized
 
 instance ToCBOR Proof where
-  toCBOR = toCBOR . proofBytes
+  toCBOR = encodeFixedSized
   encodedSizeExpr _ _ =
     encodedSizeExpr (\_ -> fromIntegral @Int @Size certSizeVRF) (Proxy :: Proxy ByteString)
 
 instance FromCBOR Proof where
-  fromCBOR = fromCBOR >>= proofFromBytes
+  fromCBOR = decodeFixedSized
 
 instance Show SignKey where
-  show = show . skBytes
+  show = show . rawEncodeFixedSized
 
 instance Eq SignKey where
-  a == b = skBytes a == skBytes b
+  a == b = rawEncodeFixedSized a == rawEncodeFixedSized b
 
 instance ToCBOR SignKey where
-  toCBOR = toCBOR . skBytes
+  toCBOR = encodeFixedSized
   encodedSizeExpr _ _ =
     encodedSizeExpr (\_ -> fromIntegral @Int @Size signKeySizeVRF) (Proxy :: Proxy ByteString)
 
 instance FromCBOR SignKey where
-  fromCBOR = fromCBOR >>= skFromBytes
+  fromCBOR = decodeFixedSized
 
 instance Show VerKey where
-  show = show . vkBytes
+  show = show . rawEncodeFixedSized
 
 instance Eq VerKey where
-  a == b = vkBytes a == vkBytes b
+  a == b = rawEncodeFixedSized a == rawEncodeFixedSized b
 
 instance ToCBOR VerKey where
-  toCBOR = toCBOR . vkBytes
+  toCBOR = encodeFixedSized
   encodedSizeExpr _ _ =
     encodedSizeExpr (\_ -> fromIntegral @Int @Size verKeySizeVRF) (Proxy :: Proxy ByteString)
 
 instance FromCBOR VerKey where
-  fromCBOR = fromCBOR >>= vkFromBytes
+  fromCBOR = decodeFixedSized
 
 -- | Allocate a Verification Key and attach a finalizer. The allocated memory will
 -- not be initialized.
@@ -349,54 +393,16 @@ mkProof :: IO Proof
 mkProof = fmap Proof $ newForeignPtr finalizerFree =<< mallocBytes certSizeVRF
 
 proofFromBytes :: MonadFail m => ByteString -> m Proof
-proofFromBytes bs
-  | bsLen /= certSizeVRF =
-      fail $
-        "Invalid proof length "
-          <> show @Int bsLen
-          <> ", expecting "
-          <> show @Int certSizeVRF
-  | otherwise = pure $! unsafePerformIO $ do
-      proof <- mkProof
-      withForeignPtr (unProof proof) $ \ptr ->
-        copyFromByteString ptr bs certSizeVRF
-      return proof
-  where
-    bsLen = BS.length bs
+proofFromBytes = rawDecodeFixedSized
+{-# DEPRECATED proofFromBytes "Use `rawDecodeFixedSized` instead" #-}
 
 skFromBytes :: MonadFail m => ByteString -> m SignKey
-skFromBytes bs = do
-  if bsLen /= signKeySizeVRF
-    then
-      fail $
-        "Invalid SignKey length "
-          <> show @Int bsLen
-          <> ", expecting "
-          <> show @Int signKeySizeVRF
-    else pure $! unsafePerformIO $ do
-      sk <- mkSignKey
-      withForeignPtr (unSignKey sk) $ \ptr ->
-        copyFromByteString ptr bs signKeySizeVRF
-      return sk
-  where
-    bsLen = BS.length bs
+skFromBytes = rawDecodeFixedSized
+{-# DEPRECATED skFromBytes "Use `rawDecodeFixedSized` instead" #-}
 
 vkFromBytes :: MonadFail m => ByteString -> m VerKey
-vkFromBytes bs = do
-  if bsLen /= verKeySizeVRF
-    then
-      fail $
-        "Invalid VerKey length "
-          <> show @Int bsLen
-          <> ", expecting "
-          <> show @Int verKeySizeVRF
-    else pure $! unsafePerformIO $ do
-      pk <- mkVerKey
-      withForeignPtr (unVerKey pk) $ \ptr ->
-        copyFromByteString ptr bs verKeySizeVRF
-      return pk
-  where
-    bsLen = BS.length bs
+vkFromBytes = rawDecodeFixedSized
+{-# DEPRECATED vkFromBytes "Use `rawDecodeFixedSized` instead" #-}
 
 -- | Allocate an Output and attach a finalizer. The allocated memory will
 -- not be initialized.
@@ -562,19 +568,19 @@ instance VRFAlgorithm PraosVRF where
      in (SignKeyPraosVRF sk, VerKeyPraosVRF pk)
 
 instance FixedSizeCodec (VerKeyVRF PraosVRF) where
-  type FixedSize (VerKeyVRF PraosVRF) = 32
-  rawEncodeFixedSized (VerKeyPraosVRF pk) = vkBytes pk
-  rawDecodeFixedSized bs = VerKeyPraosVRF <$> vkFromBytes bs
+  type FixedSize (VerKeyVRF PraosVRF) = FixedSize VerKey
+  rawEncodeFixedSized (VerKeyPraosVRF pk) = rawEncodeFixedSized pk
+  rawDecodeFixedSized bs = VerKeyPraosVRF <$> rawDecodeFixedSized bs
   {-# INLINE rawDecodeFixedSized #-}
 
 instance FixedSizeCodec (SignKeyVRF PraosVRF) where
-  type FixedSize (SignKeyVRF PraosVRF) = 64
-  rawEncodeFixedSized (SignKeyPraosVRF sk) = skBytes sk
-  rawDecodeFixedSized bs = SignKeyPraosVRF <$> skFromBytes bs
+  type FixedSize (SignKeyVRF PraosVRF) = FixedSize SignKey
+  rawEncodeFixedSized (SignKeyPraosVRF sk) = rawEncodeFixedSized sk
+  rawDecodeFixedSized bs = SignKeyPraosVRF <$> rawDecodeFixedSized bs
   {-# INLINE rawDecodeFixedSized #-}
 
 instance FixedSizeCodec (CertVRF PraosVRF) where
-  type FixedSize (CertVRF PraosVRF) = 80
-  rawEncodeFixedSized (CertPraosVRF proof) = proofBytes proof
-  rawDecodeFixedSized bs = CertPraosVRF <$> proofFromBytes bs
+  type FixedSize (CertVRF PraosVRF) = FixedSize Proof
+  rawEncodeFixedSized (CertPraosVRF proof) = rawEncodeFixedSized proof
+  rawDecodeFixedSized bs = CertPraosVRF <$> rawDecodeFixedSized bs
   {-# INLINE rawDecodeFixedSized #-}

--- a/cardano-crypto-praos/src/Cardano/Crypto/VRF/PraosBatchCompat.hs
+++ b/cardano-crypto-praos/src/Cardano/Crypto/VRF/PraosBatchCompat.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE ForeignFunctionInterface #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
@@ -10,6 +11,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE UndecidableInstances #-}
 
 -- | Verifiable Random Function (VRF) implemented as FFI wrappers around the
 -- implementation in https://github.com/input-output-hk/libsodium
@@ -63,12 +65,19 @@ module Cardano.Crypto.VRF.PraosBatchCompat (
   VerKeyVRF (..),
   CertVRF (..),
   Proof,
+  SignKey,
+  VerKey,
   Output,
 )
 where
 
 import Cardano.Binary (FromCBOR (..), Size, ToCBOR (..))
-import Cardano.Binary.FixedSizeCodec (FixedSizeCodec (..))
+import Cardano.Binary.FixedSizeCodec (
+  FixedSizeCodec (..),
+  decodeFixedSized,
+  encodeFixedSized,
+  guardFixedSized,
+ )
 import Cardano.Crypto.RandomBytes (randombytes_buf)
 import Cardano.Crypto.Seed (getBytesFromSeedT)
 import Cardano.Crypto.Util (SignableRepresentation (..))
@@ -216,12 +225,6 @@ verKeySizeVRF = fromIntegral @CSize @Int $! crypto_vrf_ietfdraft13_publickeybyte
 vrfKeySizeVRF :: Int
 vrfKeySizeVRF = fromIntegral @CSize @Int $! crypto_vrf_ietfdraft13_outputbytes
 
-ioSignKeySizeVRF :: IO Int
-ioSignKeySizeVRF = fromIntegral @CSize @Int <$> io_crypto_vrf_ietfdraft13_secretkeybytes
-
-ioVerKeySizeVRF :: IO Int
-ioVerKeySizeVRF = fromIntegral @CSize @Int <$> io_crypto_vrf_ietfdraft13_publickeybytes
-
 -- | Allocate a 'Seed' and attach a finalizer. The allocated memory will not be initialized.
 mkSeed :: IO Seed
 mkSeed = do
@@ -295,65 +298,104 @@ outputByteArray (Output op) =
 outputToOutputVRF :: Output -> OutputVRF v
 outputToOutputVRF = OutputVRF . outputByteArray
 
+instance FixedSizeCodec Proof where
+  type FixedSize Proof = 128
+  rawEncodeFixedSized (Proof op) = unsafePerformIO $ withForeignPtr op $ \ptr ->
+    BS.packCStringLen (castPtr ptr, certSizeVRF)
+  rawDecodeFixedSized bs =
+    guardFixedSized bs $
+      pure $!
+        unsafePerformIO $ do
+          proof <- mkProof
+          withForeignPtr (unProof proof) $ \ptr ->
+            copyFromByteString ptr bs certSizeVRF
+          return proof
+
+instance FixedSizeCodec VerKey where
+  type FixedSize VerKey = 32
+  rawEncodeFixedSized (VerKey op) = unsafePerformIO $ withForeignPtr op $ \ptr ->
+    BS.packCStringLen (castPtr ptr, verKeySizeVRF)
+  rawDecodeFixedSized bs =
+    guardFixedSized bs $
+      pure $!
+        unsafePerformIO $ do
+          pk <- mkVerKey
+          withForeignPtr (unVerKey pk) $ \ptr ->
+            copyFromByteString ptr bs verKeySizeVRF
+          return pk
+
+instance FixedSizeCodec SignKey where
+  type FixedSize SignKey = 64
+  rawEncodeFixedSized (SignKey op) = unsafePerformIO $ withForeignPtr op $ \ptr ->
+    BS.packCStringLen (castPtr ptr, signKeySizeVRF)
+  rawDecodeFixedSized bs =
+    guardFixedSized bs $
+      pure $!
+        unsafePerformIO $ do
+          sk <- mkSignKey
+          withForeignPtr (unSignKey sk) $ \ptr ->
+            copyFromByteString ptr bs signKeySizeVRF
+          return sk
+
 -- | Convert a proof into a 'ByteString' that we can inspect.
 proofBytes :: Proof -> ByteString
-proofBytes (Proof op) = unsafePerformIO $ withForeignPtr op $ \ptr ->
-  BS.packCStringLen (castPtr ptr, certSizeVRF)
+proofBytes = rawEncodeFixedSized
+{-# DEPRECATED proofBytes "Use `rawEncodeFixedSized` instead" #-}
 
 -- | Convert a verification key into a 'ByteString' that we can inspect.
 vkBytes :: VerKey -> ByteString
-vkBytes (VerKey op) = unsafePerformIO $ withForeignPtr op $ \ptr ->
-  BS.packCStringLen (castPtr ptr, verKeySizeVRF)
+vkBytes = rawEncodeFixedSized
+{-# DEPRECATED vkBytes "Use `rawEncodeFixedSized` instead" #-}
 
 -- | Convert a signing key into a 'ByteString' that we can inspect.
 skBytes :: SignKey -> ByteString
-skBytes (SignKey op) = unsafePerformIO $ withForeignPtr op $ \ptr ->
-  BS.packCStringLen (castPtr ptr, signKeySizeVRF)
+skBytes = rawEncodeFixedSized
+{-# DEPRECATED skBytes "Use `rawEncodeFixedSized` instead" #-}
 
 instance Show Proof where
-  show = show . proofBytes
+  show = show . rawEncodeFixedSized
 
 instance Eq Proof where
-  a == b = proofBytes a == proofBytes b
+  a == b = rawEncodeFixedSized a == rawEncodeFixedSized b
 
 instance Ord Proof where
-  compare = comparing proofBytes
+  compare = comparing rawEncodeFixedSized
 
 instance ToCBOR Proof where
-  toCBOR = toCBOR . proofBytes
+  toCBOR = encodeFixedSized
   encodedSizeExpr _ _ =
     encodedSizeExpr (\_ -> fromIntegral @Int @Size certSizeVRF) (Proxy :: Proxy ByteString)
 
 instance FromCBOR Proof where
-  fromCBOR = proofFromBytes <$> fromCBOR
+  fromCBOR = decodeFixedSized
 
 instance Show SignKey where
-  show = show . skBytes
+  show = show . rawEncodeFixedSized
 
 instance Eq SignKey where
-  a == b = skBytes a == skBytes b
+  a == b = rawEncodeFixedSized a == rawEncodeFixedSized b
 
 instance ToCBOR SignKey where
-  toCBOR = toCBOR . skBytes
+  toCBOR = encodeFixedSized
   encodedSizeExpr _ _ =
     encodedSizeExpr (\_ -> fromIntegral @Int @Size signKeySizeVRF) (Proxy :: Proxy ByteString)
 
 instance FromCBOR SignKey where
-  fromCBOR = skFromBytes <$> fromCBOR
+  fromCBOR = decodeFixedSized
 
 instance Show VerKey where
-  show = show . vkBytes
+  show = show . rawEncodeFixedSized
 
 instance Eq VerKey where
-  a == b = vkBytes a == vkBytes b
+  a == b = rawEncodeFixedSized a == rawEncodeFixedSized b
 
 instance ToCBOR VerKey where
-  toCBOR = toCBOR . vkBytes
+  toCBOR = encodeFixedSized
   encodedSizeExpr _ _ =
     encodedSizeExpr (\_ -> fromIntegral @Int @Size verKeySizeVRF) (Proxy :: Proxy ByteString)
 
 instance FromCBOR VerKey where
-  fromCBOR = vkFromBytes <$> fromCBOR
+  fromCBOR = decodeFixedSized
 
 -- | Allocate a Verification Key and attach a finalizer. The allocated memory will
 -- not be initialized.
@@ -370,58 +412,17 @@ mkSignKey = fmap SignKey $ newForeignPtr finalizerFree =<< mallocBytes signKeySi
 mkProof :: IO Proof
 mkProof = fmap Proof $ newForeignPtr finalizerFree =<< mallocBytes certSizeVRF
 
-proofFromBytes :: ByteString -> Proof
-proofFromBytes bs
-  | BS.length bs /= certSizeVRF =
-      error "Invalid proof length"
-  | otherwise =
-      unsafePerformIO $ do
-        proof <- mkProof
-        withForeignPtr (unProof proof) $ \ptr ->
-          copyFromByteString ptr bs certSizeVRF
-        return proof
+proofFromBytes :: MonadFail m => ByteString -> m Proof
+proofFromBytes = rawDecodeFixedSized
+{-# DEPRECATED proofFromBytes "Use `rawDecodeFixedSized` instead" #-}
 
-skFromBytes :: ByteString -> SignKey
-skFromBytes bs = unsafePerformIO $ do
-  if bsLen /= signKeySizeVRF
-    then do
-      ioSize <- ioSignKeySizeVRF
-      error
-        ( "Invalid sk length "
-            <> show @Int bsLen
-            <> ", expecting "
-            <> show @Int signKeySizeVRF
-            <> " or "
-            <> show @Int ioSize
-        )
-    else do
-      sk <- mkSignKey
-      withForeignPtr (unSignKey sk) $ \ptr ->
-        copyFromByteString ptr bs signKeySizeVRF
-      return sk
-  where
-    bsLen = BS.length bs
+skFromBytes :: MonadFail m => ByteString -> m SignKey
+skFromBytes = rawDecodeFixedSized
+{-# DEPRECATED skFromBytes "Use `rawDecodeFixedSized` instead" #-}
 
-vkFromBytes :: ByteString -> VerKey
-vkFromBytes bs = unsafePerformIO $ do
-  if BS.length bs /= verKeySizeVRF
-    then do
-      ioSize <- ioVerKeySizeVRF
-      error
-        ( "Invalid pk length "
-            <> show @Int bsLen
-            <> ", expecting "
-            <> show @Int verKeySizeVRF
-            <> " or "
-            <> show @Int ioSize
-        )
-    else do
-      pk <- mkVerKey
-      withForeignPtr (unVerKey pk) $ \ptr ->
-        copyFromByteString ptr bs verKeySizeVRF
-      return pk
-  where
-    bsLen = BS.length bs
+vkFromBytes :: MonadFail m => ByteString -> m VerKey
+vkFromBytes = rawDecodeFixedSized
+{-# DEPRECATED vkFromBytes "Use `rawDecodeFixedSized` instead" #-}
 
 -- | Allocate an Output and attach a finalizer. The allocated memory will
 -- not be initialized.
@@ -574,19 +575,21 @@ instance VRFAlgorithm PraosBatchCompatVRF where
      in sk `seq` pk `seq` (SignKeyPraosBatchCompatVRF sk, VerKeyPraosBatchCompatVRF pk)
 
 instance FixedSizeCodec (VerKeyVRF PraosBatchCompatVRF) where
-  type FixedSize (VerKeyVRF PraosBatchCompatVRF) = 32
-  rawEncodeFixedSized (VerKeyPraosBatchCompatVRF pk) = vkBytes pk
-  rawDecodeFixedSized bs = pure $! VerKeyPraosBatchCompatVRF (vkFromBytes bs)
+  type FixedSize (VerKeyVRF PraosBatchCompatVRF) = FixedSize VerKey
+  rawEncodeFixedSized (VerKeyPraosBatchCompatVRF pk) = rawEncodeFixedSized pk
+  rawDecodeFixedSized bs =
+    fmap VerKeyPraosBatchCompatVRF $! rawDecodeFixedSized bs
   {-# INLINE rawDecodeFixedSized #-}
 
 instance FixedSizeCodec (SignKeyVRF PraosBatchCompatVRF) where
-  type FixedSize (SignKeyVRF PraosBatchCompatVRF) = 64
-  rawEncodeFixedSized (SignKeyPraosBatchCompatVRF sk) = skBytes sk
-  rawDecodeFixedSized bs = pure $! SignKeyPraosBatchCompatVRF (skFromBytes bs)
+  type FixedSize (SignKeyVRF PraosBatchCompatVRF) = FixedSize SignKey
+  rawEncodeFixedSized (SignKeyPraosBatchCompatVRF sk) = rawEncodeFixedSized sk
+  rawDecodeFixedSized bs =
+    fmap SignKeyPraosBatchCompatVRF $! rawDecodeFixedSized bs
   {-# INLINE rawDecodeFixedSized #-}
 
 instance FixedSizeCodec (CertVRF PraosBatchCompatVRF) where
-  type FixedSize (CertVRF PraosBatchCompatVRF) = 128
-  rawEncodeFixedSized (CertPraosBatchCompatVRF proof) = proofBytes proof
-  rawDecodeFixedSized bs = pure $! CertPraosBatchCompatVRF (proofFromBytes bs)
+  type FixedSize (CertVRF PraosBatchCompatVRF) = FixedSize Proof
+  rawEncodeFixedSized (CertPraosBatchCompatVRF proof) = rawEncodeFixedSized proof
+  rawDecodeFixedSized bs = fmap CertPraosBatchCompatVRF $! rawDecodeFixedSized bs
   {-# INLINE rawDecodeFixedSized #-}

--- a/cardano-crypto-praos/src/Cardano/Crypto/VRF/PraosBatchCompat.hs
+++ b/cardano-crypto-praos/src/Cardano/Crypto/VRF/PraosBatchCompat.hs
@@ -68,6 +68,7 @@ module Cardano.Crypto.VRF.PraosBatchCompat (
 where
 
 import Cardano.Binary (FromCBOR (..), Size, ToCBOR (..))
+import Cardano.Binary.FixedSizeCodec (FixedSizeCodec (..))
 import Cardano.Crypto.RandomBytes (randombytes_buf)
 import Cardano.Crypto.Seed (getBytesFromSeedT)
 import Cardano.Crypto.Util (SignableRepresentation (..))
@@ -548,10 +549,6 @@ instance VRFAlgorithm PraosBatchCompatVRF where
 
   type Signable PraosBatchCompatVRF = SignableRepresentation
 
-  type VerKeySizeVRF PraosBatchCompatVRF = 32
-  type SignKeySizeVRF PraosBatchCompatVRF = 64
-  type CertSizeVRF PraosBatchCompatVRF = 128
-
   algorithmNameVRF = const "PraosBatchCompatVRF"
 
   deriveVerKeyVRF = coerce skToVerKey
@@ -576,16 +573,20 @@ instance VRFAlgorithm PraosBatchCompatVRF where
         (pk, sk) = keypairFromSeed seed
      in sk `seq` pk `seq` (SignKeyPraosBatchCompatVRF sk, VerKeyPraosBatchCompatVRF pk)
 
-  rawSerialiseVerKeyVRF (VerKeyPraosBatchCompatVRF pk) = vkBytes pk
-  rawSerialiseSignKeyVRF (SignKeyPraosBatchCompatVRF sk) = skBytes sk
-  rawSerialiseCertVRF (CertPraosBatchCompatVRF proof) = proofBytes proof
-  rawDeserialiseVerKeyVRF = fmap (VerKeyPraosBatchCompatVRF . vkFromBytes) . assertLength verKeySizeVRF
-  rawDeserialiseSignKeyVRF = fmap (SignKeyPraosBatchCompatVRF . skFromBytes) . assertLength signKeySizeVRF
-  rawDeserialiseCertVRF = fmap (CertPraosBatchCompatVRF . proofFromBytes) . assertLength certSizeVRF
+instance FixedSizeCodec (VerKeyVRF PraosBatchCompatVRF) where
+  type FixedSize (VerKeyVRF PraosBatchCompatVRF) = 32
+  rawEncodeFixedSized (VerKeyPraosBatchCompatVRF pk) = vkBytes pk
+  rawDecodeFixedSized bs = pure $! VerKeyPraosBatchCompatVRF (vkFromBytes bs)
+  {-# INLINE rawDecodeFixedSized #-}
 
-assertLength :: Int -> ByteString -> Maybe ByteString
-assertLength l bs
-  | BS.length bs == l =
-      Just bs
-  | otherwise =
-      Nothing
+instance FixedSizeCodec (SignKeyVRF PraosBatchCompatVRF) where
+  type FixedSize (SignKeyVRF PraosBatchCompatVRF) = 64
+  rawEncodeFixedSized (SignKeyPraosBatchCompatVRF sk) = skBytes sk
+  rawDecodeFixedSized bs = pure $! SignKeyPraosBatchCompatVRF (skFromBytes bs)
+  {-# INLINE rawDecodeFixedSized #-}
+
+instance FixedSizeCodec (CertVRF PraosBatchCompatVRF) where
+  type FixedSize (CertVRF PraosBatchCompatVRF) = 128
+  rawEncodeFixedSized (CertPraosBatchCompatVRF proof) = proofBytes proof
+  rawDecodeFixedSized bs = pure $! CertPraosBatchCompatVRF (proofFromBytes bs)
+  {-# INLINE rawDecodeFixedSized #-}

--- a/cardano-crypto-praos/src/Cardano/Crypto/VRF/PraosBatchCompat.hs
+++ b/cardano-crypto-praos/src/Cardano/Crypto/VRF/PraosBatchCompat.hs
@@ -548,6 +548,10 @@ instance VRFAlgorithm PraosBatchCompatVRF where
 
   type Signable PraosBatchCompatVRF = SignableRepresentation
 
+  type VerKeySizeVRF PraosBatchCompatVRF = 32
+  type SignKeySizeVRF PraosBatchCompatVRF = 64
+  type CertSizeVRF PraosBatchCompatVRF = 128
+
   algorithmNameVRF = const "PraosBatchCompatVRF"
 
   deriveVerKeyVRF = coerce skToVerKey
@@ -578,10 +582,6 @@ instance VRFAlgorithm PraosBatchCompatVRF where
   rawDeserialiseVerKeyVRF = fmap (VerKeyPraosBatchCompatVRF . vkFromBytes) . assertLength verKeySizeVRF
   rawDeserialiseSignKeyVRF = fmap (SignKeyPraosBatchCompatVRF . skFromBytes) . assertLength signKeySizeVRF
   rawDeserialiseCertVRF = fmap (CertPraosBatchCompatVRF . proofFromBytes) . assertLength certSizeVRF
-
-  sizeVerKeyVRF _ = fromIntegral @Int @Word verKeySizeVRF
-  sizeSignKeyVRF _ = fromIntegral @Int @Word signKeySizeVRF
-  sizeCertVRF _ = fromIntegral @Int @Word certSizeVRF
 
 assertLength :: Int -> ByteString -> Maybe ByteString
 assertLength l bs

--- a/cardano-crypto-praos/testlib/Test/Crypto/VRF.hs
+++ b/cardano-crypto-praos/testlib/Test/Crypto/VRF.hs
@@ -11,6 +11,7 @@ module Test.Crypto.VRF (
 )
 where
 
+import Cardano.Binary.FixedSizeCodec (FixedSizeCodec (..))
 import Cardano.Crypto.Util
 import Cardano.Crypto.VRF
 import Cardano.Crypto.VRF.Praos
@@ -252,17 +253,11 @@ testVRFAlgorithm _ n =
     describe "serialisation" $ do
       describe "raw" $ do
         prop "VerKey" $
-          prop_raw_serialise @(VerKeyVRF v)
-            rawSerialiseVerKeyVRF
-            rawDeserialiseVerKeyVRF
+          prop_raw_serialise_fixed_sized @(VerKeyVRF v)
         prop "SignKey" $
-          prop_raw_serialise @(SignKeyVRF v)
-            rawSerialiseSignKeyVRF
-            rawDeserialiseSignKeyVRF
+          prop_raw_serialise_fixed_sized @(SignKeyVRF v)
         prop "Cert" $
-          prop_raw_serialise @(CertVRF v)
-            rawSerialiseCertVRF
-            rawDeserialiseCertVRF
+          prop_raw_serialise_fixed_sized @(CertVRF v)
 
       describe "size" $ do
         prop "VerKey" $
@@ -397,14 +392,14 @@ prop_naturalToBytes (NonNegative sz) n =
 --
 prop_pubKeyToBatchComopat :: VerKeyVRF PraosVRF -> Property
 prop_pubKeyToBatchComopat vk =
-  rawSerialiseVerKeyVRF (vkToBatchCompat vk) === rawSerialiseVerKeyVRF vk
+  rawEncodeFixedSized (vkToBatchCompat vk) === rawEncodeFixedSized vk
 
 --
 -- Praos <-> BatchCompatPraos SignKey conversion
 --
 prop_signKeyToBatchCompat :: SignKeyVRF PraosVRF -> Property
 prop_signKeyToBatchCompat sk =
-  rawSerialiseSignKeyVRF (skToBatchCompat sk) === rawSerialiseSignKeyVRF sk
+  rawEncodeFixedSized (skToBatchCompat sk) === rawEncodeFixedSized sk
 
 --
 -- Praos <-> BatchCompatPraos Output conversion

--- a/cardano-crypto-praos/testlib/Test/Crypto/VRF.hs
+++ b/cardano-crypto-praos/testlib/Test/Crypto/VRF.hs
@@ -119,12 +119,12 @@ checkVer03TestVector file = do
       (assertFailure $ "parsing test vector: " <> file <> " not successful")
       pure
       testVectorE
-  signKey <- Ver03.skFromBytes testVectorSigningKey
-  verKey <- Ver03.vkFromBytes testVectorVerifyingKey
+  signKey <- rawDecodeFixedSized @Ver03.SignKey testVectorSigningKey
+  verKey <- rawDecodeFixedSized @Ver03.VerKey testVectorVerifyingKey
   testVectorName @?= algorithmNameVRF (Proxy :: Proxy PraosVRF)
   testVectorVersion @?= "ietfdraft03"
   testVectorCipherSuite @?= "ECVRF-ED25519-SHA512-Elligator2"
-  proof' <- Ver03.proofFromBytes testVectorProof
+  proof' <- rawDecodeFixedSized @Ver03.Proof testVectorProof
   hash' <- Ver03.outputFromBytes testVectorHash
   -- prove signKey msg -> proof
   Ver03.prove signKey testVectorMessage @?= Just proof'
@@ -145,13 +145,13 @@ checkVer13TestVector file = do
       (assertFailure $ "parsing test vector: " <> file <> " not successful")
       pure
       testVectorE
-  let signKey = Ver13.skFromBytes testVectorSigningKey
-  let verKey = Ver13.vkFromBytes testVectorVerifyingKey
+  signKey <- rawDecodeFixedSized @Ver13.SignKey testVectorSigningKey
+  verKey <- rawDecodeFixedSized @Ver13.VerKey testVectorVerifyingKey
   testVectorName @?= algorithmNameVRF (Proxy :: Proxy PraosBatchCompatVRF)
   testVectorVersion @?= "ietfdraft13"
   testVectorCipherSuite @?= "ECVRF-ED25519-SHA512-Elligator2"
   -- prove signKey msg -> proof
-  let proof' = Ver13.proofFromBytes testVectorProof
+  proof' <- rawDecodeFixedSized @Ver13.Proof testVectorProof
   hash' <- Ver13.outputFromBytes testVectorHash
   Ver13.prove signKey testVectorMessage @?= Just proof'
   -- signKey -> verKey

--- a/cardano-crypto-praos/testlib/Test/Crypto/VRF.hs
+++ b/cardano-crypto-praos/testlib/Test/Crypto/VRF.hs
@@ -266,31 +266,19 @@ testVRFAlgorithm _ n =
 
       describe "size" $ do
         prop "VerKey" $
-          prop_size_serialise @(VerKeyVRF v)
-            rawSerialiseVerKeyVRF
-            (sizeVerKeyVRF (Proxy @v))
+          prop_size_serialise_fixed_sized @(VerKeyVRF v)
         prop "SignKey" $
-          prop_size_serialise @(SignKeyVRF v)
-            rawSerialiseSignKeyVRF
-            (sizeSignKeyVRF (Proxy @v))
+          prop_size_serialise_fixed_sized @(SignKeyVRF v)
         prop "Cert" $
-          prop_size_serialise @(CertVRF v)
-            rawSerialiseCertVRF
-            (sizeCertVRF (Proxy @v))
+          prop_size_serialise_fixed_sized @(CertVRF v)
 
       describe "direct CBOR" $ do
         prop "VerKey" $
-          prop_cbor_with @(VerKeyVRF v)
-            encodeVerKeyVRF
-            decodeVerKeyVRF
+          prop_cbor_fixed_sized @(VerKeyVRF v)
         prop "SignKey" $
-          prop_cbor_with @(SignKeyVRF v)
-            encodeSignKeyVRF
-            decodeSignKeyVRF
+          prop_cbor_fixed_sized @(SignKeyVRF v)
         prop "Cert" $
-          prop_cbor_with @(CertVRF v)
-            encodeCertVRF
-            decodeCertVRF
+          prop_cbor_fixed_sized @(CertVRF v)
 
       describe "To/FromCBOR class" $ do
         prop "VerKey" $ prop_cbor @(VerKeyVRF v)
@@ -304,14 +292,11 @@ testVRFAlgorithm _ n =
 
       describe "direct matches class" $ do
         prop "VerKey" $
-          prop_cbor_direct_vs_class @(VerKeyVRF v)
-            encodeVerKeyVRF
+          prop_cbor_fixed_sized_vs_class @(VerKeyVRF v)
         prop "SignKey" $
-          prop_cbor_direct_vs_class @(SignKeyVRF v)
-            encodeSignKeyVRF
+          prop_cbor_fixed_sized_vs_class @(SignKeyVRF v)
         prop "Cert" $
-          prop_cbor_direct_vs_class @(CertVRF v)
-            encodeCertVRF
+          prop_cbor_fixed_sized_vs_class @(CertVRF v)
 
     describe "verify" $ do
       -- NOTE: we no longer test against maxVRF, because the maximum numeric


### PR DESCRIPTION
# Description

This PR lifts the sizes of `VerKeyVRF`, `SignKeyVRF` and `CertVRF` to the type level, which is similar to what we already do for `DSIGN` and `KES`. I also added the `FixedSizeBytes` typeclass, which gives a uniform interface to all the `rawDeserialise*` and `encode*` functions for  `DSIGN`/`KES`/`VRF` types.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#changelogmd))
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process))
- [x] Self-reviewed the diff
