### PR TITLE
Update dependencies

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -46,15 +46,10 @@ package bitvec
 -- cabal-allow-newer begin
 if impl(ghc >=9.14)
   allow-newer:
-    , boring:base
     , canonical-json:containers
     , cborg:base
     , cborg:containers
     , serialise:base
     , serialise:containers
     , serialise:time
-    , tree-diff:QuickCheck
-    , tree-diff:base
-    , tree-diff:containers
-    , tree-diff:time
 -- cabal-allow-newer end

--- a/cabal.project
+++ b/cabal.project
@@ -11,8 +11,8 @@ repository cardano-haskell-packages
 
 -- The index-states
 index-state:
-  , hackage.haskell.org 2026-05-07T19:55:27Z
-  , cardano-haskell-packages 2026-05-20T06:15:42Z
+  , hackage.haskell.org 2026-07-19T18:15:41Z
+  , cardano-haskell-packages 2026-07-17T14:40:55Z
 
 packages:
   base-deriving-via

--- a/cardano-crypto-class/CHANGELOG.md
+++ b/cardano-crypto-class/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog for `cardano-crypto-class`
 
-## 2.5.1.1
+## 2.6.0.0
 
-*
+* Replace memory dependency with ram (drop in replacement)
+* Depend on crypton ^>- 1.1
 
 ## 2.5.1.0
 

--- a/cardano-crypto-class/cardano-crypto-class.cabal
+++ b/cardano-crypto-class/cardano-crypto-class.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.0
 name: cardano-crypto-class
-version: 2.5.1.0
+version: 2.6.0.0
 synopsis:
   Type classes abstracting over cryptography primitives for Cardano
 
@@ -128,16 +128,16 @@ library
     cardano-base >=0.1.6,
     cardano-binary >=1.9.1,
     cardano-strict-containers,
-    crypton ^>=1.0,
+    crypton ^>=1.1,
     deepseq,
     heapwords,
     io-classes >=1.4.1,
-    memory,
     memory-pool,
     mempack,
     mtl,
     nothunks,
     primitive >=0.8,
+    ram,
     template-haskell,
     text,
     th-compat,

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1779365452,
-        "narHash": "sha256-7eggTKG1EeFnFSpka8ifw/5Xjxh87/H8vtQ0EsdKkKg=",
+        "lastModified": 1784570152,
+        "narHash": "sha256-eOcU6GF5Skq/WkBdfCgKIyTzgAjWo1WjbVsR5xDzunI=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "d3ab34aad8e3414b16d7a9eed8df8449315f30ed",
+        "rev": "f77658bfbf42886478e7a34a1522949cdfc639a3",
         "type": "github"
       },
       "original": {
@@ -225,11 +225,11 @@
     "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1778451219,
-        "narHash": "sha256-k4AmhT5+MPfyXI6G50+LW5xCxju7PpYmlSlc6qvUTiA=",
+        "lastModified": 1784605098,
+        "narHash": "sha256-pwzHxwE3ljtnIaxWvJ4nmfCVSLbJYuG/d5k3FCWhQss=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "aa349f3c7f02b41da2321474ea96948e1392c350",
+        "rev": "223a37f33a340c94eb14a14fdd11ff3efe24a3cb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Description

Update dependencies. The version of `cardano-crypto-class` was bumped to `2.6.0.0` because this change switched from depending on the `memoery` package to `ram` (supposed to be a drop-in replacement).

When bumping the upper bound on `crypton` I checked that the code built without errors and that `crypton-1.1.4` was actually in the cabal plan.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated
- [x] All visible changes are prepended to the latest section of a `CHANGELOG.md` for the affected packages.
      **_New section is never added with the code changes._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#changelogmd))
- [x] When applicable, versions are updated in `.cabal` and `CHANGELOG.md` files according to the
      [versioning process](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process).
- [x] The version bounds in `.cabal` files for all affected packages are updated.
      **_If you change the bounds in a cabal file, that package itself must have a version increase._** (See [RELEASING.md](https://github.com/intersectmbo/cardano-base/blob/master/RELEASING.md#versioning-process))
- [ ] Self-reviewed the diff
