### PR TITLE
backport psbFromByteStringM and psbToByteArray to PinnedSizedBytes to 2.3.3.0

### DIFF
--- a/cardano-crypto-class/CHANGELOG.md
+++ b/cardano-crypto-class/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog for `cardano-crypto-class`
 
+## 2.3.3.0
+
+* Add `psbToByteArray`
+* Add `psbFromByteStringM`
+
 ## 2.3.2.0
 
 * Add `Storable` instance for `PackedBytes` and `Hash`

--- a/cardano-crypto-class/cardano-crypto-class.cabal
+++ b/cardano-crypto-class/cardano-crypto-class.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-crypto-class
-version: 2.3.2.0
+version: 2.3.3.0
 synopsis:
   Type classes abstracting over cryptography primitives for Cardano
 

--- a/cardano-crypto-class/src/Cardano/Crypto/PinnedSizedBytes.hs
+++ b/cardano-crypto-class/src/Cardano/Crypto/PinnedSizedBytes.hs
@@ -22,7 +22,9 @@ module Cardano.Crypto.PinnedSizedBytes (
   psbToBytes,
   psbFromByteString,
   psbFromByteStringCheck,
+  psbFromByteStringM,
   psbToByteString,
+  psbToByteArray,
 
   -- * C usage
   psbUseAsCPtr,
@@ -237,6 +239,14 @@ psbFromByteStringCheck bs
   where
     size :: Int
     size = fromInteger (natVal (Proxy :: Proxy n))
+
+psbFromByteStringM :: (KnownNat n, MonadFail f) => BS.ByteString -> f (PinnedSizedBytes n)
+psbFromByteStringM bs = case psbFromByteStringCheck bs of
+  Just psb -> pure psb
+  Nothing -> fail $ "psbFromByteStringM: size mismatch, expected " ++ show (BS.length bs) ++ " bytes"
+
+psbToByteArray :: PinnedSizedBytes n -> ByteArray
+psbToByteArray (PSB ba) = ba
 
 {-# DEPRECATED psbZero "This is not referentially transparent" #-}
 psbZero :: KnownNat n => PinnedSizedBytes n


### PR DESCRIPTION
These were introduced in a newer commit that the cardano-crypto-wallet branch depends on but is not yet present in the tagged base this branch is rebased onto.

# Description

<!-- Add your description here, if this PR fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue. -->

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [ ] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#changelogmd))
- [ ] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process).
- [ ] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process))
- [ ] Self-reviewed the diff
