### PR TITLE
Fixes to get cardano-crypto-leios 0.1.0.0 released

### DIFF
--- a/cardano-crypto-leios/CHANGELOG.md
+++ b/cardano-crypto-leios/CHANGELOG.md
@@ -2,5 +2,4 @@
 
 ## 0.1.0.0
 
-* Initial version: `EbHash` and `LeiosCert` extracted from
-  `ouroboros-consensus` and `cardano-ledger-core` per CIP-0164.
+* Initial version of `Cardano.Crypto.Leios` that introduces `LeiosCert`, `LeiosCommittee`, and `LeiosVoterId` types, as well as main functions to interact with the types: `resolveLeiosVoter`, `getLeiosVoterId`, `aggregateLeiosCert`, and `verifyLeiosCert`  being notable functions.

--- a/cardano-crypto-leios/cardano-crypto-leios.cabal
+++ b/cardano-crypto-leios/cardano-crypto-leios.cabal
@@ -38,7 +38,7 @@ library
 
   build-depends:
     bytestring,
-    cardano-base,
+    cardano-base >=0.1.6.0,
     cardano-binary,
     cardano-crypto-class,
     cborg,


### PR DESCRIPTION

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
- [x] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process))
- [x] Self-reviewed the diff
