### PR TITLE
cardano-crypto-wallet: rename ed25519 C symbols from cardano_crypto_ …

### DIFF
--- a/cardano-crypto-wallet/cbits/ed25519/ed25519.c
+++ b/cardano-crypto-wallet/cbits/ed25519/ed25519.c
@@ -5,7 +5,7 @@
 */
 
 
-#define ED25519_FN(fn)         cardano_crypto_##fn
+#define ED25519_FN(fn)         ccw_##fn
 
 #include "ed25519-donna.h"
 #include "ed25519.h"

--- a/cardano-crypto-wallet/cbits/ed25519/ed25519.h
+++ b/cardano-crypto-wallet/cbits/ed25519/ed25519.h
@@ -12,12 +12,12 @@ typedef unsigned char ed25519_public_key[32];
 typedef unsigned char ed25519_unextended_secret_key[32]; // this is the UNEXTENDED SECRET KEY
 typedef unsigned char ed25519_secret_key[64]; // this is the EXTENDED SECRET KEY
 
-void cardano_crypto_ed25519_publickey(const ed25519_secret_key sk, ed25519_public_key pk);
-int cardano_crypto_ed25519_sign_open(const unsigned char *m, size_t mlen, const ed25519_public_key pk, const ed25519_signature RS);
-void cardano_crypto_ed25519_sign (const unsigned char *m, size_t mlen, const unsigned char *salt, size_t slen, const ed25519_secret_key sk, const ed25519_public_key pk, ed25519_signature RS);
-int cardano_crypto_ed25519_scalar_add (const ed25519_secret_key sk1, const ed25519_secret_key sk2, ed25519_secret_key res);
-int cardano_crypto_ed25519_point_add (const ed25519_public_key pk1, const ed25519_public_key pk2, ed25519_public_key res);
-int cardano_crypto_ed25519_extend (const ed25519_unextended_secret_key seed, ed25519_secret_key secret);
+void ccw_ed25519_publickey(const ed25519_secret_key sk, ed25519_public_key pk);
+int ccw_ed25519_sign_open(const unsigned char *m, size_t mlen, const ed25519_public_key pk, const ed25519_signature RS);
+void ccw_ed25519_sign (const unsigned char *m, size_t mlen, const unsigned char *salt, size_t slen, const ed25519_secret_key sk, const ed25519_public_key pk, ed25519_signature RS);
+int ccw_ed25519_scalar_add (const ed25519_secret_key sk1, const ed25519_secret_key sk2, ed25519_secret_key res);
+int ccw_ed25519_point_add (const ed25519_public_key pk1, const ed25519_public_key pk2, ed25519_public_key res);
+int ccw_ed25519_extend (const ed25519_unextended_secret_key seed, ed25519_secret_key secret);
 
 #if defined(__cplusplus)
 }

--- a/cardano-crypto-wallet/cbits/encrypted_sign.c
+++ b/cardano-crypto-wallet/cbits/encrypted_sign.c
@@ -42,7 +42,7 @@ static void wallet_encrypted_initialize
      encrypted_key *out)
 {
 	ed25519_public_key pub_key;
-	cardano_crypto_ed25519_publickey(secret_key, pub_key);
+	ccw_ed25519_publickey(secret_key, pub_key);
 	memcpy(out->ekey, secret_key, ENCRYPTED_KEY_SIZE);
 	memcpy(out->pkey, pub_key, PUBLIC_KEY_SIZE);
 	memcpy(out->cc, cc, CHAIN_CODE_SIZE);
@@ -54,7 +54,7 @@ int cardano_wallet_encrypted_from_secret
      encrypted_key *out)
 {
 	ed25519_secret_key secret_key;
-	if (cardano_crypto_ed25519_extend(seed, secret_key)) {
+	if (ccw_ed25519_extend(seed, secret_key)) {
 		secure_clear(secret_key, sizeof(secret_key));
 		return 1;
 	}
@@ -85,7 +85,7 @@ int cardano_wallet_encrypted_decrypt
 {
 	ed25519_public_key pub_key;
 
-	cardano_crypto_ed25519_publickey(in->ekey, pub_key);
+	ccw_ed25519_publickey(in->ekey, pub_key);
 	if (sodium_memcmp(pub_key, in->pkey, PUBLIC_KEY_SIZE) != 0) {
 		secure_clear(pub_key, sizeof(pub_key));
 		return 1;
@@ -105,8 +105,8 @@ int cardano_wallet_encrypted_sign
      ed25519_signature signature)
 {
 	ed25519_public_key pub_key;
-	cardano_crypto_ed25519_publickey(in->ekey, pub_key);
-	cardano_crypto_ed25519_sign(data, data_len, in->cc, CHAIN_CODE_SIZE, in->ekey, pub_key, signature);
+	ccw_ed25519_publickey(in->ekey, pub_key);
+	ccw_ed25519_sign(data, data_len, in->cc, CHAIN_CODE_SIZE, in->ekey, pub_key, signature);
 	secure_clear(pub_key, sizeof(pub_key));
 	return 0;
 }
@@ -206,7 +206,7 @@ static void add_left(ed25519_secret_key res_key, uint8_t *z, ed25519_secret_key 
 	switch (mode) {
 	case DERIVATION_V1:
 		multiply8_v1(zl8, z, 32);
-		cardano_crypto_ed25519_scalar_add(zl8, priv_key, res_key);
+		ccw_ed25519_scalar_add(zl8, priv_key, res_key);
 		break;
 	case DERIVATION_V2:
 		multiply8_v2(zl8, z, 28);
@@ -242,8 +242,8 @@ static void add_left_public(uint8_t *out, uint8_t *z, uint8_t *in, derivation_sc
 		break;
 	}
 
-	cardano_crypto_ed25519_publickey(zl8, pub_zl8);
-	cardano_crypto_ed25519_point_add(pub_zl8, in, out);
+	ccw_ed25519_publickey(zl8, pub_zl8);
+	ccw_ed25519_point_add(pub_zl8, in, out);
 }
 
 int cardano_wallet_encrypted_derive_private

--- a/cardano-crypto-wallet/test/Test/Cardano/Crypto/Wallet/SignSpec.hs
+++ b/cardano-crypto-wallet/test/Test/Cardano/Crypto/Wallet/SignSpec.hs
@@ -11,7 +11,7 @@ import Test.Hspec
 
 import Cardano.Crypto.WalletHD.Encrypted
 
-foreign import ccall "cardano_crypto_ed25519_sign_open"
+foreign import ccall "ccw_ed25519_sign_open"
   c_ed25519_sign_open ::
     Ptr a ->
     CSize ->

--- a/cardano-crypto-wallet/test/Test/Cardano/Crypto/Wallet/V2FormatSpec.hs
+++ b/cardano-crypto-wallet/test/Test/Cardano/Crypto/Wallet/V2FormatSpec.hs
@@ -23,8 +23,8 @@ wrongPass = BS.replicate 32 0x00
 -- ---------------------------------------------------------------------------
 -- Public-key golden vector
 --
--- This is the ed25519 public key derived from testSeed via cardano_crypto_ed25519_extend
--- + cardano_crypto_ed25519_publickey.  It is fully deterministic (no randomness).
+-- This is the ed25519 public key derived from testSeed via ccw_ed25519_extend
+-- + ccw_ed25519_publickey.  It is fully deterministic (no randomness).
 -- If this changes, the key derivation C code has silently changed.
 -- ---------------------------------------------------------------------------
 


### PR DESCRIPTION
…to ccw_

Both cardano-crypto and cardano-crypto-wallet bundle ed25519.c with the same ED25519_FN macro prefix, producing duplicate exported symbols (cardano_crypto_ed25519_publickey, etc.).  The GHC runtime linker aborts on duplicate symbols, breaking TH evaluation via iserv (e.g. Windows cross-builds) and GHCi on all platforms.

Rename the prefix in cardano-crypto-wallet from cardano_crypto_ to ccw_ so the two libraries no longer collide.  No Haskell FFI changes needed: the FFI only imports wallet_encrypted_* and wallet_sodium_* symbols; the ed25519 symbols are internal C-to-C calls.

# Description

<!-- Add your description here, if this PR fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process))
- [ ] Self-reviewed the diff
